### PR TITLE
fix: Check if any interface has global unicast address instead of all interfaces

### DIFF
--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -41,6 +41,10 @@ resource "proxmox_virtual_environment_vm" "example_template" {
 
   network_device {}
 
+  network_device {
+    vlan_id = 1024
+  }
+
   node_name = data.proxmox_virtual_environment_nodes.example.names[0]
 
   operating_system {

--- a/proxmox/virtual_environment_vm.go
+++ b/proxmox/virtual_environment_vm.go
@@ -396,6 +396,7 @@ func (c *VirtualEnvironmentClient) WaitForNetworkInterfacesFromVMAgent(ctx conte
 
 			if err == nil && data != nil && data.Result != nil {
 				missingIP := false
+				hasAnyGlobalUnicast := false
 
 				if waitForIP {
 					for _, nic := range *data.Result {
@@ -408,21 +409,15 @@ func (c *VirtualEnvironmentClient) WaitForNetworkInterfacesFromVMAgent(ctx conte
 							break
 						}
 
-						hasGlobalUnicast := false
 						for _, addr := range *nic.IPAddresses {
 							if ip := net.ParseIP(addr.Address); ip != nil && ip.IsGlobalUnicast() {
-								hasGlobalUnicast = true
+								hasAnyGlobalUnicast = true
 							}
 						}
-						if !hasGlobalUnicast {
-							missingIP = true
-							break
-						}
-
 					}
 				}
 
-				if !missingIP {
+				if hasAnyGlobalUnicast || !missingIP {
 					return data, err
 				}
 			}


### PR DESCRIPTION
This allows us to have multiple interfaces and only one (instead of all) has to have assigned ip

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #164

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title and labels, update them accordingly. --->
