### PR TITLE
feat(lxc): Add unprivileged option

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -169,6 +169,8 @@ output "ubuntu_container_public_key" {
   difference on the resource. You may use the `ignore_changes` lifecycle
   meta-argument to ignore changes to this attribute.
 - `template` - (Optional) Whether to create a template (defaults to `false`).
+- `unprivileged` - (Optional) Whether the container runs as unprivileged on
+the host (defaults to `false`).
 - `vm_id` - (Optional) The virtual machine identifier
 
 ## Attribute Reference

--- a/proxmoxtf/resource_virtual_environment_container.go
+++ b/proxmoxtf/resource_virtual_environment_container.go
@@ -582,6 +582,7 @@ func resourceVirtualEnvironmentContainer() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "Whether the container runs as unprivileged on the host",
 				Optional:    true,
+				ForceNew:    true,
 				Default:     dvResourceVirtualEnvironmentContainerUnprivileged,
 			},
 			mkResourceVirtualEnvironmentContainerVMID: {

--- a/proxmoxtf/resource_virtual_environment_container.go
+++ b/proxmoxtf/resource_virtual_environment_container.go
@@ -50,6 +50,7 @@ const (
 	dvResourceVirtualEnvironmentContainerPoolID                            = ""
 	dvResourceVirtualEnvironmentContainerStarted                           = true
 	dvResourceVirtualEnvironmentContainerTemplate                          = false
+	dvResourceVirtualEnvironmentContainerUnprivileged                      = false
 	dvResourceVirtualEnvironmentContainerVMID                              = -1
 
 	maxResourceVirtualEnvironmentContainerNetworkInterfaces = 8
@@ -105,6 +106,7 @@ const (
 	mkResourceVirtualEnvironmentContainerStarted                           = "started"
 	mkResourceVirtualEnvironmentContainerTags                              = "tags"
 	mkResourceVirtualEnvironmentContainerTemplate                          = "template"
+	mkResourceVirtualEnvironmentContainerUnprivileged                      = "unprivileged"
 	mkResourceVirtualEnvironmentContainerVMID                              = "vm_id"
 )
 
@@ -575,6 +577,12 @@ func resourceVirtualEnvironmentContainer() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Default:     dvResourceVirtualEnvironmentContainerTemplate,
+			},
+			mkResourceVirtualEnvironmentContainerUnprivileged: {
+				Type:        schema.TypeBool,
+				Description: "Whether the container runs as unprivileged on the host",
+				Optional:    true,
+				Default:     dvResourceVirtualEnvironmentContainerUnprivileged,
 			},
 			mkResourceVirtualEnvironmentContainerVMID: {
 				Type:             schema.TypeInt,
@@ -1203,6 +1211,7 @@ func resourceVirtualEnvironmentContainerCreateCustom(
 	started := proxmox.CustomBool(d.Get(mkResourceVirtualEnvironmentContainerStarted).(bool))
 	tags := d.Get(mkResourceVirtualEnvironmentContainerTags).([]interface{})
 	template := proxmox.CustomBool(d.Get(mkResourceVirtualEnvironmentContainerTemplate).(bool))
+	unprivileged := proxmox.CustomBool(d.Get(mkResourceVirtualEnvironmentContainerUnprivileged).(bool))
 	vmID := d.Get(mkResourceVirtualEnvironmentContainerVMID).(int)
 
 	if vmID == -1 {
@@ -1231,6 +1240,7 @@ func resourceVirtualEnvironmentContainerCreateCustom(
 		Swap:                 &memorySwap,
 		Template:             &template,
 		TTY:                  &consoleTTYCount,
+		Unprivileged:         &unprivileged,
 		VMID:                 &vmID,
 	}
 

--- a/proxmoxtf/resource_virtual_environment_container_test.go
+++ b/proxmoxtf/resource_virtual_environment_container_test.go
@@ -38,6 +38,7 @@ func TestResourceVirtualEnvironmentContainerSchema(t *testing.T) {
 		mkResourceVirtualEnvironmentContainerStarted,
 		mkResourceVirtualEnvironmentContainerTags,
 		mkResourceVirtualEnvironmentContainerTemplate,
+		mkResourceVirtualEnvironmentContainerUnprivileged,
 		mkResourceVirtualEnvironmentContainerVMID,
 	})
 
@@ -52,6 +53,7 @@ func TestResourceVirtualEnvironmentContainerSchema(t *testing.T) {
 		mkResourceVirtualEnvironmentContainerStarted:         schema.TypeBool,
 		mkResourceVirtualEnvironmentContainerTags:            schema.TypeList,
 		mkResourceVirtualEnvironmentContainerTemplate:        schema.TypeBool,
+		mkResourceVirtualEnvironmentContainerUnprivileged:    schema.TypeBool,
 		mkResourceVirtualEnvironmentContainerVMID:            schema.TypeInt,
 	})
 


### PR DESCRIPTION
Currently you cannot set `unprivileged` in `proxmox_virtual_environment_container`. I believe this adds the option to do so (I've not contributed to a provider before).


<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #224

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
