### PR TITLE
fix(vm): add missing unmarshal for vm custom startup order

### DIFF
--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -1696,6 +1696,46 @@ func (r *CustomSMBIOS) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// UnmarshalJSON converts a CustomStartupOrder string to an object.
+func (r *CustomStartupOrder) UnmarshalJSON(b []byte) error {
+	var s string
+
+	if err := json.Unmarshal(b, &s); err != nil {
+		return fmt.Errorf("failed to unmarshal CustomStartupOrder: %w", err)
+	}
+
+	pairs := strings.Split(s, ",")
+
+	for _, p := range pairs {
+		v := strings.Split(strings.TrimSpace(p), "=")
+
+		if len(v) == 2 {
+			switch v[0] {
+			case "order":
+				order, err := strconv.Atoi(v[1])
+				if err != nil {
+					return fmt.Errorf("failed to parse int: %w", err)
+				}
+				r.Order = &order
+			case "up":
+				up, err := strconv.Atoi(v[1])
+				if err != nil {
+					return fmt.Errorf("failed to parse int: %w", err)
+				}
+				r.Up = &up
+			case "down":
+				down, err := strconv.Atoi(v[1])
+				if err != nil {
+					return fmt.Errorf("failed to parse int: %w", err)
+				}
+				r.Down = &down
+			}
+		}
+	}
+
+	return nil
+}
+
 // UnmarshalJSON converts a CustomStorageDevice string to an object.
 func (r *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 	var s string

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -1716,18 +1716,21 @@ func (r *CustomStartupOrder) UnmarshalJSON(b []byte) error {
 				if err != nil {
 					return fmt.Errorf("failed to parse int: %w", err)
 				}
+
 				r.Order = &order
 			case "up":
 				up, err := strconv.Atoi(v[1])
 				if err != nil {
 					return fmt.Errorf("failed to parse int: %w", err)
 				}
+
 				r.Up = &up
 			case "down":
 				down, err := strconv.Atoi(v[1])
 				if err != nil {
 					return fmt.Errorf("failed to parse int: %w", err)
 				}
+
 				r.Down = &down
 			}
 		}


### PR DESCRIPTION
### Contributor's Note
Finally found the missing piece and just went ahead and added it myself for enough json parsing support to make the parse error go away so that vm imports will succeed when startup options are configured.

Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [ ] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #421

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
