### PR TITLE
fix(node): creating linux_bridge with 'vlan_aware=false' or 'autostart=false'

### DIFF
--- a/internal/network/resource_linux_bridge.go
+++ b/internal/network/resource_linux_bridge.go
@@ -86,7 +86,9 @@ func (m *linuxBridgeResourceModel) exportToNetworkInterfaceCreateUpdateBody() *n
 		body.BridgePorts = &bridgePorts
 	}
 
-	body.BridgeVLANAware = pvetypes.CustomBool(m.VLANAware.ValueBool()).Pointer()
+	if m.VLANAware.ValueBool() {
+		body.BridgeVLANAware = pvetypes.CustomBool(true).Pointer()
+	}
 
 	return body
 }
@@ -99,7 +101,11 @@ func (m *linuxBridgeResourceModel) importFromNetworkInterfaceList(
 	m.Gateway = pvetypes.NewIPAddrPointerValue(iface.Gateway)
 	m.Address6 = pvetypes.NewIPCIDRPointerValue(iface.CIDR6)
 	m.Gateway6 = pvetypes.NewIPAddrPointerValue(iface.Gateway6)
+
 	m.Autostart = types.BoolPointerValue(iface.Autostart.PointerBool())
+	if m.Autostart.IsNull() {
+		m.Autostart = types.BoolValue(false)
+	}
 
 	if iface.MTU != nil {
 		if v, err := strconv.Atoi(*iface.MTU); err == nil {

--- a/internal/test/network/resource_linux_bridge_test.go
+++ b/internal/test/network/resource_linux_bridge_test.go
@@ -33,6 +33,8 @@ resource "proxmox_virtual_environment_network_linux_bridge" "test" {
 	name = "vmbr99"
 	address = "3.3.3.3/24"
 	comment = "created by terraform"
+    vlan_aware = false
+    autostart = false
 	mtu = 1499
 }
 `,
@@ -40,7 +42,8 @@ resource "proxmox_virtual_environment_network_linux_bridge" "test" {
 					resource.TestCheckResourceAttr(resourceName, "name", "vmbr99"),
 					resource.TestCheckResourceAttr(resourceName, "address", "3.3.3.3/24"),
 					resource.TestCheckResourceAttr(resourceName, "comment", "created by terraform"),
-					resource.TestCheckResourceAttr(resourceName, "vlan_aware", "true"),
+					resource.TestCheckResourceAttr(resourceName, "vlan_aware", "false"),
+					resource.TestCheckResourceAttr(resourceName, "autostart", "false"),
 					resource.TestCheckResourceAttr(resourceName, "mtu", "1499"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
@@ -60,7 +63,8 @@ resource "proxmox_virtual_environment_network_linux_bridge" "test" {
 	address = "1.1.1.1/24"
 	address6 = "FE80:0000:0000:0000:0202:B3FF:FE1E:8329/64"
 	comment = "updated by terraform"
-	vlan_aware = false
+	vlan_aware = true
+	autostart = true
 	mtu = null
 }
 `,
@@ -69,8 +73,30 @@ resource "proxmox_virtual_environment_network_linux_bridge" "test" {
 					resource.TestCheckResourceAttr(resourceName, "address", "1.1.1.1/24"),
 					resource.TestCheckResourceAttr(resourceName, "address6", "FE80:0000:0000:0000:0202:B3FF:FE1E:8329/64"),
 					resource.TestCheckResourceAttr(resourceName, "comment", "updated by terraform"),
-					resource.TestCheckResourceAttr(resourceName, "vlan_aware", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vlan_aware", "true"),
+					resource.TestCheckResourceAttr(resourceName, "autostart", "true"),
 					resource.TestCheckNoResourceAttr(resourceName, "mtu"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+			// Create with other default overrides
+			{
+				Config: test.ProviderConfig + `
+resource "proxmox_virtual_environment_network_linux_bridge" "test" {
+	node_name = "pve"
+	name = "vmbr98"
+	address = "3.3.3.4/24"
+	comment = "created by terraform 2"
+    vlan_aware = true
+    autostart = true
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "vmbr98"),
+					resource.TestCheckResourceAttr(resourceName, "address", "3.3.3.4/24"),
+					resource.TestCheckResourceAttr(resourceName, "comment", "created by terraform 2"),
+					resource.TestCheckResourceAttr(resourceName, "vlan_aware", "true"),
+					resource.TestCheckResourceAttr(resourceName, "autostart", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},


### PR DESCRIPTION
### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #519

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
