### PR TITLE
fix(user): make `password` attribute optional

### DIFF
--- a/example/resource_virtual_environment_user.tf
+++ b/example/resource_virtual_environment_user.tf
@@ -10,6 +10,11 @@ resource "proxmox_virtual_environment_user" "example" {
   user_id  = "terraform-provider-proxmox-example@pve"
 }
 
+resource "proxmox_virtual_environment_user" "example2" {
+  comment  = "Managed by Terraform"
+  user_id  = "terraform-provider-proxmox-example2@pve"
+}
+
 output "resource_proxmox_virtual_environment_user_example_acl" {
   value = proxmox_virtual_environment_user.example.acl
 }

--- a/proxmox/access/users_types.go
+++ b/proxmox/access/users_types.go
@@ -27,7 +27,7 @@ type UserCreateRequestBody struct {
 	ID             string                 `json:"userid"              url:"userid"`
 	Keys           *string                `json:"keys,omitempty"      url:"keys,omitempty"`
 	LastName       *string                `json:"lastname,omitempty"  url:"lastname,omitempty"`
-	Password       string                 `json:"password"            url:"password"`
+	Password       string                 `json:"password"            url:"password,omitempty"`
 }
 
 // UserGetResponseBody contains the body from a user get response.


### PR DESCRIPTION
The password is already optional in the terraform schema, but still serialized and sent as an empty string via the client. This addresses the request body serialization.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #462

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
