### PR TITLE
fix(core): Do not limit cluster size to 1 in provider's `ssh` config

### DIFF
--- a/proxmoxtf/provider/provider_test.go
+++ b/proxmoxtf/provider/provider_test.go
@@ -58,6 +58,7 @@ func TestProviderSchema(t *testing.T) {
 		mkProviderOTP,
 		mkProviderPassword,
 		mkProviderUsername,
+		mkProviderSSH,
 	})
 
 	test.AssertValueTypes(t, veSchema, map[string]schema.ValueType{
@@ -66,5 +67,11 @@ func TestProviderSchema(t *testing.T) {
 		mkProviderOTP:      schema.TypeString,
 		mkProviderPassword: schema.TypeString,
 		mkProviderUsername: schema.TypeString,
+		mkProviderSSH:      schema.TypeList,
 	})
+
+	providerSSHSchema := test.AssertNestedSchemaExistence(t, s, mkProviderSSH)
+
+	// do not limit number of nodes in the cluster
+	test.AssertListMaxItems(t, providerSSHSchema, mkProviderSSHNode, 0)
 }

--- a/proxmoxtf/provider/schema.go
+++ b/proxmoxtf/provider/schema.go
@@ -197,7 +197,6 @@ func nestedProviderSchema() map[string]*schema.Schema {
 						Type:        schema.TypeList,
 						Optional:    true,
 						MinItems:    0,
-						MaxItems:    1,
 						Description: "Overrides for SSH connection configuration to a Proxmox node",
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{

--- a/proxmoxtf/test/test_utils.go
+++ b/proxmoxtf/test/test_utils.go
@@ -39,6 +39,16 @@ func AssertNestedSchemaExistence(t *testing.T, s *schema.Resource, key string) *
 	return sh
 }
 
+// AssertListMaxItems checks that the given schema attribute has given expected MaxItems value.
+func AssertListMaxItems(t *testing.T, s *schema.Resource, key string, expectedMaxItems int) {
+	t.Helper()
+
+	require.NotNil(t, s.Schema[key], "Error in Schema: Missing definition for \"%s\"", key)
+	assert.Equal(t, s.Schema[key].MaxItems, expectedMaxItems,
+		"Error in Schema: Argument \"%s\" has \"MaxItems: %#v\", but value %#v is expected!",
+		key, s.Schema[key].MaxItems, expectedMaxItems)
+}
+
 // AssertOptionalArguments checks that the given schema has the given optional arguments.
 func AssertOptionalArguments(t *testing.T, s *schema.Resource, keys []string) {
 	t.Helper()


### PR DESCRIPTION
Allow using repeated 'node' blocks in ssh configuration.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [ ] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to #355

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
