### PR TITLE
feat(vm): Add cloud-init network-config support

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -224,6 +224,8 @@ output "ubuntu_vm_public_key" {
         * `keys` - (Optional) The SSH keys.
         * `password` - (Optional) The SSH password.
         * `username` - (Optional) The SSH username.
+    * `network_data_file_id` - (Optional) The identifier for a file containing network configuration data passed to the 
+      VM via cloud-init (conflicts with `ip_config`).
     * `user_data_file_id` - (Optional) The identifier for a file containing custom user data (conflicts
       with `user_account`).
     * `vendor_data_file_id` - (Optional) The identifier for a file containing all vendor data passed to the VM via cloud-init.

--- a/proxmox/virtual_environment_vm_types.go
+++ b/proxmox/virtual_environment_vm_types.go
@@ -1310,7 +1310,7 @@ func (r *CustomCloudInitFiles) UnmarshalJSON(b []byte) error {
 			case "meta":
 				r.MetaVolume = &v[1]
 			case "network":
-				r.MetaVolume = &v[1]
+				r.NetworkVolume = &v[1]
 			case "user":
 				r.UserVolume = &v[1]
 			case "vendor":

--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -76,6 +76,7 @@ const (
 	dvResourceVirtualEnvironmentVMInitializationUserAccountPassword = ""
 	dvResourceVirtualEnvironmentVMInitializationUserDataFileID      = ""
 	dvResourceVirtualEnvironmentVMInitializationVendorDataFileID    = ""
+	dvResourceVirtualEnvironmentVMInitializationNetworkDataFileID   = ""
 	dvResourceVirtualEnvironmentVMInitializationType                = ""
 	dvResourceVirtualEnvironmentVMKeyboardLayout                    = "en-us"
 	dvResourceVirtualEnvironmentVMMachineType                       = ""
@@ -183,6 +184,7 @@ const (
 	mkResourceVirtualEnvironmentVMInitializationUserAccountUsername = "username"
 	mkResourceVirtualEnvironmentVMInitializationUserDataFileID      = "user_data_file_id"
 	mkResourceVirtualEnvironmentVMInitializationVendorDataFileID    = "vendor_data_file_id"
+	mkResourceVirtualEnvironmentVMInitializationNetworkDataFileID   = "network_data_file_id"
 	mkResourceVirtualEnvironmentVMIPv4Addresses                     = "ipv4_addresses"
 	mkResourceVirtualEnvironmentVMIPv6Addresses                     = "ipv6_addresses"
 	mkResourceVirtualEnvironmentVMKeyboardLayout                    = "keyboard_layout"
@@ -780,6 +782,14 @@ func resourceVirtualEnvironmentVM() *schema.Resource {
 							Optional:         true,
 							ForceNew:         true,
 							Default:          dvResourceVirtualEnvironmentVMInitializationVendorDataFileID,
+							ValidateDiagFunc: getFileIDValidator(),
+						},
+						mkResourceVirtualEnvironmentVMInitializationNetworkDataFileID: {
+							Type:             schema.TypeString,
+							Description:      "The ID of a file containing network config",
+							Optional:         true,
+							ForceNew:         true,
+							Default:          dvResourceVirtualEnvironmentVMInitializationNetworkDataFileID,
 							ValidateDiagFunc: getFileIDValidator(),
 						},
 						mkResourceVirtualEnvironmentVMInitializationType: {
@@ -2315,6 +2325,15 @@ func resourceVirtualEnvironmentVMGetCloudInitConfig(d *schema.ResourceData) (*pr
 			initializationConfig.Files.VendorVolume = &initializationVendorDataFileID
 		}
 
+		initializationNetworkDataFileID := initializationBlock[mkResourceVirtualEnvironmentVMInitializationNetworkDataFileID].(string)
+
+		if initializationNetworkDataFileID != "" {
+			if initializationConfig.Files == nil {
+				initializationConfig.Files = &proxmox.CustomCloudInitFiles{}
+			}
+			initializationConfig.Files.NetworkVolume = &initializationNetworkDataFileID
+		}
+
 		initializationType := initializationBlock[mkResourceVirtualEnvironmentVMInitializationType].(string)
 
 		if initializationType != "" {
@@ -3182,6 +3201,11 @@ func resourceVirtualEnvironmentVMReadCustom(ctx context.Context, d *schema.Resou
 			initialization[mkResourceVirtualEnvironmentVMInitializationVendorDataFileID] = *vmConfig.CloudInitFiles.VendorVolume
 		} else {
 			initialization[mkResourceVirtualEnvironmentVMInitializationVendorDataFileID] = ""
+		}
+		if vmConfig.CloudInitFiles.NetworkVolume != nil {
+			initialization[mkResourceVirtualEnvironmentVMInitializationNetworkDataFileID] = *vmConfig.CloudInitFiles.NetworkVolume
+		} else {
+			initialization[mkResourceVirtualEnvironmentVMInitializationNetworkDataFileID] = ""
 		}
 	} else if len(initialization) > 0 {
 		initialization[mkResourceVirtualEnvironmentVMInitializationUserDataFileID] = ""

--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -3210,6 +3210,7 @@ func resourceVirtualEnvironmentVMReadCustom(ctx context.Context, d *schema.Resou
 	} else if len(initialization) > 0 {
 		initialization[mkResourceVirtualEnvironmentVMInitializationUserDataFileID] = ""
 		initialization[mkResourceVirtualEnvironmentVMInitializationVendorDataFileID] = ""
+		initialization[mkResourceVirtualEnvironmentVMInitializationNetworkDataFileID] = ""
 	}
 
 	if vmConfig.CloudInitType != nil {


### PR DESCRIPTION
Adds the option to specify a `network-config` cloud-init file just like you can already specify user/vendor data.

The currently provided `ip_config` blocks under the `initialization` block for the VM resource are rather limited, and implementing all possible network options and features would not really make sense. With this modifications users can write the cloud-init network config file themselves if they want to, supporting way more advanced network setups.

Using it is the same as with the user/vendor data files;
```
resource "proxmox_virtual_environment_vm" "instance" {
  #...
  initialization {
    user_data_file_id      = proxmox_virtual_environment_file.cloud_config_user.id
    network_data_file_id = proxmox_virtual_environment_file.cloud_config_network.id
  }
}
```

The backend code already supported this, so I mainly had to expose the option to the user.

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
