### PR TITLE
fix(user): make `password` attribute optional

### DIFF
--- a/docs/resources/virtual_environment_user.md
+++ b/docs/resources/virtual_environment_user.md
@@ -49,7 +49,7 @@ resource "proxmox_virtual_environment_role" "operations_monitoring" {
 - `groups` - (Optional) The user's groups.
 - `keys` - (Optional) The user's keys.
 - `last_name` - (Optional) The user's last name.
-- `password` - (Required) The user's password.
+- `password` - (Optional) The user's password. Required for PVE or PAM realms.
 - `user_id` - (Required) The user identifier.
 
 ## Attribute Reference

--- a/proxmoxtf/resource/user.go
+++ b/proxmoxtf/resource/user.go
@@ -131,7 +131,7 @@ func User() *schema.Resource {
 			mkResourceVirtualEnvironmentUserPassword: {
 				Type:        schema.TypeString,
 				Description: "The user's password",
-				Required:    true,
+				Optional:    true,
 			},
 			mkResourceVirtualEnvironmentUserUserID: {
 				Type:        schema.TypeString,

--- a/proxmoxtf/resource/user_test.go
+++ b/proxmoxtf/resource/user_test.go
@@ -31,7 +31,6 @@ func TestUserSchema(t *testing.T) {
 	s := User()
 
 	test.AssertRequiredArguments(t, s, []string{
-		mkResourceVirtualEnvironmentUserPassword,
 		mkResourceVirtualEnvironmentUserUserID,
 	})
 
@@ -45,6 +44,7 @@ func TestUserSchema(t *testing.T) {
 		mkResourceVirtualEnvironmentUserGroups,
 		mkResourceVirtualEnvironmentUserKeys,
 		mkResourceVirtualEnvironmentUserLastName,
+		mkResourceVirtualEnvironmentUserPassword,
 	})
 
 	test.AssertValueTypes(t, s, map[string]schema.ValueType{


### PR DESCRIPTION
### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #462 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
