### PR TITLE
fix(vm): fix for the api call upon empty disks

### DIFF
--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -3397,7 +3397,7 @@ func vmReadCustom(
 	for di, dd := range diskObjects {
 		disk := map[string]interface{}{}
 
-		if dd == nil || strings.HasPrefix(di, "ide") {
+		if dd == nil || dd.FileVolume == "none" || strings.HasPrefix(di, "ide") {
 			continue
 		}
 


### PR DESCRIPTION
Ignore empty storage devices which may not have any media mounted, or the API will throw an error.

<img width="889" alt="image" src="https://github.com/bpg/terraform-provider-proxmox/assets/6451933/dba3e230-4eee-47f6-940f-9f3aac825abd">

---

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
