### PR TITLE
fix `make test` error

### DIFF
--- a/proxmox/virtual_environment_vm_types.go
+++ b/proxmox/virtual_environment_vm_types.go
@@ -1145,7 +1145,7 @@ func (r CustomVirtualIODevices) EncodeValues(key string, v *url.Values) error {
 // EncodeValues converts a CustomWatchdogDevice struct to a URL vlaue.
 func (r CustomWatchdogDevice) EncodeValues(key string, v *url.Values) error {
 	values := []string{
-		fmt.Sprintf("model=%s", r.Model),
+		fmt.Sprintf("model=%+v", r.Model),
 	}
 
 	if r.Action != nil {


### PR DESCRIPTION
`make test` was failing with
```
# github.com/danitso/terraform-provider-proxmox/proxmox
proxmox/virtual_environment_vm_types.go:1148:3: Sprintf format %s has arg r.Model of wrong type *string
make: *** [Makefile:82: test] Error 2
```

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/danitso/terraform-provider-proxmox/blob/master/CHANGELOG.md):
<!-- If change is not user facing, just write "NONE" in the release-note block below. -->

```release-note
NONE
```
