### PR TITLE
feat(lxc): Add support for container tags

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -166,6 +166,7 @@ output "ubuntu_container_public_key" {
         - `unmanaged` - Unmanaged.
 - `pool_id` - (Optional) The identifier for a pool to assign the container to.
 - `started` - (Optional) Whether to start the container (defaults to `true`).
+- `tags` - (Optional) A list of tags of the container. This is only meta information (defaults to `[]`). Note: Proxmox always sorts the container tags. If the list in template is not sorted, then Proxmox will always report a difference on the resource. You may use the `ignore_changes` lifecycle meta-argument to ignore changes to this attribute.
 - `template` - (Optional) Whether to create a template (defaults to `false`).
 - `vm_id` - (Optional) The virtual machine identifier
 

--- a/example/resource_virtual_environment_container.tf
+++ b/example/resource_virtual_environment_container.tf
@@ -40,6 +40,12 @@ resource "proxmox_virtual_environment_container" "example_template" {
   pool_id  = proxmox_virtual_environment_pool.example.id
   template = true
   vm_id    = 2042
+
+  tags = [
+    "container",
+    "example",
+    "terraform",
+  ]
 }
 
 resource "proxmox_virtual_environment_container" "example" {

--- a/proxmoxtf/resource_virtual_environment_container_test.go
+++ b/proxmoxtf/resource_virtual_environment_container_test.go
@@ -36,6 +36,7 @@ func TestResourceVirtualEnvironmentContainerSchema(t *testing.T) {
 		mkResourceVirtualEnvironmentContainerOperatingSystem,
 		mkResourceVirtualEnvironmentContainerPoolID,
 		mkResourceVirtualEnvironmentContainerStarted,
+		mkResourceVirtualEnvironmentContainerTags,
 		mkResourceVirtualEnvironmentContainerTemplate,
 		mkResourceVirtualEnvironmentContainerVMID,
 	})
@@ -49,6 +50,7 @@ func TestResourceVirtualEnvironmentContainerSchema(t *testing.T) {
 		mkResourceVirtualEnvironmentContainerOperatingSystem: schema.TypeList,
 		mkResourceVirtualEnvironmentContainerPoolID:          schema.TypeString,
 		mkResourceVirtualEnvironmentContainerStarted:         schema.TypeBool,
+		mkResourceVirtualEnvironmentContainerTags:            schema.TypeList,
 		mkResourceVirtualEnvironmentContainerTemplate:        schema.TypeBool,
 		mkResourceVirtualEnvironmentContainerVMID:            schema.TypeInt,
 	})


### PR DESCRIPTION
A great project, thanks.
I am currently working on automating my small homelab. I am using VM and container tags to build an ansible inventory dynamically and missed the `tags` parameter for containers. 
This PR is merely an adaptation of https://github.com/bpg/terraform-provider-proxmox/pull/169 for LXC containers.

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
