### PR TITLE
fix(vm): Regression: wait for 'net.IsGlobalUnicast' IP address  (#100)

### DIFF
--- a/proxmox/virtual_environment_vm.go
+++ b/proxmox/virtual_environment_vm.go
@@ -667,7 +667,6 @@ func (c *VirtualEnvironmentClient) WaitForNetworkInterfacesFromVMAgent(
 			data, err := c.GetVMNetworkInterfacesFromAgent(ctx, nodeName, vmID)
 
 			if err == nil && data != nil && data.Result != nil {
-				missingIP := false
 				hasAnyGlobalUnicast := false
 
 				if waitForIP {
@@ -678,7 +677,6 @@ func (c *VirtualEnvironmentClient) WaitForNetworkInterfacesFromVMAgent(
 
 						if nic.IPAddresses == nil ||
 							(nic.IPAddresses != nil && len(*nic.IPAddresses) == 0) {
-							missingIP = true
 							break
 						}
 
@@ -690,7 +688,7 @@ func (c *VirtualEnvironmentClient) WaitForNetworkInterfacesFromVMAgent(
 					}
 				}
 
-				if hasAnyGlobalUnicast || !missingIP {
+				if hasAnyGlobalUnicast {
 					return data, err
 				}
 			}


### PR DESCRIPTION
VM can get IPv6 link-local address faster than a DHCP server response, that results in 'ipv4_addresses' output being an empty list. It is then impossible to provision the VM using 'connection.host' field derived from 'self.ipv4_addresses'.

Once again change waiting for IP address to wait for better address than IPv4 link-local addresses and IPv6 link-local addresses.

Should not break #182, because it requires only one GlobalUnicast address per VM.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [ ] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #100

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
