### PR TITLE
fix(vm): give CloudInit's `interface` the correct default value

### DIFF
--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -79,7 +79,7 @@ const (
 	dvResourceVirtualEnvironmentVMEFIDiskType                       = "2m"
 	dvResourceVirtualEnvironmentVMEFIDiskPreEnrolledKeys            = false
 	dvResourceVirtualEnvironmentVMInitializationDatastoreID         = "local-lvm"
-	dvResourceVirtualEnvironmentVMInitializationInterface           = ""
+	dvResourceVirtualEnvironmentVMInitializationInterface           = "ide2"
 	dvResourceVirtualEnvironmentVMInitializationDNSDomain           = ""
 	dvResourceVirtualEnvironmentVMInitializationDNSServer           = ""
 	dvResourceVirtualEnvironmentVMInitializationIPConfigIPv4Address = ""


### PR DESCRIPTION
CloudInit's `interface` should be one of [ide0 ide1 ide2 ide3], the default "" is given, however. I made the change based on the assumption of the original commit's author.

<img width="1073" alt="image" src="https://github.com/bpg/terraform-provider-proxmox/assets/6451933/447990f5-91b3-4220-b3af-09226b278c3e">

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
