### PR TITLE
fix(firewall): Improve firewall resources argument validation

### DIFF
--- a/proxmoxtf/resource/firewall/selector.go
+++ b/proxmoxtf/resource/firewall/selector.go
@@ -30,14 +30,16 @@ func selectorSchema() map[string]*schema.Schema {
 			Description: "The name of the node.",
 		},
 		mkSelectorVMID: {
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Description: "The ID of the VM to manage the firewall for.",
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "The ID of the VM to manage the firewall for.",
+			RequiredWith: []string{mkSelectorNodeName},
 		},
 		mkSelectorContainerID: {
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Description: "The ID of the container to manage the firewall for.",
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "The ID of the container to manage the firewall for.",
+			RequiredWith: []string{mkSelectorNodeName},
 		},
 	}
 }
@@ -46,6 +48,9 @@ func selectorSchemaMandatory() map[string]*schema.Schema {
 	s := selectorSchema()
 	s[mkSelectorNodeName].Optional = false
 	s[mkSelectorNodeName].Required = true
+	// required attributes can't be included in RequiredWith
+	s[mkSelectorVMID].RequiredWith = nil
+	s[mkSelectorContainerID].RequiredWith = nil
 
 	return s
 }


### PR DESCRIPTION
Make sure VM / Container rules, SGs, IPSets are always include `node_name` along with `vm_id`, `container_id`.

New validation rule:
```
╷
│ Error: Missing required argument
│
│   with proxmox_virtual_environment_firewall_rules.vm_rule_sg,
│   on main.tf line 210, in resource "proxmox_virtual_environment_firewall_rules" "vm_rule_sg":
│  210:   vm_id     = proxmox_virtual_environment_container.example.vm_id
│
│ "vm_id": all of `node_name,vm_id` must be specified
```

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes to #358

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
