### PR TITLE
fix(file): forced replacement of file resources that missing `timeout_upload` attribute

### DIFF
--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -196,13 +196,13 @@ func File() *schema.Resource {
 				Type:        schema.TypeInt,
 				Description: "Timeout for uploading ISO/VSTMPL files in seconds",
 				Optional:    true,
-				ForceNew:    true,
 				Default:     dvResourceVirtualEnvironmentFileTimeoutUpload,
 			},
 		},
 		CreateContext: fileCreate,
 		ReadContext:   fileRead,
 		DeleteContext: fileDelete,
+		UpdateContext: fileUpdate,
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
 				node, datastore, volumeID, err := fileParseImportID(d.Id())
@@ -801,5 +801,11 @@ func fileDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 
 	d.SetId("")
 
+	return nil
+}
+
+func fileUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// a pass-through update function -- no actual resource update is needed / allowed
+	// only the TF state is updated, for example, a timeout_upload attribute value
 	return nil
 }


### PR DESCRIPTION
### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #523

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
