### PR TITLE
fix: Non-default VM disk format is not preserved in TF state

### DIFF
--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -18,6 +18,7 @@ resource "proxmox_virtual_environment_vm" "example_template" {
 #    interface    = "scsi1"
 #    discard      = "ignore"
 #    iothread     = true
+#    file_format  = "raw"
 #  }
 
   initialization {

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,14 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.23.0
 	github.com/pkg/sftp v1.13.5
+	github.com/stretchr/testify v1.7.2
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
 )
 
 require (
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
@@ -40,6 +42,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
@@ -52,4 +55,5 @@ require (
 	google.golang.org/grpc v1.48.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/proxmox/virtual_environment_vm_types.go
+++ b/proxmox/virtual_environment_vm_types.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -1555,6 +1556,11 @@ func (r *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 
 		if len(v) == 1 {
 			r.FileVolume = v[0]
+			ext := filepath.Ext(v[0])
+			if ext != "" {
+				format := string([]byte(ext)[1:])
+				r.Format = &format
+			}
 		} else if len(v) == 2 {
 			switch v[0] {
 			case "aio":

--- a/proxmox/virtual_environment_vm_types_test.go
+++ b/proxmox/virtual_environment_vm_types_test.go
@@ -1,0 +1,56 @@
+package proxmox
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCustomStorageDevice_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		want    *CustomStorageDevice
+		wantErr bool
+	}{
+		{
+			name: "simple volume",
+			line: `"local-lvm:vm-2041-disk-0,discard=on,iothread=1,size=8G"`,
+			want: &CustomStorageDevice{
+				Discard:    strPtr("on"),
+				Enabled:    true,
+				FileVolume: "local-lvm:vm-2041-disk-0",
+				IOThread:   boolPtr(true),
+				Size:       strPtr("8G"),
+			},
+		},
+		{
+			name: "raw volume type",
+			line: `"nfs:2041/vm-2041-disk-0.raw,discard=ignore,iothread=1,size=8G"`,
+			want: &CustomStorageDevice{
+				Discard:    strPtr("ignore"),
+				Enabled:    true,
+				FileVolume: "nfs:2041/vm-2041-disk-0.raw",
+				Format:     strPtr("raw"),
+				IOThread:   boolPtr(true),
+				Size:       strPtr("8G"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &CustomStorageDevice{}
+			if err := r.UnmarshalJSON([]byte(tt.line)); (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			require.Equal(t, tt.want, r)
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+func boolPtr(s bool) *CustomBool {
+	customBool := CustomBool(s)
+	return &customBool
+}

--- a/proxmoxtf/version.go
+++ b/proxmoxtf/version.go
@@ -10,5 +10,5 @@ const (
 	TerraformProviderName = "terraform-provider-proxmox"
 
 	// TerraformProviderVersion specifies the version number.
-	TerraformProviderVersion = "0.6.0"
+	TerraformProviderVersion = "0.6.3"
 )


### PR DESCRIPTION
Fix disk format parsing from the volume string.
Add basic unit tests for disk volume string parsing.

Closes: https://github.com/bpg/terraform-provider-proxmox/issues/129
