### PR TITLE
fix(vm): Make mac_address computed, fix #339

### DIFF
--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -84,7 +84,6 @@ const (
 	dvResourceVirtualEnvironmentVMNetworkDeviceBridge               = "vmbr0"
 	dvResourceVirtualEnvironmentVMNetworkDeviceEnabled              = true
 	dvResourceVirtualEnvironmentVMNetworkDeviceFirewall             = false
-	dvResourceVirtualEnvironmentVMNetworkDeviceMACAddress           = ""
 	dvResourceVirtualEnvironmentVMNetworkDeviceModel                = "virtio"
 	dvResourceVirtualEnvironmentVMNetworkDeviceRateLimit            = 0
 	dvResourceVirtualEnvironmentVMNetworkDeviceVLANID               = 0
@@ -994,13 +993,10 @@ func VM() *schema.Resource {
 							Default:     dvResourceVirtualEnvironmentVMNetworkDeviceFirewall,
 						},
 						mkResourceVirtualEnvironmentVMNetworkDeviceMACAddress: {
-							Type:        schema.TypeString,
-							Description: "The MAC address",
-							Optional:    true,
-							Default:     dvResourceVirtualEnvironmentVMNetworkDeviceMACAddress,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								return new == ""
-							},
+							Type:             schema.TypeString,
+							Description:      "The MAC address",
+							Optional:         true,
+							Computed:         true,
 							ValidateDiagFunc: getMACAddressValidator(),
 						},
 						mkResourceVirtualEnvironmentVMNetworkDeviceModel: {


### PR DESCRIPTION
Fields `network_interface_names`, `ipv4_addresses` and `ipv6_addresses` are sometimes be marked `computed` again, using `CustomizeDiff`. Changes in `VMStarted` or `VMNetworkDevice` attributes invalidate those values. Marking fields `computed` again avoids stale values.

`network_device` configuration block without `mac_address` results in MAC address set to its default value (an empty string). Terraform state expects `mac_address` to be an empty string, server provides the actual (random) MAC address of the network device. Terraform detects there are changes to be made, but because of `DiffSuppressFunc` on `mac_address` they are hidden from the user, but not from d.HasChange(mkResourceVirtualEnvironmentVMNetworkDevice)

By making `mac_address` also `computed`, the server-generated MAC address is stored locally, avoiding spurious changes that trigger re-computation of `network_interface_names`, `ipv4_addresses` and `ipv6_addresses`.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #339 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
