### PR TITLE
feat(vm): OnBoot: change default to `true`

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -263,7 +263,7 @@ output "ubuntu_vm_public_key" {
     * `rate_limit` - (Optional) The rate limit in megabytes per second.
     * `vlan_id` - (Optional) The VLAN identifier.
 * `node_name` - (Required) The name of the node to assign the virtual machine to.
-* `on_boot` - (Optional) Specifies whether a VM will be started during system boot. (defaults to `false`)
+* `on_boot` - (Optional) Specifies whether a VM will be started during system boot. (defaults to `true`)
 * `operating_system` - (Optional) The Operating System configuration.
     * `type` - (Optional) The type (defaults to `other`).
         * `l24` - Linux Kernel 2.4.

--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	dvResourceVirtualEnvironmentVMRebootAfterCreation               = false
-	dvResourceVirtualEnvironmentVMOnBoot                            = false
+	dvResourceVirtualEnvironmentVMOnBoot                            = true
 	dvResourceVirtualEnvironmentVMACPI                              = true
 	dvResourceVirtualEnvironmentVMAgentEnabled                      = false
 	dvResourceVirtualEnvironmentVMAgentTimeout                      = "15m"


### PR DESCRIPTION
Hi,

The `on_boot` parameter is used to start a VM when the node reboots. As the VM infrastructure should not really care whether an hypervisor has rebooted, we change the default value from `false` to `true` in order to make it explicit not to start the VM on reboot.

Cheers

Signed-off-by: Frank Villaro-Dixon <frank@villaro-dixon.eu>

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->
