### PR TITLE
fix(provider): Deprecate `virtual_environment` block

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,12 +17,10 @@ Use the navigation to the left to read about the available resources.
 
 ```terraform
 provider "proxmox" {
-  virtual_environment {
-    endpoint = "https://10.0.0.2:8006/"
-    username = "root@pam"
-    password = "the-password-set-during-installation-of-proxmox-ve"
-    insecure = true
-  }
+  endpoint = "https://10.0.0.2:8006/"
+  username = "root@pam"
+  password = "the-password-set-during-installation-of-proxmox-ve"
+  insecure = true
 }
 ```
 
@@ -46,10 +44,8 @@ in the Proxmox provider block:
 
 ```terraform
 provider "proxmox" {
-  virtual_environment {
-    username = "username@realm"
-    password = "a-strong-password"
-  }
+  username = "username@realm"
+  password = "a-strong-password"
 }
 ```
 
@@ -60,9 +56,7 @@ and `PROXMOX_VE_PASSWORD`, environment variables, representing your Proxmox
 username, realm and password, respectively:
 
 ```terraform
-provider "proxmox" {
-  virtual_environment {}
-}
+provider "proxmox" {}
 ```
 
 Usage:
@@ -80,18 +74,16 @@ to [generic provider arguments](https://www.terraform.io/docs/configuration/prov
 e.g. `alias` and `version`), the following arguments are supported in the
 Proxmox `provider` block:
 
-- `virtual_environment` - (Optional) The Proxmox Virtual Environment
-  configuration.
-  - `endpoint` - (Required) The endpoint for the Proxmox Virtual Environment
-    API (can also be sourced from `PROXMOX_VE_ENDPOINT`). Usually this is
-    `https://<your-cluster-endpoint>:8006/`.
-  - `insecure` - (Optional) Whether to skip the TLS verification step (can
-    also be sourced from `PROXMOX_VE_INSECURE`). If omitted, defaults
-    to `false`.
-  - `otp` - (Optional) The one-time password for the Proxmox Virtual
-    Environment API (can also be sourced from `PROXMOX_VE_OTP`).
-  - `password` - (Required) The password for the Proxmox Virtual Environment
-    API (can also be sourced from `PROXMOX_VE_PASSWORD`).
-  - `username` - (Required) The username and realm for the Proxmox Virtual
-    Environment API (can also be sourced from `PROXMOX_VE_USERNAME`). For 
-    example, `root@pam`.
+- `endpoint` - (Required) The endpoint for the Proxmox Virtual Environment
+  API (can also be sourced from `PROXMOX_VE_ENDPOINT`). Usually this is
+  `https://<your-cluster-endpoint>:8006/`.
+- `insecure` - (Optional) Whether to skip the TLS verification step (can
+  also be sourced from `PROXMOX_VE_INSECURE`). If omitted, defaults
+  to `false`.
+- `otp` - (Optional) The one-time password for the Proxmox Virtual
+  Environment API (can also be sourced from `PROXMOX_VE_OTP`).
+- `password` - (Required) The password for the Proxmox Virtual Environment
+  API (can also be sourced from `PROXMOX_VE_PASSWORD`).
+- `username` - (Required) The username and realm for the Proxmox Virtual
+  Environment API (can also be sourced from `PROXMOX_VE_USERNAME`). For 
+  example, `root@pam`.

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,8 +1,6 @@
 provider "proxmox" {
-  virtual_environment {
-    endpoint = var.virtual_environment_endpoint
-    username = var.virtual_environment_username
-    password = var.virtual_environment_password
-    insecure = true
-  }
+  endpoint = var.virtual_environment_endpoint
+  username = var.virtual_environment_username
+  password = var.virtual_environment_password
+  insecure = true
 }

--- a/proxmoxtf/provider/provider.go
+++ b/proxmoxtf/provider/provider.go
@@ -17,17 +17,14 @@ import (
 )
 
 const (
-	dvProviderVirtualEnvironmentEndpoint = ""
-	dvProviderVirtualEnvironmentOTP      = ""
-	dvProviderVirtualEnvironmentPassword = ""
-	dvProviderVirtualEnvironmentUsername = ""
+	dvProviderOTP = ""
 
-	mkProviderVirtualEnvironment         = "virtual_environment"
-	mkProviderVirtualEnvironmentEndpoint = "endpoint"
-	mkProviderVirtualEnvironmentInsecure = "insecure"
-	mkProviderVirtualEnvironmentOTP      = "otp"
-	mkProviderVirtualEnvironmentPassword = "password"
-	mkProviderVirtualEnvironmentUsername = "username"
+	mkProviderVirtualEnvironment = "virtual_environment"
+	mkProviderEndpoint           = "endpoint"
+	mkProviderInsecure           = "insecure"
+	mkProviderOTP                = "otp"
+	mkProviderPassword           = "password"
+	mkProviderUsername           = "username"
 )
 
 // ProxmoxVirtualEnvironment returns the object for this provider.
@@ -51,15 +48,24 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 		veConfig := veConfigBlock[0].(map[string]interface{})
 
 		veClient, err = proxmox.NewVirtualEnvironmentClient(
-			veConfig[mkProviderVirtualEnvironmentEndpoint].(string),
-			veConfig[mkProviderVirtualEnvironmentUsername].(string),
-			veConfig[mkProviderVirtualEnvironmentPassword].(string),
-			veConfig[mkProviderVirtualEnvironmentOTP].(string),
-			veConfig[mkProviderVirtualEnvironmentInsecure].(bool),
+			veConfig[mkProviderEndpoint].(string),
+			veConfig[mkProviderUsername].(string),
+			veConfig[mkProviderPassword].(string),
+			veConfig[mkProviderOTP].(string),
+			veConfig[mkProviderInsecure].(bool),
 		)
-		if err != nil {
-			return nil, diag.FromErr(err)
-		}
+	} else {
+		veClient, err = proxmox.NewVirtualEnvironmentClient(
+			d.Get(mkProviderEndpoint).(string),
+			d.Get(mkProviderUsername).(string),
+			d.Get(mkProviderPassword).(string),
+			d.Get(mkProviderOTP).(string),
+			d.Get(mkProviderInsecure).(bool),
+		)
+	}
+
+	if err != nil {
+		return nil, diag.FromErr(err)
 	}
 
 	config := proxmoxtf.NewProviderConfiguration(veClient)

--- a/proxmoxtf/provider/provider_test.go
+++ b/proxmoxtf/provider/provider_test.go
@@ -33,27 +33,37 @@ func TestProviderSchema(t *testing.T) {
 
 	test.AssertOptionalArguments(t, s, []string{
 		mkProviderVirtualEnvironment,
+		mkProviderUsername,
+		mkProviderPassword,
+		mkProviderEndpoint,
+		mkProviderInsecure,
+		mkProviderOTP,
 	})
 
 	test.AssertValueTypes(t, s, map[string]schema.ValueType{
 		mkProviderVirtualEnvironment: schema.TypeList,
+		mkProviderUsername:           schema.TypeString,
+		mkProviderPassword:           schema.TypeString,
+		mkProviderEndpoint:           schema.TypeString,
+		mkProviderInsecure:           schema.TypeBool,
+		mkProviderOTP:                schema.TypeString,
 	})
 
 	veSchema := test.AssertNestedSchemaExistence(t, s, mkProviderVirtualEnvironment)
 
 	test.AssertOptionalArguments(t, veSchema, []string{
-		mkProviderVirtualEnvironmentEndpoint,
-		mkProviderVirtualEnvironmentInsecure,
-		mkProviderVirtualEnvironmentOTP,
-		mkProviderVirtualEnvironmentPassword,
-		mkProviderVirtualEnvironmentUsername,
+		mkProviderEndpoint,
+		mkProviderInsecure,
+		mkProviderOTP,
+		mkProviderPassword,
+		mkProviderUsername,
 	})
 
 	test.AssertValueTypes(t, veSchema, map[string]schema.ValueType{
-		mkProviderVirtualEnvironmentEndpoint: schema.TypeString,
-		mkProviderVirtualEnvironmentInsecure: schema.TypeBool,
-		mkProviderVirtualEnvironmentOTP:      schema.TypeString,
-		mkProviderVirtualEnvironmentPassword: schema.TypeString,
-		mkProviderVirtualEnvironmentUsername: schema.TypeString,
+		mkProviderEndpoint: schema.TypeString,
+		mkProviderInsecure: schema.TypeBool,
+		mkProviderOTP:      schema.TypeString,
+		mkProviderPassword: schema.TypeString,
+		mkProviderUsername: schema.TypeString,
 	})
 }

--- a/proxmoxtf/provider/schema.go
+++ b/proxmoxtf/provider/schema.go
@@ -7,123 +7,96 @@
 package provider
 
 import (
-	"errors"
-	"net/url"
+	"fmt"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func createSchema() map[string]*schema.Schema {
+	providerSchema := nestedProviderSchema()
+	providerSchema[mkProviderVirtualEnvironment] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: nestedProviderSchema(),
+		},
+		MaxItems:   1,
+		Deprecated: "Move attributes out of virtual_environment block",
+	}
+
+	return providerSchema
+}
+
+func nestedProviderSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		mkProviderVirtualEnvironment: {
-			Type:     schema.TypeList,
-			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					mkProviderVirtualEnvironmentEndpoint: {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "The endpoint for the Proxmox Virtual Environment API",
-						DefaultFunc: schema.MultiEnvDefaultFunc(
-							[]string{"PROXMOX_VE_ENDPOINT", "PM_VE_ENDPOINT"},
-							dvProviderVirtualEnvironmentEndpoint,
-						),
-						ValidateFunc: func(v interface{}, k string) (warns []string, errs []error) {
-							value := v.(string)
-
-							if value == "" {
-								return []string{}, []error{
-									errors.New(
-										"you must specify an endpoint for the Proxmox Virtual Environment API (valid: https://host:port)",
-									),
-								}
-							}
-
-							_, err := url.ParseRequestURI(value)
-							if err != nil {
-								return []string{}, []error{
-									errors.New(
-										"you must specify a valid endpoint for the Proxmox Virtual Environment API (valid: https://host:port)",
-									),
-								}
-							}
-
-							return []string{}, []error{}
-						},
-					},
-					mkProviderVirtualEnvironmentInsecure: {
-						Type:        schema.TypeBool,
-						Optional:    true,
-						Description: "Whether to skip the TLS verification step",
-						DefaultFunc: func() (interface{}, error) {
-							for _, k := range []string{"PROXMOX_VE_INSECURE", "PM_VE_INSECURE"} {
-								v := os.Getenv(k)
-
-								if v == "true" || v == "1" {
-									return true, nil
-								}
-							}
-
-							return false, nil
-						},
-					},
-					mkProviderVirtualEnvironmentOTP: {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "The one-time password for the Proxmox Virtual Environment API",
-						DefaultFunc: schema.MultiEnvDefaultFunc(
-							[]string{"PROXMOX_VE_OTP", "PM_VE_OTP"},
-							dvProviderVirtualEnvironmentOTP,
-						),
-					},
-					mkProviderVirtualEnvironmentPassword: {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "The password for the Proxmox Virtual Environment API",
-						DefaultFunc: schema.MultiEnvDefaultFunc(
-							[]string{"PROXMOX_VE_PASSWORD", "PM_VE_PASSWORD"},
-							dvProviderVirtualEnvironmentPassword,
-						),
-						ValidateFunc: func(v interface{}, k string) (warns []string, errs []error) {
-							value := v.(string)
-
-							if value == "" {
-								return []string{}, []error{
-									errors.New(
-										"you must specify a password for the Proxmox Virtual Environment API",
-									),
-								}
-							}
-
-							return []string{}, []error{}
-						},
-					},
-					mkProviderVirtualEnvironmentUsername: {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "The username for the Proxmox Virtual Environment API",
-						DefaultFunc: schema.MultiEnvDefaultFunc(
-							[]string{"PROXMOX_VE_USERNAME", "PM_VE_USERNAME"},
-							dvProviderVirtualEnvironmentUsername,
-						),
-						ValidateFunc: func(v interface{}, k string) (warns []string, errs []error) {
-							value := v.(string)
-
-							if value == "" {
-								return []string{}, []error{
-									errors.New(
-										"you must specify a username for the Proxmox Virtual Environment API (valid: username@realm)",
-									),
-								}
-							}
-
-							return []string{}, []error{}
-						},
-					},
-				},
+		mkProviderEndpoint: {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The endpoint for the Proxmox Virtual Environment API",
+			DefaultFunc: schema.MultiEnvDefaultFunc(
+				[]string{"PROXMOX_VE_ENDPOINT", "PM_VE_ENDPOINT"},
+				nil,
+			),
+			AtLeastOneOf: []string{
+				mkProviderEndpoint,
+				fmt.Sprintf("%s.0.%s", mkProviderVirtualEnvironment, mkProviderEndpoint),
 			},
-			MaxItems: 1,
+			ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+		},
+		mkProviderInsecure: {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Whether to skip the TLS verification step",
+			DefaultFunc: func() (interface{}, error) {
+				for _, k := range []string{"PROXMOX_VE_INSECURE", "PM_VE_INSECURE"} {
+					v := os.Getenv(k)
+
+					if v == "true" || v == "1" {
+						return true, nil
+					}
+				}
+
+				return false, nil
+			},
+		},
+		mkProviderOTP: {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The one-time password for the Proxmox Virtual Environment API",
+			DefaultFunc: schema.MultiEnvDefaultFunc(
+				[]string{"PROXMOX_VE_OTP", "PM_VE_OTP"},
+				dvProviderOTP,
+			),
+		},
+		mkProviderPassword: {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The password for the Proxmox Virtual Environment API",
+			DefaultFunc: schema.MultiEnvDefaultFunc(
+				[]string{"PROXMOX_VE_PASSWORD", "PM_VE_PASSWORD"},
+				nil,
+			),
+			AtLeastOneOf: []string{
+				mkProviderPassword,
+				fmt.Sprintf("%s.0.%s", mkProviderVirtualEnvironment, mkProviderPassword),
+			},
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		mkProviderUsername: {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The username for the Proxmox Virtual Environment API",
+			DefaultFunc: schema.MultiEnvDefaultFunc(
+				[]string{"PROXMOX_VE_USERNAME", "PM_VE_USERNAME"},
+				nil,
+			),
+			AtLeastOneOf: []string{
+				mkProviderUsername,
+				fmt.Sprintf("%s.0.%s", mkProviderVirtualEnvironment, mkProviderUsername),
+			},
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
 }


### PR DESCRIPTION
Also deprecate virtual_environment block, update docs and examples.
Not sure if there is any reason for keeping it.

Fixes #117 
Apparently CDKTF skips schemas without attributes, it has been fixed but it is available only in prerelease currently (https://github.com/hashicorp/terraform-cdk/pull/2736)

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated templates in `/examples` for any new or updated resources / data sources.
  - [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #117 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
