### PR TITLE
fix(vm): do not error on `read` at state refresh if VM is missing

### DIFF
--- a/proxmox/cluster/cluster.go
+++ b/proxmox/cluster/cluster.go
@@ -22,6 +22,9 @@ const (
 	getVMIDStep = 1
 )
 
+// ErrVMDoesNotExist is returned when the VM identifier cannot be found on any cluster node.
+var ErrVMDoesNotExist = errors.New("unable to find VM identifier on any cluster node")
+
 var (
 	//nolint:gochecknoglobals
 	getVMIDCounter = -1
@@ -136,5 +139,5 @@ func (c *Client) GetVMNodeName(ctx context.Context, vmID int) (*string, error) {
 		}
 	}
 
-	return nil, errors.New("unable to determine node name for VM identifier")
+	return nil, ErrVMDoesNotExist
 }

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	types2 "github.com/bpg/terraform-provider-proxmox/internal/types"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/cluster"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf"
@@ -3042,6 +3043,12 @@ func vmRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 
 	vmNodeName, err := api.Cluster().GetVMNodeName(ctx, vmID)
 	if err != nil {
+		if errors.Is(err, cluster.ErrVMDoesNotExist) {
+			d.SetId("")
+
+			return nil
+		}
+
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #393

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
