### PR TITLE
feat(vm): Wait for the VM creation task to complete

### DIFF
--- a/proxmox/virtual_environment_vm.go
+++ b/proxmox/virtual_environment_vm.go
@@ -77,8 +77,45 @@ func (c *VirtualEnvironmentClient) CreateVM(
 	ctx context.Context,
 	nodeName string,
 	d *VirtualEnvironmentVMCreateRequestBody,
+	timeout int,
 ) error {
-	return c.DoRequest(ctx, http.MethodPost, fmt.Sprintf("nodes/%s/qemu", url.PathEscape(nodeName)), d, nil)
+	taskID, err := c.CreateVMAsync(ctx, nodeName, d)
+	if err != nil {
+		return err
+	}
+
+	err = c.WaitForNodeTask(ctx, nodeName, *taskID, timeout, 1)
+
+	if err != nil {
+		return fmt.Errorf("error waiting for VM creation: %w", err)
+	}
+
+	return nil
+}
+
+// CreateVMAsync creates a virtual machine asynchronously.
+func (c *VirtualEnvironmentClient) CreateVMAsync(
+	ctx context.Context,
+	nodeName string,
+	d *VirtualEnvironmentVMCreateRequestBody,
+) (*string, error) {
+	resBody := &VirtualEnvironmentVMCreateResponseBody{}
+	err := c.DoRequest(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf("nodes/%s/qemu", url.PathEscape(nodeName)),
+		d,
+		resBody,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if resBody.Data == nil {
+		return nil, errors.New("the server did not include a data object in the response")
+	}
+
+	return resBody.Data, nil
 }
 
 // DeleteVM deletes a virtual machine.

--- a/proxmox/virtual_environment_vm_types.go
+++ b/proxmox/virtual_environment_vm_types.go
@@ -303,6 +303,10 @@ type VirtualEnvironmentVMCreateRequestBody struct {
 	WatchdogDevice       *CustomWatchdogDevice          `json:"watchdog,omitempty"           url:"watchdog,omitempty"`
 }
 
+type VirtualEnvironmentVMCreateResponseBody struct {
+	Data *string `json:"data,omitempty"`
+}
+
 // VirtualEnvironmentVMGetQEMUNetworkInterfacesResponseBody contains the body from a QEMU get network interfaces response.
 type VirtualEnvironmentVMGetQEMUNetworkInterfacesResponseBody struct {
 	Data *VirtualEnvironmentVMGetQEMUNetworkInterfacesResponseData `json:"data,omitempty"`

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -228,6 +228,8 @@ const (
 	mkResourceVirtualEnvironmentVMVGAType                           = "type"
 	mkResourceVirtualEnvironmentVMVMID                              = "vm_id"
 	mkResourceVirtualEnvironmentVMSCSIHardware                      = "scsi_hardware"
+
+	vmCreateTimeoutSeconds = 10
 )
 
 func VM() *schema.Resource {
@@ -2072,20 +2074,12 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		createBody.PoolID = &poolID
 	}
 
-	err = veClient.CreateVM(ctx, nodeName, createBody)
+	err = veClient.CreateVM(ctx, nodeName, createBody, vmCreateTimeoutSeconds)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	d.SetId(strconv.Itoa(vmID))
-
-	// NOTE: The VM creation is not atomic, and not synchronous. This means that the VM might not be
-	//   	available immediately after the creation, or its state reported by the API might not be
-	//    	up to date. This is a problem for the following operations, which rely on the VM information
-	//    	returned by API calls, particularly read-back to populate the Terraform state.
-	//		Would it be possible to wait for the VM to be fully available, or to wait for the API to report
-	//		the correct state?
-	// time.Sleep(5 * time.Second)
 
 	return vmCreateCustomDisks(ctx, d, m)
 }


### PR DESCRIPTION
The current implementation of the VM creation flow in the provider does not wait until the VM is created by PVE, nor does it handle a response from the `Create VM` API call. Ignoring the error API response can cause #211 because the VM is not created, and the VM ID is not available for the provider to read from. This causes the provider to reset the state to empty, resulting in an "inconsistent result after apply" error.

The added sync functionality may also improve behaviour in #186, although this use case has not been tested yet.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
