### PR TITLE
fix(lxc,vm): error unmarshalling string `cpulimit`

### DIFF
--- a/proxmox/nodes/containers/containers_types.go
+++ b/proxmox/nodes/containers/containers_types.go
@@ -157,7 +157,7 @@ type GetResponseData struct {
 	ConsoleMode       *string                 `json:"cmode,omitempty"`
 	CPUArchitecture   *string                 `json:"arch,omitempty"`
 	CPUCores          *int                    `json:"cores,omitempty"`
-	CPULimit          *int                    `json:"cpulimit,omitempty"`
+	CPULimit          *types2.CustomInt       `json:"cpulimit,omitempty"`
 	CPUUnits          *int                    `json:"cpuunits,omitempty"`
 	DedicatedMemory   *int                    `json:"memory,omitempty"`
 	Description       *string                 `json:"description,omitempty"`

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -379,7 +379,7 @@ type GetResponseData struct {
 	CPUArchitecture      *string                          `json:"arch,omitempty"`
 	CPUCores             *int                             `json:"cores,omitempty"`
 	CPUEmulation         *CustomCPUEmulation              `json:"cpu,omitempty"`
-	CPULimit             *int                             `json:"cpulimit,omitempty"`
+	CPULimit             *types2.CustomInt                `json:"cpulimit,omitempty"`
 	CPUSockets           *int                             `json:"sockets,omitempty"`
 	CPUUnits             *int                             `json:"cpuunits,omitempty"`
 	DedicatedMemory      *int                             `json:"memory,omitempty"`


### PR DESCRIPTION
Note: configuring `cpulimit` via container resource attributes is not supported at the moment.

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #552

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
