### PR TITLE
fix(file): spurious unsupported content type warning

### DIFF
--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -404,13 +405,15 @@ func fileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 			return diag.Errorf("failed to determine the datastore path")
 		}
 
+		sort.Strings(datastore.Content)
+
 		_, found := slices.BinarySearch(datastore.Content, *contentType)
 		if !found {
 			diags = append(diags, diag.Diagnostics{
 				diag.Diagnostic{
 					Severity: diag.Warning,
-					Summary: fmt.Sprintf("the datastore %q does not support content type %q",
-						*datastore.Storage, *contentType,
+					Summary: fmt.Sprintf("the datastore %q does not support content type %q; supported content types are: %v",
+						*datastore.Storage, *contentType, datastore.Content,
 					),
 				},
 			}...)


### PR DESCRIPTION
Error like may pop up when uploading a file over SSH (snippets is the most common use case), when the storage in fact has "snippets" type enabled.

> Warning: the datastore "local" does not support content type "snippets"


### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
