### PR TITLE
fix(vm): explicitly allow `""` as a value for CloudInit interfaces

### DIFF
--- a/proxmoxtf/resource/validator/vm.go
+++ b/proxmoxtf/resource/validator/vm.go
@@ -253,6 +253,18 @@ func IDEInterface() schema.SchemaValidateDiagFunc {
 	}, false))
 }
 
+// CloudInitInterface is a schema validation function that accepts either an IDE interface identifier or an
+// empty string, which is used as the default and means "detect which interface should be used automatically".
+func CloudInitInterface() schema.SchemaValidateDiagFunc {
+	return validation.ToDiagFunc(validation.StringInSlice([]string{
+		"",
+		"ide0",
+		"ide1",
+		"ide2",
+		"ide3",
+	}, false))
+}
+
 // CloudInitType is a schema validation function for cloud-init types.
 func CloudInitType() schema.SchemaValidateDiagFunc {
 	return validation.ToDiagFunc(validation.StringInSlice([]string{

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -795,7 +795,7 @@ func VM() *schema.Resource {
 							Description:      "The IDE interface on which the CloudInit drive will be added",
 							Optional:         true,
 							Default:          dvResourceVirtualEnvironmentVMInitializationInterface,
-							ValidateDiagFunc: validator.IDEInterface(),
+							ValidateDiagFunc: validator.CloudInitInterface(),
 							DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 								return newValue == ""
 							},


### PR DESCRIPTION
The CloudInit interface can be left empty in order to allow autodetection of the drive being used. However, it would seem that this value was causing problems (see #539).

This commit adds an additional validator for CloudInit interfaces which allows the `""` value.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/examples` for any new or updated resources / data sources.
- [ ] I have ran `make examples` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #0539

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
