### PR TITLE
feat(vm): pool update support

### DIFF
--- a/proxmox/pools/pool_types.go
+++ b/proxmox/pools/pool_types.go
@@ -6,6 +6,8 @@
 
 package pools
 
+import "github.com/bpg/terraform-provider-proxmox/internal/types"
+
 // PoolCreateRequestBody contains the data for a pool create request.
 type PoolCreateRequestBody struct {
 	Comment *string `json:"comment,omitempty" url:"comment,omitempty"`
@@ -45,5 +47,12 @@ type PoolListResponseData struct {
 
 // PoolUpdateRequestBody contains the data for an pool update request.
 type PoolUpdateRequestBody struct {
+	// The pool's comment
 	Comment *string `json:"comment,omitempty" url:"comment,omitempty"`
+	// If this is set to 1, VMs and datastores will be removed from the pool instead of added.
+	Delete *types.CustomBool `json:"delete,omitempty" url:"delete,omitempty,int"`
+	// The list of virtual machines to add or delete.
+	VMs *[]string `json:"vms,omitempty" url:"vms,omitempty,comma"`
+	// The list of datastores to add or delete.
+	Storage *[]string `json:"storage,omitempty" url:"storage,omitempty,comma"`
 }

--- a/proxmox/pools/pool_types.go
+++ b/proxmox/pools/pool_types.go
@@ -52,7 +52,7 @@ type PoolUpdateRequestBody struct {
 	// If this is set to 1, VMs and datastores will be removed from the pool instead of added.
 	Delete *types.CustomBool `json:"delete,omitempty" url:"delete,omitempty,int"`
 	// The list of virtual machines to add or delete.
-	VMs *[]string `json:"vms,omitempty" url:"vms,omitempty,comma"`
+	VMs *types.CustomCommaSeparatedList `json:"vms,omitempty" url:"vms,omitempty,comma"`
 	// The list of datastores to add or delete.
-	Storage *[]string `json:"storage,omitempty" url:"storage,omitempty,comma"`
+	Storage *types.CustomCommaSeparatedList `json:"storage,omitempty" url:"storage,omitempty,comma"`
 }

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -17,6 +17,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -27,6 +28,7 @@ import (
 	"github.com/bpg/terraform-provider-proxmox/internal/types"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/cluster"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/pools"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/validator"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/structure"
@@ -1212,7 +1214,6 @@ func VM() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The ID of the pool to assign the virtual machine to",
 				Optional:    true,
-				ForceNew:    true,
 				Default:     dvResourceVirtualEnvironmentVMPoolID,
 			},
 			mkResourceVirtualEnvironmentVMSerialDevice: {
@@ -4793,6 +4794,49 @@ func vmReadPrimitiveValues(
 	return diags
 }
 
+// vmUpdatePool moves the VM to the pool it is supposed to be in if the pool ID changed.
+func vmUpdatePool(
+	ctx context.Context,
+	d *schema.ResourceData,
+	api *pools.Client,
+	vmID int,
+) error {
+	oldPoolValue, newPoolValue := d.GetChange(mkResourceVirtualEnvironmentVMPoolID)
+	if cmp.Equal(newPoolValue, oldPoolValue) {
+		return nil
+	}
+
+	oldPool := oldPoolValue.(string)
+	newPool := newPoolValue.(string)
+	vmList := []string{strconv.Itoa(vmID)}
+
+	tflog.Debug(ctx, fmt.Sprintf("Moving VM %d from pool '%s' to pool '%s'", vmID, oldPool, newPool))
+
+	if oldPool != "" {
+		trueValue := types.CustomBool(true)
+		poolUpdate := &pools.PoolUpdateRequestBody{
+			VMs:    &vmList,
+			Delete: &trueValue,
+		}
+
+		err := api.UpdatePool(ctx, oldPool, poolUpdate)
+		if err != nil {
+			return fmt.Errorf("while removing VM %d from pool %s: %w", vmID, oldPool, err)
+		}
+	}
+
+	if newPool != "" {
+		poolUpdate := &pools.PoolUpdateRequestBody{VMs: &vmList}
+
+		err := api.UpdatePool(ctx, newPool, poolUpdate)
+		if err != nil {
+			return fmt.Errorf("while adding VM %d to pool %s: %w", vmID, newPool, err)
+		}
+	}
+
+	return nil
+}
+
 func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	config := m.(proxmoxtf.ProviderConfiguration)
 
@@ -4806,6 +4850,10 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 
 	vmID, e := strconv.Atoi(d.Id())
 	if e != nil {
+		return diag.FromErr(e)
+	}
+
+	if vmUpdatePool(ctx, d, api.Pool(), vmID) != nil {
 		return diag.FromErr(e)
 	}
 

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -4797,7 +4797,7 @@ func vmUpdatePool(
 
 	oldPool := oldPoolValue.(string)
 	newPool := newPoolValue.(string)
-	vmList := []string{strconv.Itoa(vmID)}
+	vmList := (types.CustomCommaSeparatedList)([]string{strconv.Itoa(vmID)})
 
 	tflog.Debug(ctx, fmt.Sprintf("Moving VM %d from pool '%s' to pool '%s'", vmID, oldPool, newPool))
 
@@ -4842,7 +4842,8 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 		return diag.FromErr(e)
 	}
 
-	if vmUpdatePool(ctx, d, api.Pool(), vmID) != nil {
+	e = vmUpdatePool(ctx, d, api.Pool(), vmID)
+	if e != nil {
 		return diag.FromErr(e)
 	}
 


### PR DESCRIPTION
This commit removed the `ForceNew` flag from the VM resource's `pool_id` argument and implements pool update:

  * if the VM was part of a pool, it is removed from it,
  * if the new `pool_id` value is non-empty, the VM is added to that new pool.

It triggers the same linter problem as my other pull request, the same [solution](https://github.com/bpg/terraform-provider-proxmox/pull/501#issuecomment-1682782500) would apply.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->
