### PR TITLE
feat(vm): add support for start/shutdown order configuration

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -26,6 +26,12 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
     enabled = true
   }
 
+  startup {
+    order      = "3"
+    up_delay   = "60"
+    down_delay = "60"
+  }
+  
   disk {
     datastore_id = "local-lvm"
     file_id      = proxmox_virtual_environment_file.ubuntu_cloud_image.id
@@ -410,6 +416,13 @@ output "ubuntu_vm_public_key" {
     - `pvscsi` - VMware Paravirtual SCSI.
 - `started` - (Optional) Whether to start the virtual machine (defaults
   to `true`).
+- `startup` - (Optional) Defines startup and shutdown behavior of the VM.
+    - `order` - (Required) A non-negative number defining the general startup
+      order.
+    - `up` - (Optional) A non-negative number defining the delay in seconds
+      before the next VM is started.
+    - `down` - (Optional) A non-negative number defining the delay in seconds
+      before the next VM is shut down.
 - `tablet_device` - (Optional) Whether to enable the USB tablet device (defaults
   to `true`).
 - `tags` - (Optional) A list of tags of the VM. This is only meta information (

--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -13,10 +13,16 @@ resource "proxmox_virtual_environment_vm" "example_template" {
     numa = true
   }
 
+  startup {
+    order      = "3"
+    up_delay   = "60"
+    down_delay = "60"
+  }
+
   efi_disk {
-    datastore_id      = local.datastore_id
-    file_format       = "raw"
-    type              = "4m"
+    datastore_id = local.datastore_id
+    file_format  = "raw"
+    type         = "4m"
   }
 
   #  disk {


### PR DESCRIPTION
```terraform
  startup {
    order      = "3"
    up_delay   = "60"
    down_delay = "60"
  }
```

<img width="766" alt="Screenshot 2023-07-29 at 10 49 05 PM" src="https://github.com/bpg/terraform-provider-proxmox/assets/627562/7e942df7-a3bc-4944-be74-19a1cc2a4028">

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #392

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
