### PR TITLE
fix(provider): Better handling of root@pam token

### DIFF
--- a/proxmox/api/authenticator.go
+++ b/proxmox/api/authenticator.go
@@ -18,6 +18,10 @@ type Authenticator interface {
 	// IsRoot returns true if the authenticator is configured to use the root
 	IsRoot() bool
 
+	// IsRootTicket returns true if the authenticator is configured to use the root directly using a login ticket.
+	// (root using token is weaker, cannot change VM arch)
+	IsRootTicket() bool
+
 	// AuthenticateRequest adds authentication data to a new request.
 	AuthenticateRequest(ctx context.Context, req *http.Request) error
 }

--- a/proxmox/api/client.go
+++ b/proxmox/api/client.go
@@ -52,6 +52,10 @@ type Client interface {
 
 	// IsRoot returns true if the client is configured with the root user.
 	IsRoot() bool
+
+	// IsRootTicket returns true if the authenticator is configured to use the root directly using a login ticket.
+	// (root using token is weaker, cannot change VM arch)
+	IsRootTicket() bool
 }
 
 // Connection represents a connection to the Proxmox Virtual Environment API.
@@ -283,6 +287,10 @@ func (c *client) ExpandPath(path string) string {
 
 func (c *client) IsRoot() bool {
 	return c.auth.IsRoot()
+}
+
+func (c *client) IsRootTicket() bool {
+	return c.auth.IsRootTicket()
 }
 
 // validateResponseCode ensures that a response is valid.

--- a/proxmox/api/ticket_auth.go
+++ b/proxmox/api/ticket_auth.go
@@ -113,6 +113,10 @@ func (t *ticketAuthenticator) IsRoot() bool {
 	return t.authData != nil && t.authData.Username == rootUsername
 }
 
+func (t *ticketAuthenticator) IsRootTicket() bool {
+	return t.IsRoot()
+}
+
 // AuthenticateRequest adds authentication data to a new request.
 func (t *ticketAuthenticator) AuthenticateRequest(ctx context.Context, req *http.Request) error {
 	a, err := t.authenticate(ctx)

--- a/proxmox/api/token_auth.go
+++ b/proxmox/api/token_auth.go
@@ -30,6 +30,11 @@ func (t *tokenAuthenticator) IsRoot() bool {
 	return t.username == rootUsername
 }
 
+func (t *tokenAuthenticator) IsRootTicket() bool {
+	// Logged using a token, therefore not a ticket login
+	return false
+}
+
 func (t *tokenAuthenticator) AuthenticateRequest(_ context.Context, req *http.Request) error {
 	req.Header.Set("Authorization", "PVEAPIToken="+t.token)
 	return nil

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -1555,7 +1555,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		}
 
 		// Only the root account is allowed to change the CPU architecture, which makes this check necessary.
-		if api.API().IsRoot() ||
+		if api.API().IsRootTicket() ||
 			cpuArchitecture != dvResourceVirtualEnvironmentVMCPUArchitecture {
 			updateBody.CPUArchitecture = &cpuArchitecture
 		}
@@ -2084,7 +2084,7 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 	}
 
 	// Only the root account is allowed to change the CPU architecture, which makes this check necessary.
-	if api.API().IsRoot() ||
+	if api.API().IsRootTicket() ||
 		cpuArchitecture != dvResourceVirtualEnvironmentVMCPUArchitecture {
 		createBody.CPUArchitecture = &cpuArchitecture
 	}
@@ -3017,7 +3017,7 @@ func vmReadCustom(
 	} else {
 		// Default value of "arch" is "" according to the API documentation.
 		// However, assume the provider's default value as a workaround when the root account is not being used.
-		if !api.API().IsRoot() {
+		if !api.API().IsRootTicket() {
 			cpu[mkResourceVirtualEnvironmentVMCPUArchitecture] = dvResourceVirtualEnvironmentVMCPUArchitecture
 		} else {
 			cpu[mkResourceVirtualEnvironmentVMCPUArchitecture] = ""
@@ -4221,7 +4221,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 		cpuUnits := cpuBlock[mkResourceVirtualEnvironmentVMCPUUnits].(int)
 
 		// Only the root account is allowed to change the CPU architecture, which makes this check necessary.
-		if api.API().IsRoot() ||
+		if api.API().IsRootTicket() ||
 			cpuArchitecture != dvResourceVirtualEnvironmentVMCPUArchitecture {
 			updateBody.CPUArchitecture = &cpuArchitecture
 		}


### PR DESCRIPTION
Token logins using root@pam!sometoken=uuid are not considered by PVE as 'root' logins, and fail to change VM's arch. Make sure the provider does not try to set/change VM's arch.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
