### PR TITLE
feat(file): ensure upload of ISO/VSTMPL is completed upon resource creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ example: example-build example-init example-apply example-destroy
 
 example-apply:
 	export TF_CLI_CONFIG_FILE="$(shell pwd -P)/example.tfrc" \
+		&& export TF_REATTACH_PROVIDERS='{"registry.terraform.io/bpg/proxmox":{"Protocol":"grpc","ProtocolVersion":6,"Pid":82711,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/xx/4plpx_3133lbctp7b7v1yfch0000gn/T/plugin3121225613"}}}' \
 		&& export TF_DISABLE_CHECKPOINT="true" \
 		&& export TF_PLUGIN_CACHE_DIR="$(TERRAFORM_PLUGIN_CACHE_DIRECTORY)" \
 		&& cd ./example \

--- a/docs/resources/virtual_environment_file.md
+++ b/docs/resources/virtual_environment_file.md
@@ -76,7 +76,8 @@ EOF
     - `data` - (Required) The raw data.
     - `file_name` - (Required) The file name.
     - `resize` - (Optional) The number of bytes to resize the file to.
-- `timeout_upload` - (Optional) Timeout for uploading ISO/VSTMPL files. Default 1800s.
+- `timeout_upload` - (Optional) Timeout for uploading ISO/VSTMPL files in
+  seconds (defaults to 1800).
 
 ## Attribute Reference
 
@@ -97,7 +98,8 @@ created as another temporary file).
 
 ## Import
 
-Instances can be imported using the `node_name`, `datastore_id`, `content_type` and the `file_name`, e.g.,
+Instances can be imported using the `node_name`, `datastore_id`, `content_type`
+and the `file_name`, e.g.,
 
 ```bash
 $ terraform import proxmox_virtual_environment_file.cloud_config pve/local/snippets/example.cloud-config.yaml

--- a/docs/resources/virtual_environment_file.md
+++ b/docs/resources/virtual_environment_file.md
@@ -76,6 +76,7 @@ EOF
     - `data` - (Required) The raw data.
     - `file_name` - (Required) The file name.
     - `resize` - (Optional) The number of bytes to resize the file to.
+- `timeout_upload` - (Optional) Timeout for uploading ISO/VSTMPL files. Default 1800s.
 
 ## Attribute Reference
 

--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -194,7 +194,7 @@ func File() *schema.Resource {
 			},
 			mkResourceVirtualEnvironmentFileTimeoutUpload: {
 				Type:        schema.TypeInt,
-				Description: "Timeout to upload ISO/VZTMPL",
+				Description: "Timeout for uploading ISO/VSTMPL files in seconds",
 				Optional:    true,
 				Default:     dvResourceVirtualEnvironmentFileTimeoutUpload,
 			},

--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -197,7 +197,6 @@ func File() *schema.Resource {
 				Description: "Timeout to upload ISO/VZTMPL",
 				Optional:    true,
 				Default:     dvResourceVirtualEnvironmentFileTimeoutUpload,
-				ForceNew:    true,
 			},
 		},
 		CreateContext: fileCreate,

--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -40,6 +40,7 @@ const (
 	dvResourceVirtualEnvironmentFileSourceFileFileName = ""
 	dvResourceVirtualEnvironmentFileSourceFileInsecure = false
 	dvResourceVirtualEnvironmentFileSourceRawResize    = 0
+	dvResourceVirtualEnvironmentFileTimeoutUpload      = 1800
 
 	mkResourceVirtualEnvironmentFileContentType          = "content_type"
 	mkResourceVirtualEnvironmentFileDatastoreID          = "datastore_id"
@@ -58,6 +59,7 @@ const (
 	mkResourceVirtualEnvironmentFileSourceRawData        = "data"
 	mkResourceVirtualEnvironmentFileSourceRawFileName    = "file_name"
 	mkResourceVirtualEnvironmentFileSourceRawResize      = "resize"
+	mkResourceVirtualEnvironmentFileTimeoutUpload        = "timeout_upload"
 )
 
 // File returns a resource that manages files on a node.
@@ -189,6 +191,13 @@ func File() *schema.Resource {
 				},
 				MaxItems: 1,
 				MinItems: 0,
+			},
+			mkResourceVirtualEnvironmentFileTimeoutUpload: {
+				Type:        schema.TypeInt,
+				Description: "Timeout to upload ISO/VZTMPL",
+				Optional:    true,
+				Default:     dvResourceVirtualEnvironmentFileTimeoutUpload,
+				ForceNew:    true,
 			},
 		},
 		CreateContext: fileCreate,
@@ -425,7 +434,8 @@ func fileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 
 	switch *contentType {
 	case "iso", "vztmpl":
-		_, err = capi.Node(nodeName).APIUpload(ctx, datastoreID, request)
+		uploadTimeout := d.Get(mkResourceVirtualEnvironmentFileTimeoutUpload).(int)
+		_, err = capi.Node(nodeName).APIUpload(ctx, datastoreID, request, uploadTimeout)
 	default:
 		// For all other content types, we need to upload the file to the node's
 		// datastore using SFTP.

--- a/proxmoxtf/resource/file_test.go
+++ b/proxmoxtf/resource/file_test.go
@@ -40,6 +40,7 @@ func TestFileSchema(t *testing.T) {
 		mkResourceVirtualEnvironmentFileContentType,
 		mkResourceVirtualEnvironmentFileSourceFile,
 		mkResourceVirtualEnvironmentFileSourceRaw,
+		mkResourceVirtualEnvironmentFileTimeoutUpload,
 	})
 
 	test.AssertComputedAttributes(t, s, []string{
@@ -59,6 +60,7 @@ func TestFileSchema(t *testing.T) {
 		mkResourceVirtualEnvironmentFileNodeName:             schema.TypeString,
 		mkResourceVirtualEnvironmentFileSourceFile:           schema.TypeList,
 		mkResourceVirtualEnvironmentFileSourceRaw:            schema.TypeList,
+		mkResourceVirtualEnvironmentFileTimeoutUpload:        schema.TypeInt,
 	})
 
 	sourceFileSchema := test.AssertNestedSchemaExistence(t, s, mkResourceVirtualEnvironmentFileSourceFile)


### PR DESCRIPTION
The upload of ISO/VMTMPLs uses the Proxmox REST API Upload. But as the code doesn't wait for this to finish you can run into problems deploying the VM

We saw this when creating multiple VMs that were using a "proxmox_virtual_environment_file" to point to our Ubuntu image (~6GB). You could see the upload task was still running on the Proxmox node, but then started creating the VM. This led to a corrupt image that couldn't start

We've added WaitForTask for the upload so that it polls to check it really is uploaded. 

Rather that hardcode a timeout (as in network.go) we've added a parameter into "proxmox_virtual_environment_file" which defaults to 1800s but can be overridden

Updated file_test.go that checks the file Schema
Tested locally and with the fix we were then able to create VMs as the upload always completed first

Didn't add anything to examples as this is primarily a fix and the documentation is enough to explain what the new argument does

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [X] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
