### PR TITLE
fix(vm): ensure startup / shutdown delay is applied when order is not configured

### DIFF
--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -1303,18 +1303,16 @@ func VM() *schema.Resource {
 							Default:     dvResourceVirtualEnvironmentVMStartupOrder,
 						},
 						mkResourceVirtualEnvironmentVMStartupUpDelay: {
-							Type:             schema.TypeInt,
-							Description:      "A non-negative number defining the delay in seconds before the next VM is started",
-							Optional:         true,
-							Default:          dvResourceVirtualEnvironmentVMStartupUpDelay,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
+							Type:        schema.TypeInt,
+							Description: "A non-negative number defining the delay in seconds before the next VM is started",
+							Optional:    true,
+							Default:     dvResourceVirtualEnvironmentVMStartupUpDelay,
 						},
 						mkResourceVirtualEnvironmentVMStartupDownDelay: {
-							Type:             schema.TypeInt,
-							Description:      "A non-negative number defining the delay in seconds before the next VM is shut down",
-							Optional:         true,
-							Default:          dvResourceVirtualEnvironmentVMStartupDownDelay,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
+							Type:        schema.TypeInt,
+							Description: "A non-negative number defining the delay in seconds before the next VM is shut down",
+							Optional:    true,
+							Default:     dvResourceVirtualEnvironmentVMStartupDownDelay,
 						},
 					},
 				},
@@ -3206,8 +3204,9 @@ func vmGetStartupOrder(d *schema.ResourceData) *vms.CustomStartupOrder {
 
 		if startupOrder >= 0 {
 			order.Order = &startupOrder
-			return &order
 		}
+
+		return &order
 	}
 
 	return nil


### PR DESCRIPTION
### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #475

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
