### PR TITLE
Fix disk import when VM template has multiple disks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build:
 	rm -f "$(TERRAFORM_PLUGIN_EXECUTABLE)"
 	go build -o "$(TERRAFORM_PLUGIN_EXECUTABLE)"
 
-example: example-build example-init example-apply example-apply example-destroy
+example: example-build example-init example-apply example-destroy
 
 example-apply:
 	export TF_CLI_CONFIG_FILE="$(shell pwd -P)/example.tfrc" \
@@ -36,8 +36,8 @@ example-apply:
 		&& terraform apply -auto-approve
 
 example-build:
+	rm -rf "$(TERRAFORM_PLUGIN_DIRECTORY_EXAMPLE)"
 	mkdir -p "$(TERRAFORM_PLUGIN_DIRECTORY_EXAMPLE)"
-	rm -f "$(TERRAFORM_PLUGIN_EXECUTABLE_EXAMPLE)"
 	go build -o "$(TERRAFORM_PLUGIN_EXECUTABLE_EXAMPLE)"
 
 example-destroy:

--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -1832,7 +1832,6 @@ func resourceVirtualEnvironmentVMCreateCustomDisks(ctx context.Context, d *schem
 			`set -e`,
 			fmt.Sprintf(`datastore_id_image="%s"`, fileIDParts[0]),
 			fmt.Sprintf(`datastore_id_target="%s"`, datastoreID),
-			fmt.Sprintf(`disk_count="%d"`, diskCount+importedDiskCount),
 			fmt.Sprintf(`disk_index="%d"`, i),
 			fmt.Sprintf(`disk_options="%s"`, diskOptions),
 			fmt.Sprintf(`disk_size="%d"`, size),
@@ -1849,8 +1848,8 @@ func resourceVirtualEnvironmentVMCreateCustomDisks(ctx context.Context, d *schem
 			`dsp_target="$(echo "$dsi_target" | cut -d ";" -f 1)"`,
 			`cp "${dsp_image}${file_path}" "$file_path_tmp"`,
 			`qemu-img resize "$file_path_tmp" "${disk_size}G"`,
-			`qm importdisk "$vm_id" "$file_path_tmp" "$datastore_id_target" -format qcow2`,
-			`disk_id="${datastore_id_target}:$([[ -n "$dsp_target" ]] && echo "${vm_id}/" || echo "")vm-${vm_id}-disk-${disk_count}$([[ -n "$dsp_target" ]] && echo ".qcow2" || echo "")${disk_options}"`,
+			`imported_disk="$(qm importdisk "$vm_id" "$file_path_tmp" "$datastore_id_target" -format qcow2 | grep "unused0" | cut -d ":" -f 3 | cut -d "'" -f 1)"`,
+			`disk_id="${datastore_id_target}:$([[ -n "$dsp_target" ]] && echo "${vm_id}/" || echo "")$imported_disk$([[ -n "$dsp_target" ]] && echo ".qcow2" || echo "")${disk_options}"`,
 			`qm set "$vm_id" "-${disk_interface}" "$disk_id"`,
 			`rm -f "$file_path_tmp"`,
 		)


### PR DESCRIPTION
The disk import operation is not exposed via Proxmox APIs, so implemented as a sequence of commands run as an inline script via ssh.
`qm importdisk` is used to import a disk into VM from an external file, however, it auto-generates the disk ID.
The following command `qm set` is used to assign the imported disk to a VM, and it requires the disk ID as a parameter.

Update the import logic to read the disk ID from the output of `qm importdisk` command rather than trying to assume it from a number of disks defined in the VM.

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #88

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title and labels, update them accordingly. --->
