### PR TITLE
feat(vm): add support for "args" flag for VM

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -255,7 +255,7 @@ output "ubuntu_vm_public_key" {
     * `sl` - Slovenian.
     * `sv` - Swedish.
     * `tr` - Turkish.
-* `kvmarguments` - (Optional) The KVM Argument implementation.
+* `kvm_arguments` - (Optional) Arbitrary arguments passed to kvm.
 * `machine` - (Optional) The VM machine type (defaults to `i440fx`).
     * `i440fx` - Standard PC (i440FX + PIIX, 1996).
     * `q35` - Standard PC (Q35 + ICH9, 2009).

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -106,7 +106,6 @@ output "ubuntu_vm_public_key" {
     * `type` - (Optional) The QEMU agent interface type (defaults to `virtio`).
         * `isa` - ISA Serial Port.
         * `virtio` - VirtIO (paravirtualized).
-* `args` - (Optional) The Boot Args implementation.
 * `audio_device` - (Optional) An audio device.
     * `device` - (Optional) The device (defaults to `intel-hda`).
         * `AC97` - Intel 82801AA AC97 Audio.
@@ -256,6 +255,7 @@ output "ubuntu_vm_public_key" {
     * `sl` - Slovenian.
     * `sv` - Swedish.
     * `tr` - Turkish.
+* `kvmarguments` - (Optional) The KVM Argument implementation.
 * `machine` - (Optional) The VM machine type (defaults to `i440fx`).
     * `i440fx` - Standard PC (i440FX + PIIX, 1996).
     * `q35` - Standard PC (Q35 + ICH9, 2009).

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -106,6 +106,7 @@ output "ubuntu_vm_public_key" {
     * `type` - (Optional) The QEMU agent interface type (defaults to `virtio`).
         * `isa` - ISA Serial Port.
         * `virtio` - VirtIO (paravirtualized).
+* `args` - (Optional) The Boot Args implementation.
 * `audio_device` - (Optional) An audio device.
     * `device` - (Optional) The device (defaults to `intel-hda`).
         * `AC97` - Intel 82801AA AC97 Audio.

--- a/proxmox/virtual_environment_vm_types.go
+++ b/proxmox/virtual_environment_vm_types.go
@@ -229,6 +229,7 @@ type VirtualEnvironmentVMCreateRequestBody struct {
 	ACPI                 *CustomBool                  `json:"acpi,omitempty" url:"acpi,omitempty,int"`
 	Agent                *CustomAgent                 `json:"agent,omitempty" url:"agent,omitempty"`
 	AllowReboot          *CustomBool                  `json:"reboot,omitempty" url:"reboot,omitempty,int"`
+	Args                 *string                      `json:"args,omitempty" url:"args,omitempty"`
 	AudioDevices         CustomAudioDevices           `json:"audio,omitempty" url:"audio,omitempty"`
 	Autostart            *CustomBool                  `json:"autostart,omitempty" url:"autostart,omitempty,int"`
 	BackupFile           *string                      `json:"archive,omitempty" url:"archive,omitempty"`
@@ -345,6 +346,7 @@ type VirtualEnvironmentVMGetResponseData struct {
 	ACPI                 *CustomBool                   `json:"acpi,omitempty"`
 	Agent                *CustomAgent                  `json:"agent,omitempty"`
 	AllowReboot          *CustomBool                   `json:"reboot,omitempty"`
+	Args                 *string                       `json:"args,omitempty""`
 	AudioDevice          *CustomAudioDevice            `json:"audio0,omitempty"`
 	Autostart            *CustomBool                   `json:"autostart,omitempty"`
 	BackupFile           *string                       `json:"archive,omitempty"`

--- a/proxmox/virtual_environment_vm_types.go
+++ b/proxmox/virtual_environment_vm_types.go
@@ -229,7 +229,6 @@ type VirtualEnvironmentVMCreateRequestBody struct {
 	ACPI                 *CustomBool                  `json:"acpi,omitempty" url:"acpi,omitempty,int"`
 	Agent                *CustomAgent                 `json:"agent,omitempty" url:"agent,omitempty"`
 	AllowReboot          *CustomBool                  `json:"reboot,omitempty" url:"reboot,omitempty,int"`
-	Args                 *string                      `json:"args,omitempty" url:"args,omitempty"`
 	AudioDevices         CustomAudioDevices           `json:"audio,omitempty" url:"audio,omitempty"`
 	Autostart            *CustomBool                  `json:"autostart,omitempty" url:"autostart,omitempty,int"`
 	BackupFile           *string                      `json:"archive,omitempty" url:"archive,omitempty"`
@@ -258,7 +257,7 @@ type VirtualEnvironmentVMCreateRequestBody struct {
 	Hugepages            *string                      `json:"hugepages,omitempty" url:"hugepages,omitempty"`
 	IDEDevices           CustomStorageDevices         `json:"ide,omitempty" url:",omitempty"`
 	KeyboardLayout       *string                      `json:"keyboard,omitempty" url:"keyboard,omitempty"`
-	KVMArguments         CustomLineBreakSeparatedList `json:"args,omitempty" url:"args,omitempty,space"`
+	KVMArguments         *string                      `json:"args,omitempty" url:"args,omitempty,space"`
 	KVMEnabled           *CustomBool                  `json:"kvm,omitempty" url:"kvm,omitempty,int"`
 	LocalTime            *CustomBool                  `json:"localtime,omitempty" url:"localtime,omitempty,int"`
 	Lock                 *string                      `json:"lock,omitempty" url:"lock,omitempty"`
@@ -346,7 +345,6 @@ type VirtualEnvironmentVMGetResponseData struct {
 	ACPI                 *CustomBool                   `json:"acpi,omitempty"`
 	Agent                *CustomAgent                  `json:"agent,omitempty"`
 	AllowReboot          *CustomBool                   `json:"reboot,omitempty"`
-	Args                 *string                       `json:"args,omitempty""`
 	AudioDevice          *CustomAudioDevice            `json:"audio0,omitempty"`
 	Autostart            *CustomBool                   `json:"autostart,omitempty"`
 	BackupFile           *string                       `json:"archive,omitempty"`
@@ -391,7 +389,7 @@ type VirtualEnvironmentVMGetResponseData struct {
 	IPConfig6            *CustomCloudInitIPConfig      `json:"ipconfig6,omitempty"`
 	IPConfig7            *CustomCloudInitIPConfig      `json:"ipconfig7,omitempty"`
 	KeyboardLayout       *string                       `json:"keyboard,omitempty"`
-	KVMArguments         *CustomLineBreakSeparatedList `json:"args,omitempty"`
+	KVMArguments         *string                       `json:"args,omitempty"`
 	KVMEnabled           *CustomBool                   `json:"kvm,omitempty"`
 	LocalTime            *CustomBool                   `json:"localtime,omitempty"`
 	Lock                 *string                       `json:"lock,omitempty"`

--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -189,7 +189,7 @@ const (
 	mkResourceVirtualEnvironmentVMIPv4Addresses                     = "ipv4_addresses"
 	mkResourceVirtualEnvironmentVMIPv6Addresses                     = "ipv6_addresses"
 	mkResourceVirtualEnvironmentVMKeyboardLayout                    = "keyboard_layout"
-	mkResourceVirtualEnvironmentVMKVMArguments                      = "kvmarguments"
+	mkResourceVirtualEnvironmentVMKVMArguments                      = "kvm_arguments"
 	mkResourceVirtualEnvironmentVMMachine                           = "machine"
 	mkResourceVirtualEnvironmentVMMACAddresses                      = "mac_addresses"
 	mkResourceVirtualEnvironmentVMMemory                            = "memory"
@@ -298,10 +298,10 @@ func resourceVirtualEnvironmentVM() *schema.Resource {
 				MinItems: 0,
 			},
 			mkResourceVirtualEnvironmentVMKVMArguments: {
-				Type:             schema.TypeString,
-				Description:      "The args implementation",
-				Optional:         true,
-				Default:          dvResourceVirtualEnvironmentVMKVMArguments,
+				Type:        schema.TypeString,
+				Description: "The args implementation",
+				Optional:    true,
+				Default:     dvResourceVirtualEnvironmentVMKVMArguments,
 			},
 			mkResourceVirtualEnvironmentVMAudioDevice: {
 				Type:        schema.TypeList,
@@ -3264,7 +3264,6 @@ func resourceVirtualEnvironmentVMReadCustom(ctx context.Context, d *schema.Resou
 		kvmArguments[mkResourceVirtualEnvironmentVMKVMArguments] = ""
 	}
 
-
 	// Compare the memory configuration to the one stored in the state.
 	memory := map[string]interface{}{}
 
@@ -3605,7 +3604,6 @@ func resourceVirtualEnvironmentVMReadPrimitiveValues(d *schema.ResourceData, vmC
 		}
 		diags = append(diags, diag.FromErr(err)...)
 	}
-
 
 	currentBIOS := d.Get(mkResourceVirtualEnvironmentVMBIOS).(string)
 

--- a/proxmoxtf/resource_virtual_environment_vm_test.go
+++ b/proxmoxtf/resource_virtual_environment_vm_test.go
@@ -30,6 +30,7 @@ func TestResourceVirtualEnvironmentVMSchema(t *testing.T) {
 	testOptionalArguments(t, s, []string{
 		mkResourceVirtualEnvironmentVMACPI,
 		mkResourceVirtualEnvironmentVMAgent,
+		mkResourceVirtualEnvironmentVMArgs,
 		mkResourceVirtualEnvironmentVMAudioDevice,
 		mkResourceVirtualEnvironmentVMBIOS,
 		mkResourceVirtualEnvironmentVMCDROM,
@@ -63,6 +64,7 @@ func TestResourceVirtualEnvironmentVMSchema(t *testing.T) {
 	testValueTypes(t, s, map[string]schema.ValueType{
 		mkResourceVirtualEnvironmentVMACPI:                  schema.TypeBool,
 		mkResourceVirtualEnvironmentVMAgent:                 schema.TypeList,
+		mkResourceVirtualEnvironmentVMArgs:                 schema.TypeString,
 		mkResourceVirtualEnvironmentVMAudioDevice:           schema.TypeList,
 		mkResourceVirtualEnvironmentVMBIOS:                  schema.TypeString,
 		mkResourceVirtualEnvironmentVMCDROM:                 schema.TypeList,

--- a/proxmoxtf/resource_virtual_environment_vm_test.go
+++ b/proxmoxtf/resource_virtual_environment_vm_test.go
@@ -30,7 +30,6 @@ func TestResourceVirtualEnvironmentVMSchema(t *testing.T) {
 	testOptionalArguments(t, s, []string{
 		mkResourceVirtualEnvironmentVMACPI,
 		mkResourceVirtualEnvironmentVMAgent,
-		mkResourceVirtualEnvironmentVMArgs,
 		mkResourceVirtualEnvironmentVMAudioDevice,
 		mkResourceVirtualEnvironmentVMBIOS,
 		mkResourceVirtualEnvironmentVMCDROM,
@@ -41,6 +40,7 @@ func TestResourceVirtualEnvironmentVMSchema(t *testing.T) {
 		mkResourceVirtualEnvironmentVMInitialization,
 		mkResourceVirtualEnvironmentVMHostPCI,
 		mkResourceVirtualEnvironmentVMKeyboardLayout,
+		mkResourceVirtualEnvironmentVMKVMArguments,
 		mkResourceVirtualEnvironmentVMMachine,
 		mkResourceVirtualEnvironmentVMMemory,
 		mkResourceVirtualEnvironmentVMName,
@@ -64,7 +64,6 @@ func TestResourceVirtualEnvironmentVMSchema(t *testing.T) {
 	testValueTypes(t, s, map[string]schema.ValueType{
 		mkResourceVirtualEnvironmentVMACPI:                  schema.TypeBool,
 		mkResourceVirtualEnvironmentVMAgent:                 schema.TypeList,
-		mkResourceVirtualEnvironmentVMArgs:                 schema.TypeString,
 		mkResourceVirtualEnvironmentVMAudioDevice:           schema.TypeList,
 		mkResourceVirtualEnvironmentVMBIOS:                  schema.TypeString,
 		mkResourceVirtualEnvironmentVMCDROM:                 schema.TypeList,
@@ -76,6 +75,7 @@ func TestResourceVirtualEnvironmentVMSchema(t *testing.T) {
 		mkResourceVirtualEnvironmentVMIPv4Addresses:         schema.TypeList,
 		mkResourceVirtualEnvironmentVMIPv6Addresses:         schema.TypeList,
 		mkResourceVirtualEnvironmentVMKeyboardLayout:        schema.TypeString,
+		mkResourceVirtualEnvironmentVMKVMArguments:          schema.TypeString,
 		mkResourceVirtualEnvironmentVMMachine:               schema.TypeString,
 		mkResourceVirtualEnvironmentVMMemory:                schema.TypeList,
 		mkResourceVirtualEnvironmentVMName:                  schema.TypeString,


### PR DESCRIPTION
<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->

### Example to deploy OpenSuse MicroOS and setup it with Ingition

1. You need first a template and a qcow2 image:

```
mkdir -p /root/download/
cd /root/download/
wget https://download.opensuse.org/tumbleweed/appliances/openSUSE-MicroOS.x86_64-ContainerHost-kvm-and-xen.qcow2

qm create 1001 --name opensuse-microos --memory 4098 --cores 4
qm importdisk 1001 /root/download/openSUSE-MicroOS.x86_64-ContainerHost-kvm-and-xen.qcow2 local
qm set 1001 --scsihw virtio-scsi-pci --virtio0 local:vm-1001-disk-0 --serial0 socket --boot c --bootdisk virtio0 --agent 1 --vga qxl

```

2. enable `snippets` for `local` storage

3. terraform template:

```
terraform {
	required_providers {
        proxmox = {
          source = "bpg/proxmox"
          version = "0.9.1-1"
        }
        ignition = {
          source = "community-terraform-providers/ignition"
          version = "2.1.3"
        }
	}
}

provider "proxmox" {
  virtual_environment {
    endpoint = var.pve.address
    username = var.pve.username
    password = var.pve.password
    insecure = var.pve.insecure
  }
}


data "ignition_systemd_unit" "hello_world" {
  name = "hello_world.service"
  content = "[Service]\nType=oneshot\nExecStart=/usr/bin/echo Hello World\n\n[Install]\nWantedBy=multi-user.target"
}

data "ignition_user" "root" {
    name = "root"
    password_hash = "$6$rounds=4096$yWKn7iI7kTgxrXia$jHovsXMe1pYWwJKhzg.VheV6/RtVBFGVjbj/Q6Q5.Ck8fs14jaVwid7NJIe7n5caZFsITnb6EFbxDU.cK.ahE/"
}

data "ignition_config" "hello_world" {
    systemd = [
        data.ignition_systemd_unit.hello_world.rendered,
    ]

    users = [
        data.ignition_user.root.rendered,
    ]
}

resource "proxmox_virtual_environment_file" "ignition_hello_world" {
    content_type = "snippets"
    datastore_id = "local"
    node_name    = "pve01"

    source_raw {
        data = data.ignition_config.hello_world.rendered
        file_name = "ignition_hello_world.ign"
    }
}

resource "proxmox_virtual_environment_vm" "vms" {
    name                = "test-ignition"
    node_name           = "pve01"
    started             = true
    timeout_shutdown_vm = 10

    args = "-fw_cfg name=opt/com.coreos/config,file=/mnt/pve/local/snippets/ignition_hello_world.ign"

    clone  {
        vm_id = 1001
        retries = 20
    }    
}

```

Login with `root` and `testtest`