### PR TITLE
fix: handling `datastore_id` in LXC template

### DIFF
--- a/example/resource_virtual_environment_container.tf
+++ b/example/resource_virtual_environment_container.tf
@@ -1,6 +1,10 @@
 resource "proxmox_virtual_environment_container" "example_template" {
   description = "Managed by Terraform"
 
+  disk {
+    datastore_id = element(data.proxmox_virtual_environment_datastores.example.datastore_ids, index(data.proxmox_virtual_environment_datastores.example.datastore_ids, "local-lvm"))
+  }
+
   initialization {
     dns {
       server = "1.1.1.1"
@@ -37,6 +41,10 @@ resource "proxmox_virtual_environment_container" "example_template" {
 }
 
 resource "proxmox_virtual_environment_container" "example" {
+  disk {
+    datastore_id = element(data.proxmox_virtual_environment_datastores.example.datastore_ids, index(data.proxmox_virtual_environment_datastores.example.datastore_ids, "local-lvm"))
+  }
+
   clone {
     vm_id = proxmox_virtual_environment_container.example_template.id
   }

--- a/proxmoxtf/resource_virtual_environment_container.go
+++ b/proxmoxtf/resource_virtual_environment_container.go
@@ -1393,12 +1393,12 @@ func resourceVirtualEnvironmentContainerRead(ctx context.Context, d *schema.Reso
 
 	if len(clone) > 0 {
 		if len(currentDisk) > 0 {
-			err := d.Set(mkResourceVirtualEnvironmentContainerDiskDatastoreID, []interface{}{disk})
+			err := d.Set(mkResourceVirtualEnvironmentContainerDisk, []interface{}{disk})
 			diags = append(diags, diag.FromErr(err)...)
 		}
 	} else if len(currentDisk) > 0 ||
 		disk[mkResourceVirtualEnvironmentContainerDiskDatastoreID] != dvResourceVirtualEnvironmentContainerDiskDatastoreID {
-		err := d.Set(mkResourceVirtualEnvironmentContainerDiskDatastoreID, []interface{}{disk})
+		err := d.Set(mkResourceVirtualEnvironmentContainerDisk, []interface{}{disk})
 		diags = append(diags, diag.FromErr(err)...)
 	}
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #179

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title and labels, update them accordingly. --->
