### PR TITLE
Provide correct outputs from stopped VM

### DIFF
--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"sort"
 	"strconv"
 	"strings"
@@ -1057,6 +1058,17 @@ func resourceVirtualEnvironmentVM() *schema.Resource {
 		ReadContext:   resourceVirtualEnvironmentVMRead,
 		UpdateContext: resourceVirtualEnvironmentVMUpdate,
 		DeleteContext: resourceVirtualEnvironmentVMDelete,
+		CustomizeDiff: customdiff.All(
+			customdiff.ComputedIf(mkResourceVirtualEnvironmentVMIPv4Addresses, func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				return d.HasChange(mkResourceVirtualEnvironmentVMStarted) || d.HasChange(mkResourceVirtualEnvironmentVMNetworkDevice)
+			}),
+			customdiff.ComputedIf(mkResourceVirtualEnvironmentVMIPv6Addresses, func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				return d.HasChange(mkResourceVirtualEnvironmentVMStarted) || d.HasChange(mkResourceVirtualEnvironmentVMNetworkDevice)
+			}),
+			customdiff.ComputedIf(mkResourceVirtualEnvironmentVMNetworkInterfaceNames, func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				return d.HasChange(mkResourceVirtualEnvironmentVMStarted) || d.HasChange(mkResourceVirtualEnvironmentVMNetworkDevice)
+			}),
+		),
 	}
 }
 


### PR DESCRIPTION
Outputs 'ipv4_addresses', 'ipv6_addresses', 'network_interface_names' of
stopped VM are empty and break plans - e.g. search for "eth0" in empty list.
On update, mark them 'Computed' if there is planned change in 'started'
or 'network_device' of the VM.

This makes it possible to depend on e.g. 'network_interface_names' of VM
which is not running at the time of 'terraform plan', but which will be
started during 'terraform apply'.

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #105 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title and labels, update them accordingly. --->
