### PR TITLE
fix(vm): no IP address detection when VM contains bridges

### DIFF
--- a/proxmox/nodes/vms/vms.go
+++ b/proxmox/nodes/vms/vms.go
@@ -445,7 +445,7 @@ func (c *Client) WaitForNetworkInterfacesFromVMAgent(
 
 						if nic.IPAddresses == nil ||
 							(nic.IPAddresses != nil && len(*nic.IPAddresses) == 0) {
-							break
+							continue
 						}
 
 						for _, addr := range *nic.IPAddresses {


### PR DESCRIPTION
When the VM contains at least one bridge, the main interface (e.g. `eth0`) is left without an IP address because that's how networks usually work.

The code that queries the VM's IP addresses (through the guest agent), loops all available interfaces to find one. The existing code though would prematurely exit the loop if the interface it was checking had no IP address assigned. Like the aforementioned `eth0`, when it is controlled by a bridge.

This patch fixes this problem by not exiting the loop, instead just continuing to the next interface.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #492

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
