### PR TITLE
fix(vm): Make `vm_id` computed

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -173,7 +173,7 @@ output "ubuntu_container_public_key" {
 - `template` - (Optional) Whether to create a template (defaults to `false`).
 - `unprivileged` - (Optional) Whether the container runs as unprivileged on
   the host (defaults to `false`).
-- `vm_id` - (Optional) The virtual machine identifier
+- `vm_id` - (Optional) The container identifier
 - `features` - (Optional) The container features
     - `nesting` - (Optional) Whether the container is nested (defaults
       to `false`)

--- a/example/resource_virtual_environment_container.tf
+++ b/example/resource_virtual_environment_container.tf
@@ -39,7 +39,8 @@ resource "proxmox_virtual_environment_container" "example_template" {
 
   pool_id  = proxmox_virtual_environment_pool.example.id
   template = true
-  vm_id    = 2042
+
+  // use auto-generated vm_id
 
   tags = [
     "container",

--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -72,7 +72,8 @@ resource "proxmox_virtual_environment_vm" "example_template" {
   serial_device {}
 
   template = true
-  vm_id    = 2040
+
+  // use auto-generated vm_id
 }
 
 resource "proxmox_virtual_environment_vm" "example" {


### PR DESCRIPTION
Defaulting vm_id to -1 prevents resources depending on vm_id value. Make vm_id computed, also update existing vm_id = -1 with correct vm_id.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #364

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
