### PR TITLE
fix(vm): default disk cache is not set to `none` if not specified for an existing disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ example: example-build example-init example-apply example-destroy
 
 example-apply:
 	export TF_CLI_CONFIG_FILE="$(shell pwd -P)/example.tfrc" \
-		&& export TF_REATTACH_PROVIDERS='{"registry.terraform.io/bpg/proxmox":{"Protocol":"grpc","ProtocolVersion":6,"Pid":82711,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/xx/4plpx_3133lbctp7b7v1yfch0000gn/T/plugin3121225613"}}}' \
 		&& export TF_DISABLE_CHECKPOINT="true" \
 		&& export TF_PLUGIN_CACHE_DIR="$(TERRAFORM_PLUGIN_CACHE_DIRECTORY)" \
 		&& cd ./example \

--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -196,6 +196,7 @@ func File() *schema.Resource {
 				Type:        schema.TypeInt,
 				Description: "Timeout for uploading ISO/VSTMPL files in seconds",
 				Optional:    true,
+				ForceNew:    true,
 				Default:     dvResourceVirtualEnvironmentFileTimeoutUpload,
 			},
 		},

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -3706,13 +3706,13 @@ func vmReadCustom(
 		if dd.Discard != nil {
 			disk[mkResourceVirtualEnvironmentVMDiskDiscard] = *dd.Discard
 		} else {
-			disk[mkResourceVirtualEnvironmentVMDiskDiscard] = ""
+			disk[mkResourceVirtualEnvironmentVMDiskDiscard] = dvResourceVirtualEnvironmentVMDiskDiscard
 		}
 
 		if dd.Cache != nil {
 			disk[mkResourceVirtualEnvironmentVMDiskCache] = *dd.Cache
 		} else {
-			disk[mkResourceVirtualEnvironmentVMDiskCache] = ""
+			disk[mkResourceVirtualEnvironmentVMDiskCache] = dvResourceVirtualEnvironmentVMDiskCache
 		}
 
 		diskMap[di] = disk
@@ -5007,6 +5007,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 				tmp.BurstableWriteSpeedMbps = value.BurstableWriteSpeedMbps
 				tmp.MaxReadSpeedMbps = value.MaxReadSpeedMbps
 				tmp.MaxWriteSpeedMbps = value.MaxWriteSpeedMbps
+				tmp.Cache = value.Cache
 
 				switch prefix {
 				case "virtio":


### PR DESCRIPTION
Also fixes missing `ForceNew` for `file` resources.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #468

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
