### PR TITLE
fix(firewall): Add support for `firewall` flag for LXC/VM net adapters

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -142,6 +142,8 @@ output "ubuntu_container_public_key" {
       to `vmbr0`).
     - `enabled` - (Optional) Whether to enable the network device (defaults
       to `true`).
+    - `firewall` - (Optional) Whether this interface's firewall rules should be
+        used (defaults to `false`).
     - `mac_address` - (Optional) The MAC address.
     - `mtu` - (Optional) Maximum transfer unit of the interface. Cannot be
       larger than the bridge's MTU.
@@ -170,10 +172,11 @@ output "ubuntu_container_public_key" {
   meta-argument to ignore changes to this attribute.
 - `template` - (Optional) Whether to create a template (defaults to `false`).
 - `unprivileged` - (Optional) Whether the container runs as unprivileged on
-the host (defaults to `false`).
+  the host (defaults to `false`).
 - `vm_id` - (Optional) The virtual machine identifier
 - `features` - (Optional) The container features
-  - `nesting` - (Optional) Whether the container is nested (defaults to `false`)
+    - `nesting` - (Optional) Whether the container is nested (defaults
+      to `false`)
 
 ## Attribute Reference
 

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -327,6 +327,8 @@ output "ubuntu_vm_public_key" {
       to `vmbr0`).
     - `enabled` - (Optional) Whether to enable the network device (defaults
       to `true`).
+    - `firewall` - (Optional) Whether this interface's firewall rules should be
+        used (defaults to `false`).
     - `mac_address` - (Optional) The MAC address.
     - `model` - (Optional) The network device model (defaults to `virtio`).
         - `e1000` - Intel E1000.

--- a/proxmoxtf/resource/container.go
+++ b/proxmoxtf/resource/container.go
@@ -47,6 +47,7 @@ const (
 	dvResourceVirtualEnvironmentContainerMemorySwap                        = 0
 	dvResourceVirtualEnvironmentContainerNetworkInterfaceBridge            = "vmbr0"
 	dvResourceVirtualEnvironmentContainerNetworkInterfaceEnabled           = true
+	dvResourceVirtualEnvironmentContainerNetworkInterfaceFirewall          = false
 	dvResourceVirtualEnvironmentContainerNetworkInterfaceMACAddress        = ""
 	dvResourceVirtualEnvironmentContainerNetworkInterfaceRateLimit         = 0
 	dvResourceVirtualEnvironmentContainerNetworkInterfaceVLANID            = 0
@@ -98,6 +99,7 @@ const (
 	mkResourceVirtualEnvironmentContainerNetworkInterface                  = "network_interface"
 	mkResourceVirtualEnvironmentContainerNetworkInterfaceBridge            = "bridge"
 	mkResourceVirtualEnvironmentContainerNetworkInterfaceEnabled           = "enabled"
+	mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall          = "firewall"
 	mkResourceVirtualEnvironmentContainerNetworkInterfaceMACAddress        = "mac_address"
 	mkResourceVirtualEnvironmentContainerNetworkInterfaceName              = "name"
 	mkResourceVirtualEnvironmentContainerNetworkInterfaceRateLimit         = "rate_limit"
@@ -510,6 +512,12 @@ func Container() *schema.Resource {
 							Optional:    true,
 							Default:     dvResourceVirtualEnvironmentContainerNetworkInterfaceEnabled,
 						},
+						mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall: {
+							Type:        schema.TypeBool,
+							Description: "Whether this interface's firewall rules should be used.",
+							Optional:    true,
+							Default:     dvResourceVirtualEnvironmentContainerNetworkInterfaceFirewall,
+						},
 						mkResourceVirtualEnvironmentContainerNetworkInterfaceMACAddress: {
 							Type:        schema.TypeString,
 							Description: "The MAC address",
@@ -888,6 +896,9 @@ func containerCreateClone(ctx context.Context, d *schema.ResourceData, m interfa
 
 		bridge := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceBridge].(string)
 		enabled := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceEnabled].(bool)
+		firewall := types.CustomBool(
+			networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall].(bool),
+		)
 		macAddress := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceMACAddress].(string)
 		name := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceName].(string)
 		rateLimit := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceRateLimit].(float64)
@@ -899,6 +910,7 @@ func containerCreateClone(ctx context.Context, d *schema.ResourceData, m interfa
 		}
 
 		networkInterfaceObject.Enabled = enabled
+		networkInterfaceObject.Firewall = &firewall
 
 		if len(initializationIPConfigIPv4Address) > ni {
 			if initializationIPConfigIPv4Address[ni] != "" {
@@ -1418,6 +1430,11 @@ func containerGetExistingNetworkInterface(
 		}
 
 		networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceEnabled] = true
+		if nv.Firewall != nil {
+			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall] = *nv.Firewall
+		} else {
+			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall] = false
+		}
 
 		if nv.MACAddress != nil {
 			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceMACAddress] = *nv.MACAddress
@@ -1775,6 +1792,12 @@ func containerRead(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		}
 
 		networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceEnabled] = true
+
+		if nv.Firewall != nil {
+			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall] = *nv.Firewall
+		} else {
+			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall] = false
+		}
 
 		if nv.MACAddress != nil {
 			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceMACAddress] = *nv.MACAddress
@@ -2150,6 +2173,9 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m interface{})
 
 			bridge := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceBridge].(string)
 			enabled := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceEnabled].(bool)
+			firewall := types.CustomBool(
+				networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall].(bool),
+			)
 			macAddress := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceMACAddress].(string)
 			name := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceName].(string)
 			rateLimit := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceRateLimit].(float64)
@@ -2161,6 +2187,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m interface{})
 			}
 
 			networkInterfaceObject.Enabled = enabled
+			networkInterfaceObject.Firewall = &firewall
 
 			if len(initializationIPConfigIPv4Address) > ni {
 				if initializationIPConfigIPv4Address[ni] != "" {


### PR DESCRIPTION
### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #294

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
