### PR TITLE
feat(file): FORMAT CHANGE: update import id, so it matches the resource's format: `<node_name>/<datastore_id>:<content_type>/<file>`

### DIFF
--- a/docs/resources/virtual_environment_file.md
+++ b/docs/resources/virtual_environment_file.md
@@ -98,10 +98,13 @@ created as another temporary file).
 
 ## Import
 
-Instances can be imported using the `node_name`, `volume_id`, where `volume_id`
-consists of the `datastore_id`, `content_type`, and `file_name`, separated as following: `<datastore_id>:<content_type>/<file_name>`, 
-for example: `local:snippets/example.cloud-config.yaml`
+Instances can be imported using the `node_name`, `datastore_id`, `content_type`
+and the `file_name` in the following format:
+```
+<node_name>:<datastore_id>/<content_type>/<file_name>
+```
 
+Example:
 ```bash
 $ terraform import proxmox_virtual_environment_file.cloud_config pve/local:snippets/example.cloud-config.yaml
 ```

--- a/docs/resources/virtual_environment_file.md
+++ b/docs/resources/virtual_environment_file.md
@@ -98,9 +98,10 @@ created as another temporary file).
 
 ## Import
 
-Instances can be imported using the `node_name`, `datastore_id`, `content_type`
-and the `file_name`, e.g.,
+Instances can be imported using the `node_name`, `volume_id`, where `volume_id`
+consists of the `datastore_id`, `content_type`, and `file_name`, separated as following: `<datastore_id>:<content_type>/<file_name>`, 
+for example: `local:snippets/example.cloud-config.yaml`
 
 ```bash
-$ terraform import proxmox_virtual_environment_file.cloud_config pve/local/snippets/example.cloud-config.yaml
+$ terraform import proxmox_virtual_environment_file.cloud_config pve/local:snippets/example.cloud-config.yaml
 ```


### PR DESCRIPTION
`proxmox_virtual_environment_file` uses the following format as a resource ID (aka `volumeID`): `datastore_id:content_type/file_name`.

However, the file `import` operation uses import ID of a slightly different format: `node_name/datastore_id/content_type/file_name` and sets the imported file resource ID as `datastore_id/content_type/file_name` at the end.

This PR updates import ID to use compatible `node_name/datastore_id:content_type/file_name` notation.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [x] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
