### PR TITLE
fix(node): ignore field `bridge_fd` when listing network interfaces of a node

### DIFF
--- a/proxmox/nodes/network_types.go
+++ b/proxmox/nodes/network_types.go
@@ -17,11 +17,14 @@ type NetworkInterfaceListResponseBody struct {
 
 // NetworkInterfaceListResponseData contains the data from a node network interface list response.
 type NetworkInterfaceListResponseData struct {
+	// There seems to be inconsistency in the APIs between certain versions of Proxmox.
+	// See https://github.com/bpg/terraform-provider-proxmox/issues/410
+	// BridgeFD        *int              `json:"bridge_fd,omitempty"`
+
 	Active          *types.CustomBool `json:"active,omitempty"`
 	Address         *string           `json:"address,omitempty"`
 	Address6        *string           `json:"address6,omitempty"`
 	Autostart       *types.CustomBool `json:"autostart,omitempty"`
-	BridgeFD        *int              `json:"bridge_fd,omitempty"`
 	BridgePorts     *string           `json:"bridge_ports,omitempty"`
 	BridgeSTP       *string           `json:"bridge_stp,omitempty"`
 	BridgeVIDs      *string           `json:"bridge_vids,omitempty"`


### PR DESCRIPTION
There is inconsistency in PVE API between versions, so ignore the field altogether as it is not used anywhere at the moment. 

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates: #410

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
