### PR TITLE
fix(vm): `proxmox_virtual_environment_file.changed` stored as `true` at file creation

### DIFF
--- a/proxmoxtf/resource_virtual_environment_file.go
+++ b/proxmoxtf/resource_virtual_environment_file.go
@@ -594,9 +594,12 @@ func resourceVirtualEnvironmentFileRead(
 			err = d.Set(mkResourceVirtualEnvironmentFileFileTag, fileTag)
 			diags = append(diags, diag.FromErr(err)...)
 
-			sourceFileBlock[mkResourceVirtualEnvironmentFileSourceFileChanged] = lastFileMD != fileModificationDate ||
-				lastFileSize != fileSize ||
-				lastFileTag != fileTag
+			// just to make the logic easier to read
+			changed := false
+			if lastFileMD != "" && lastFileSize != 0 && lastFileTag != "" {
+				changed = lastFileMD != fileModificationDate || lastFileSize != fileSize || lastFileTag != fileTag
+			}
+			sourceFileBlock[mkResourceVirtualEnvironmentFileSourceFileChanged] = changed
 			err = d.Set(mkResourceVirtualEnvironmentFileSourceFile, sourceFile)
 			diags = append(diags, diag.FromErr(err)...)
 


### PR DESCRIPTION
This triggers "changed outside of Terraform" detection on the resource when Terraform re-applies the same plan second time.

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
