### PR TITLE
fix(vm): fix PCI dev resource mapping changed

### DIFF
--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -3945,7 +3945,7 @@ func vmReadCustom(
 
 	pciDevices := getPCIInfo(vmConfig, d)
 	for pi, pp := range pciDevices {
-		if (pp == nil) || (pp.DeviceIDs == nil) {
+		if (pp == nil) || (pp.DeviceIDs == nil && pp.Mapping == nil) {
 			continue
 		}
 


### PR DESCRIPTION
Fix PCI device showing always changes when using resource mapping. 

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ x] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [ ] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
