### PR TITLE
feat(vm): support for migration when the node name is modified

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -365,6 +365,8 @@ output "ubuntu_vm_public_key" {
     - `floating` - (Optional) The floating memory in megabytes (defaults
       to `0`).
     - `shared` - (Optional) The shared memory in megabytes (defaults to `0`).
+- `migrate` - (Optional) Migrate the VM on node change instead of re-creating
+  it (defaults to `false`).
 - `name` - (Optional) The virtual machine name.
 - `network_device` - (Optional) A network device (multiple blocks supported).
     - `bridge` - (Optional) The name of the network bridge (defaults
@@ -446,6 +448,8 @@ output "ubuntu_vm_public_key" {
   1800).
 - `timeout_move_disk` - (Optional) Timeout for moving the disk of a VM in
   seconds (defaults to 1800).
+- `timeout_migrate` - (Optional) Timeout for migrating the VM (defaults to
+  1800).
 - `timeout_reboot` - (Optional) Timeout for rebooting a VM in seconds (defaults
   to 1800).
 - `timeout_shutdown_vm` - (Optional) Timeout for shutting down a VM in seconds (

--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -104,6 +104,7 @@ resource "proxmox_virtual_environment_vm" "example_template" {
 resource "proxmox_virtual_environment_vm" "example" {
   name      = "terraform-provider-proxmox-example"
   node_name = data.proxmox_virtual_environment_nodes.example.names[0]
+  migrate   = true // migrate the VM on node change
   pool_id   = proxmox_virtual_environment_pool.example.id
   vm_id     = 2041
   tags      = ["terraform", "ubuntu"]

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -526,7 +526,7 @@ type ListResponseData struct {
 
 // MigrateRequestBody contains the body for a VM migration request.
 type MigrateRequestBody struct {
-	OnlineMigration *types.CustomBool `json:"online,omitempty"           url:"online,omitempty"`
+	OnlineMigration *types.CustomBool `json:"online,omitempty"           url:"online,omitempty,int"`
 	TargetNode      string            `json:"target"                     url:"target"`
 	TargetStorage   *string           `json:"targetstorage,omitempty"    url:"targetstorage,omitempty"`
 	WithLocalDisks  *types.CustomBool `json:"with-local-disks,omitempty" url:"with-local-disks,omitempty,int"`

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -96,6 +96,7 @@ const (
 	dvResourceVirtualEnvironmentVMMemoryDedicated                   = 512
 	dvResourceVirtualEnvironmentVMMemoryFloating                    = 0
 	dvResourceVirtualEnvironmentVMMemoryShared                      = 0
+	dvResourceVirtualEnvironmentVMMigrate                           = false
 	dvResourceVirtualEnvironmentVMName                              = ""
 	dvResourceVirtualEnvironmentVMNetworkDeviceBridge               = "vmbr0"
 	dvResourceVirtualEnvironmentVMNetworkDeviceEnabled              = true
@@ -121,6 +122,7 @@ const (
 	dvResourceVirtualEnvironmentVMTemplate                          = false
 	dvResourceVirtualEnvironmentVMTimeoutClone                      = 1800
 	dvResourceVirtualEnvironmentVMTimeoutMoveDisk                   = 1800
+	dvResourceVirtualEnvironmentVMTimeoutMigrate                    = 1800
 	dvResourceVirtualEnvironmentVMTimeoutReboot                     = 1800
 	dvResourceVirtualEnvironmentVMTimeoutShutdownVM                 = 1800
 	dvResourceVirtualEnvironmentVMTimeoutStartVM                    = 1800
@@ -228,6 +230,7 @@ const (
 	mkResourceVirtualEnvironmentVMMemoryDedicated                   = "dedicated"
 	mkResourceVirtualEnvironmentVMMemoryFloating                    = "floating"
 	mkResourceVirtualEnvironmentVMMemoryShared                      = "shared"
+	mkResourceVirtualEnvironmentVMMigrate                           = "migrate"
 	mkResourceVirtualEnvironmentVMName                              = "name"
 	mkResourceVirtualEnvironmentVMNetworkDevice                     = "network_device"
 	mkResourceVirtualEnvironmentVMNetworkDeviceBridge               = "bridge"
@@ -263,6 +266,7 @@ const (
 	mkResourceVirtualEnvironmentVMTemplate                          = "template"
 	mkResourceVirtualEnvironmentVMTimeoutClone                      = "timeout_clone"
 	mkResourceVirtualEnvironmentVMTimeoutMoveDisk                   = "timeout_move_disk"
+	mkResourceVirtualEnvironmentVMTimeoutMigrate                    = "timeout_migrate"
 	mkResourceVirtualEnvironmentVMTimeoutReboot                     = "timeout_reboot"
 	mkResourceVirtualEnvironmentVMTimeoutShutdownVM                 = "timeout_shutdown_vm"
 	mkResourceVirtualEnvironmentVMTimeoutStartVM                    = "timeout_start_vm"
@@ -1181,7 +1185,12 @@ func VM() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The node name",
 				Required:    true,
-				ForceNew:    true,
+			},
+			mkResourceVirtualEnvironmentVMMigrate: {
+				Type:        schema.TypeBool,
+				Description: "Whether to migrate the VM on node change instead of re-creating it",
+				Optional:    true,
+				Default:     dvResourceVirtualEnvironmentVMMigrate,
 			},
 			mkResourceVirtualEnvironmentVMOperatingSystem: {
 				Type:        schema.TypeList,
@@ -1367,6 +1376,12 @@ func VM() *schema.Resource {
 				Optional:    true,
 				Default:     dvResourceVirtualEnvironmentVMTimeoutMoveDisk,
 			},
+			mkResourceVirtualEnvironmentVMTimeoutMigrate: {
+				Type:        schema.TypeInt,
+				Description: "MoveDisk timeout",
+				Optional:    true,
+				Default:     dvResourceVirtualEnvironmentVMTimeoutMigrate,
+			},
 			mkResourceVirtualEnvironmentVMTimeoutReboot: {
 				Type:        schema.TypeInt,
 				Description: "Reboot timeout",
@@ -1482,6 +1497,12 @@ func VM() *schema.Resource {
 					// 'vm_id' is ForceNew, except when changing 'vm_id' to existing correct id
 					// (automatic fix from -1 to actual vm_id must not re-create VM)
 					return strconv.Itoa(newValue.(int)) != d.Id()
+				},
+			),
+			customdiff.ForceNewIf(
+				mkResourceVirtualEnvironmentVMNodeName,
+				func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+					return !d.Get(mkResourceVirtualEnvironmentVMMigrate).(bool)
 				},
 			),
 		),
@@ -4807,6 +4828,26 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 	vmID, e := strconv.Atoi(d.Id())
 	if e != nil {
 		return diag.FromErr(e)
+	}
+
+	// If the node name has changed we need to migrate the VM to the new node before we do anything else.
+	if d.HasChange(mkResourceVirtualEnvironmentVMNodeName) {
+		oldNodeNameValue, _ := d.GetChange(mkResourceVirtualEnvironmentVMNodeName)
+		oldNodeName := oldNodeNameValue.(string)
+		vmAPI := api.Node(oldNodeName).VM(vmID)
+
+		migrateTimeout := d.Get(mkResourceVirtualEnvironmentVMTimeoutMigrate).(int)
+		trueValue := types.CustomBool(true)
+		migrateBody := &vms.MigrateRequestBody{
+			TargetNode:      nodeName,
+			WithLocalDisks:  &trueValue,
+			OnlineMigration: &trueValue,
+		}
+
+		err := vmAPI.MigrateVM(ctx, migrateBody, migrateTimeout)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	vmAPI := api.Node(nodeName).VM(vmID)

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -1379,7 +1379,7 @@ func VM() *schema.Resource {
 			},
 			mkResourceVirtualEnvironmentVMTimeoutMigrate: {
 				Type:        schema.TypeInt,
-				Description: "MoveDisk timeout",
+				Description: "Migrate VM timeout",
 				Optional:    true,
 				Default:     dvResourceVirtualEnvironmentVMTimeoutMigrate,
 			},


### PR DESCRIPTION
  * Added a `migrate` VM flag which changes the provider's behaviour when the VM's `node_name` is updated. If `true`, the VM will be migrated to the specified node instead of being re-created.

  * Added a `timeout_migrate` setting to control the timeout for VM migration.

  * Fixed a bug in the API's migration data structure that prevented the online migration flag to be set.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [ ] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0499

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
