### PR TITLE
Wait for 'net.IsGlobalUnicast' IP address

### DIFF
--- a/proxmox/virtual_environment_vm.go
+++ b/proxmox/virtual_environment_vm.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"net"
 	"net/url"
 	"strings"
 	"sync"
@@ -406,6 +407,18 @@ func (c *VirtualEnvironmentClient) WaitForNetworkInterfacesFromVMAgent(ctx conte
 							missingIP = true
 							break
 						}
+
+						hasGlobalUnicast := false
+						for _, addr := range *nic.IPAddresses {
+							if ip := net.ParseIP(addr.Address); ip != nil && ip.IsGlobalUnicast() {
+								hasGlobalUnicast = true
+							}
+						}
+						if !hasGlobalUnicast {
+							missingIP = true
+							break
+						}
+
 					}
 				}
 


### PR DESCRIPTION
VM can get IPv6 link-local address faster than a DHCP server response,
that results in 'ipv4_addresses' output being an empty list.
It is then impossible to provision the VM using 'connection.host' field
derived from 'self.ipv4_addresses'.

Change the waiting for IP address to ignore IPv4 link-local addresses
and IPv6 link-local addresses.

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #100

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title and labels, update them accordingly. --->
