### PR TITLE
fix(vm): Don't add an extra hostpci entry

### DIFF
--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -839,17 +839,7 @@ func resourceVirtualEnvironmentVM() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				DefaultFunc: func() (interface{}, error) {
-					return []interface{}{
-						map[string]interface{}{
-							mkResourceVirtualEnvironmentVMHostPCIDevice:        dvResourceVirtualEnvironmentVMHostPCIDevice,
-							mkResourceVirtualEnvironmentVMHostPCIDeviceID:      dvResourceVirtualEnvironmentVMHostPCIDeviceID,
-							mkResourceVirtualEnvironmentVMHostPCIDeviceXVGA:    dvResourceVirtualEnvironmentVMHostPCIDeviceXVGA,
-							mkResourceVirtualEnvironmentVMHostPCIDevicePCIE:    dvResourceVirtualEnvironmentVMHostPCIDevicePCIE,
-							mkResourceVirtualEnvironmentVMHostPCIDeviceROMBAR:  dvResourceVirtualEnvironmentVMHostPCIDeviceROMBAR,
-							mkResourceVirtualEnvironmentVMHostPCIDeviceROMFile: dvResourceVirtualEnvironmentVMHostPCIDeviceROMFile,
-							mkResourceVirtualEnvironmentVMHostPCIDeviceMDev:    dvResourceVirtualEnvironmentVMHostPCIDeviceMDev,
-						},
-					}, nil
+					return []interface{}{}, nil
 				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
When I try to clone from a template with no `hostpci` in the config, the post body would contain an extra `hostpci` because of these lines (from `DefaultFunc`).

<img width="1101" alt="image" src="https://user-images.githubusercontent.com/6451933/215993642-d61b881f-825d-40e1-b697-8d342bfbd882.png">

---

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
