### PR TITLE
feat(vm): update VM disc import logic

### DIFF
--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -23,7 +23,7 @@ resource "proxmox_virtual_environment_vm" "example_template" {
     discard      = "on"
     ssd          = true
   }
-#
+
 #  disk {
 #    datastore_id = "nfs"
 #    interface    = "scsi1"

--- a/proxmox/virtual_environment_nodes.go
+++ b/proxmox/virtual_environment_nodes.go
@@ -41,10 +41,11 @@ func (c *VirtualEnvironmentClient) ExecuteNodeCommands(
 	}
 	defer closeOrLogError(sshSession)
 
+	script := strings.Join(commands, " && \\\n")
 	output, err := sshSession.CombinedOutput(
 		fmt.Sprintf(
 			"/bin/bash -c '%s'",
-			strings.ReplaceAll(strings.Join(commands, " && \\\n"), "'", "'\"'\"'"),
+			strings.ReplaceAll(script, "'", "'\"'\"'"),
 		),
 	)
 	if err != nil {

--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -2157,6 +2157,7 @@ func resourceVirtualEnvironmentVMCreateCustomDisks(
 			fileFormat,
 		)
 
+		//nolint:lll
 		commands = append(
 			commands,
 			`set -e`,
@@ -2168,10 +2169,8 @@ func resourceVirtualEnvironmentVMCreateCustomDisks(
 			fmt.Sprintf(`disk_interface="%s"`, diskInterface),
 			fmt.Sprintf(`file_path_tmp="%s"`, filePathTmp),
 			fmt.Sprintf(`vm_id="%d"`, vmID),
-
 			`source_image=$(pvesm path "$file_id")`,
 			`cp "$source_image" "$file_path_tmp"`,
-
 			`qemu-img resize -f "$file_format" "$file_path_tmp" "${disk_size}G"`,
 			`imported_disk="$(qm importdisk "$vm_id" "$file_path_tmp" "$datastore_id_target" -format $file_format | grep "unused0" | cut -d ":" -f 3 | cut -d "'" -f 1)"`,
 			`disk_id="${datastore_id_target}:$imported_disk${disk_options}"`,


### PR DESCRIPTION
Update [shell scripting](https://github.com/bpg/terraform-provider-proxmox/issues/187#issuecomment-1363594575) responsible for disk imports.

Tested with
```terraform
data "local_file" "ssh_public_key" {
  filename = "./id_rsa.pub"
}

resource "proxmox_virtual_environment_file" "cloud_config" {
  content_type = "snippets"
  datastore_id = "local"
  node_name    = var.virtual_environment_node_name

  source_raw {
    data = <<EOF
#cloud-config
users:
  - default
  - name: ubuntu
    groups:
      - sudo
    shell: /bin/bash
    ssh_authorized_keys:
      - ${trimspace(data.local_file.ssh_public_key.content)}
    sudo: ALL=(ALL) NOPASSWD:ALL
runcmd:
    - apt update
    - apt install -y qemu-guest-agent net-tools
    - timedatectl set-timezone America/Toronto
    - systemctl enable qemu-guest-agent
    - systemctl start qemu-guest-agent
    - echo "done" > /tmp/vendor-cloud-init-done
    EOF

    file_name = "cloud-config.yaml"
  }
}

resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
  vm_id     = 1000
  name = "test-ubuntu"
  node_name = "pve"

  agent {
    enabled = true
  }

  disk {
    datastore_id = "local"
    file_format  = "qcow2"
    interface    = "scsi0"
    file_id      = proxmox_virtual_environment_file.ubuntu_cloud_image.id
    size         = 8
  }

  initialization {
    ip_config {
      ipv4 {
        address = "dhcp"
      }
    }

    // note: cloud-init config is required to enable user agent
    user_data_file_id = proxmox_virtual_environment_file.cloud_config.id
  }

  network_device {
    bridge = "vmbr0"
  }

}

resource "proxmox_virtual_environment_file" "ubuntu_cloud_image" {
  // not really an ISO image, but that's what the closest content type for proxmox.
  // can be omitted if the file extension is `.iso` or `.img`
  content_type = "iso"
  datastore_id = "local"
  node_name    = var.virtual_environment_node_name

  source_file {
    // umuntu's `*.img` is a qcow2 image
    path = "https://cloud-images.ubuntu.com/kinetic/current/kinetic-server-cloudimg-amd64.img"
  }
}


//////////////////

resource "proxmox_virtual_environment_vm" "debian_vm" {
  vm_id     = 1001
  name = "test-debian"
  node_name = "pve"

  agent {
    enabled = true
  }

  disk {
    datastore_id = "local"
    file_format  = "raw"
    interface    = "scsi0"
    file_id      = proxmox_virtual_environment_file.debian_cloud_image.id
    size         = 8
  }

  initialization {
    ip_config {
      ipv4 {
        address = "dhcp"
      }
    }

    // note: cloud-init config is required to enable user agent
    user_data_file_id = proxmox_virtual_environment_file.cloud_config.id
  }

  network_device {
    bridge = "vmbr0"
  }

}

resource "proxmox_virtual_environment_file" "debian_cloud_image" {
  // can be omitted if the file extension is `.tar.xz` or `.tar.gz`
  content_type = "vztmpl"
  datastore_id = "local"
  node_name    = var.virtual_environment_node_name

  source_file {
    path = "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-generic-amd64.tar.xz"
  }
}
```

ubuntu VM 1000:
<img width="713" alt="Screenshot 2023-02-17 at 3 18 55 PM" src="https://user-images.githubusercontent.com/627562/219785327-bcddf462-63bc-41a1-ad53-f4cb2e6ccff3.png">


However, the debian VM (from the `.tar.xz` image), while created successfully, is not bootable. I suspect the raw format does not match what PVE expects. 
QCOW2 version of it works fine.

Also tested cloning between different data stores.

NOT TESTED: cloning between PVE nodes in a cluster, as I don't have it available in my lab.

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #187
Closes #188 
Closes #203 
Closes #210

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
