### PR TITLE
virtual_environment_datastores.go: Update remote command to get datasource path

### DIFF
--- a/proxmox/virtual_environment_datastores.go
+++ b/proxmox/virtual_environment_datastores.go
@@ -167,7 +167,7 @@ func (c *VirtualEnvironmentClient) UploadFileToDatastore(d *VirtualEnvironmentDa
 		}
 
 		buf, err := sshSession.CombinedOutput(
-			fmt.Sprintf(`grep -Pzo ': %s\s+path\s+[^\s]+' /etc/pve/storage.cfg | grep -Pzo '/[^\s]*' | tr -d '\000'`, d.DatastoreID),
+			fmt.Sprintf(`awk "/.+: %s$/,/^$/" /etc/pve/storage.cfg | grep -oP '(?<=path[ ])[^\s]+' | head -c -1`, d.DatastoreID),
 		)
 
 		if err != nil {


### PR DESCRIPTION
During the setup of this Terraform module, I was trying to create a cloud-init template based on [this example](https://github.com/bpg/terraform-provider-proxmox/blob/main/example/resource_virtual_environment_file.tf). I noticed that when trying to retrieve the datasource path for NFS mounts, it was failing with the following error: 

```
proxmox_virtual_environment_file.ubuntu_cloud_config["lrhq-ubuntu-test01"]: Creating...
proxmox_virtual_environment_file.test: Creating...
╷
│ Error: Failed to determine the datastore path
│ 
│   with proxmox_virtual_environment_file.ubuntu_cloud_config["lrhq-ubuntu-test01"],
│   on files.tf line 1, in resource "proxmox_virtual_environment_file" "ubuntu_cloud_config":
│    1: resource "proxmox_virtual_environment_file" "ubuntu_cloud_config" {
│ 
╵
╷
│ Error: Failed to determine the datastore path
│ 
│   with proxmox_virtual_environment_file.test,
│   on files2.tf line 1, in resource "proxmox_virtual_environment_file" "test":
│    1: resource "proxmox_virtual_environment_file" "test" { 
│ 
╵
```

When running the original shell command in the code from my Proxmox host, it returns nothing: 

```
# grep -Pzo ': storage-arn\s+path\s+[^\s]+' /etc/pve/storage.cfg | grep -Pzo '/[^\s]*' | tr -d '\000'
#
```

However, testing it with the 'local' datasource, it works as expected.

```
# grep -Pzo ': local\s+path\s+[^\s]+' /etc/pve/storage.cfg | grep -Pzo '/[^\s]*' | tr -d '\000'
/var/lib/vz
#
```

That's when we noticed that the regex was assuming that "path" would be available on the next line. We rewrote the command to be agnostic of which line "path" exists on.

Credit to @AndrewPaglusch for helping solve this issue with me.

