### PR TITLE
fix(vm): fix index out of range when unmarshalling custompcidevice

### DIFF
--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -1606,7 +1606,7 @@ func (r *CustomPCIDevice) UnmarshalJSON(b []byte) error {
 	for _, p := range pairs {
 		v := strings.Split(strings.TrimSpace(p), "=")
 		if len(v) == 1 {
-			r.DeviceIDs = strings.Split(v[1], ";")
+			r.DeviceIDs = strings.Split(v[0], ";")
 		} else if len(v) == 2 {
 			switch v[0] {
 			case "host":

--- a/proxmox/nodes/vms/vms_types_test.go
+++ b/proxmox/nodes/vms/vms_types_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestCustomStorageDevice_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
 	ds8gig := types.DiskSizeFromGigabytes(8)
 	tests := []struct {
 		name    string
@@ -49,8 +51,11 @@ func TestCustomStorageDevice_UnmarshalJSON(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			r := &CustomStorageDevice{}
 			if err := r.UnmarshalJSON([]byte(tt.line)); (err != nil) != tt.wantErr {
 				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
@@ -61,6 +66,8 @@ func TestCustomStorageDevice_UnmarshalJSON(t *testing.T) {
 }
 
 func TestCustomPCIDevice_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		line    string
@@ -94,7 +101,9 @@ func TestCustomPCIDevice_UnmarshalJSON(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			r := &CustomPCIDevice{}
 			if err := r.UnmarshalJSON([]byte(tt.line)); (err != nil) != tt.wantErr {
 				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)

--- a/proxmox/nodes/vms/vms_types_test.go
+++ b/proxmox/nodes/vms/vms_types_test.go
@@ -59,3 +59,46 @@ func TestCustomStorageDevice_UnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestCustomPCIDevice_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		line    string
+		want    *CustomPCIDevice
+		wantErr bool
+	}{
+		{
+			name: "id only pci device",
+			line: `"0000:81:00.2"`,
+			want: &CustomPCIDevice{
+				DeviceIDs:  []string{"0000:81:00.2"},
+				MDev:       nil,
+				PCIExpress: types.BoolPtr(false),
+				ROMBAR:     types.BoolPtr(true),
+				ROMFile:    nil,
+				XVGA:       types.BoolPtr(false),
+			},
+		},
+		{
+			name: "pci device with more details",
+			line: `"host=81:00.4,pcie=0,rombar=1,x-vga=0"`,
+			want: &CustomPCIDevice{
+				DeviceIDs:  []string{"81:00.4"},
+				MDev:       nil,
+				PCIExpress: types.BoolPtr(false),
+				ROMBAR:     types.BoolPtr(true),
+				ROMFile:    nil,
+				XVGA:       types.BoolPtr(false),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &CustomPCIDevice{}
+			if err := r.UnmarshalJSON([]byte(tt.line)); (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change fixes an index out of range error when trying to unmarshal a CustomPCIDevice from a string just containing the device id and no comma separated key/value pairs.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->