### PR TITLE
fix(vm): give `cache` the correct default value

### DIFF
--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -64,7 +64,7 @@ const (
 	dvResourceVirtualEnvironmentVMDiskIOThread                      = false
 	dvResourceVirtualEnvironmentVMDiskSSD                           = false
 	dvResourceVirtualEnvironmentVMDiskDiscard                       = ""
-	dvResourceVirtualEnvironmentVMDiskCache                         = ""
+	dvResourceVirtualEnvironmentVMDiskCache                         = "none"
 	dvResourceVirtualEnvironmentVMDiskSpeedRead                     = 0
 	dvResourceVirtualEnvironmentVMDiskSpeedReadBurstable            = 0
 	dvResourceVirtualEnvironmentVMDiskSpeedWrite                    = 0


### PR DESCRIPTION
`cache` should be one of [none writethrough writeback unsafe directsync], the default "" is given, however.

<img width="1187" alt="image" src="https://github.com/bpg/terraform-provider-proxmox/assets/6451933/0c983aaf-dc8e-4360-b209-58a9ce1c888b">

---

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
