### PR TITLE
Bump provider version to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ A Terraform Provider which adds support for Proxmox solutions.
 This repository is a fork of https://github.com/danitso/terraform-provider-proxmox with several critical fixes to unblock
 VM deployment in Proxmox v7.0, and a few other enhancements.
 
+## Compatibility Matrix
+
+| Proxmox version | Provider version         |
+|-----------------|--------------------------|
+| 6.x             | \<= 0.4.4                |
+| 7.x             | 0.4.x \> 0.4.4 <br>0.5.x |
+
 ## Requirements
 - [Terraform](https://www.terraform.io/downloads.html) 0.14+
 - [Go](https://golang.org/doc/install) 1.16+ (to build the provider plugin)
@@ -44,7 +51,7 @@ In order to test the provider, you can simply run `make test`.
 $ make test
 ```
 
-Tests are limited to regression tests, ensuring backwards compability.
+Tests are limited to regression tests, ensuring backwards compatibility.
 
 ## Known issues
 


### PR DESCRIPTION
Recent changes in the provider to make it compatible with Proxmox v7.x broke backward compatibility with previous versions, as was reported in #30.
This PR does not introduce any changes in the provider's functionality.

- Update README.md to indicate version compatibility with PVE
