### PR TITLE
feat: bump Go to 1.20 to resolve MacOS DNS resolution issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 NAME=terraform-provider-proxmox
 TARGETS=darwin linux windows
 TERRAFORM_PLUGIN_EXTENSION=
-VERSION=0.19.1# x-release-please-version
+VERSION=0.19.2# x-release-please-version
 
 ifeq ($(OS),Windows_NT)
 	TERRAFORM_PLATFORM=windows_amd64

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ other enhancements.
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) 1.2+
-- [Go](https://golang.org/doc/install) 1.19+ (to build the provider plugin)
+- [Go](https://golang.org/doc/install) 1.20+ (to build the provider plugin)
 - [GoReleaser](https://goreleaser.com/install/) v1.15+ (to build the provider plugin)
 
 ## Table of Contents

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bpg/terraform-provider-proxmox
 
-go 1.19
+go 1.20
 
 require (
 	github.com/google/go-querystring v1.1.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/golang-templates/seed/build
 
-go 1.19
+go 1.20
 
 require (
 	github.com/golangci/golangci-lint v1.52.2


### PR DESCRIPTION
Bumping the go version ensures that MacOS DNS is resolved correctly as per https://go-review.googlesource.com/c/go/+/446178.

Resolves: #341

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [ ] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
