### PR TITLE
chore(code): remove redundant `types2` import aliases

### DIFF
--- a/proxmox/cluster/ha/resources/resources.go
+++ b/proxmox/cluster/ha/resources/resources.go
@@ -14,16 +14,16 @@ import (
 	"sort"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
-	types2 "github.com/bpg/terraform-provider-proxmox/proxmox/types"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 )
 
 type haResourceTypeListQuery struct {
-	ResType *types2.HAResourceType `url:"type"`
+	ResType *types.HAResourceType `url:"type"`
 }
 
 // List retrieves the list of HA resources. If the `resType` argument is `nil`, all resources will be returned;
 // otherwise resources will be filtered by the specified type (either `ct` or `vm`).
-func (c *Client) List(ctx context.Context, resType *types2.HAResourceType) ([]*HAResourceListResponseData, error) {
+func (c *Client) List(ctx context.Context, resType *types.HAResourceType) ([]*HAResourceListResponseData, error) {
 	options := &haResourceTypeListQuery{resType}
 	resBody := &HAResourceListResponseBody{}
 
@@ -46,7 +46,7 @@ func (c *Client) List(ctx context.Context, resType *types2.HAResourceType) ([]*H
 }
 
 // Get retrieves the configuration of a single HA resource.
-func (c *Client) Get(ctx context.Context, id types2.HAResourceID) (*HAResourceGetResponseData, error) {
+func (c *Client) Get(ctx context.Context, id types.HAResourceID) (*HAResourceGetResponseData, error) {
 	resBody := &HAResourceGetResponseBody{}
 
 	err := c.DoRequest(ctx, http.MethodGet, c.ExpandPath(url.PathEscape(id.String())), nil, resBody)
@@ -72,7 +72,7 @@ func (c *Client) Create(ctx context.Context, data *HAResourceCreateRequestBody) 
 }
 
 // Update updates an existing HA resource.
-func (c *Client) Update(ctx context.Context, id types2.HAResourceID, data *HAResourceUpdateRequestBody) error {
+func (c *Client) Update(ctx context.Context, id types.HAResourceID, data *HAResourceUpdateRequestBody) error {
 	err := c.DoRequest(ctx, http.MethodPut, c.ExpandPath(url.PathEscape(id.String())), data, nil)
 	if err != nil {
 		return fmt.Errorf("error updating HA resource %v: %w", id, err)
@@ -82,7 +82,7 @@ func (c *Client) Update(ctx context.Context, id types2.HAResourceID, data *HARes
 }
 
 // Delete deletes a HA resource.
-func (c *Client) Delete(ctx context.Context, id types2.HAResourceID) error {
+func (c *Client) Delete(ctx context.Context, id types.HAResourceID) error {
 	err := c.DoRequest(ctx, http.MethodDelete, c.ExpandPath(url.PathEscape(id.String())), nil, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting HA resource %v: %w", id, err)

--- a/proxmox/cluster/ha/resources/resources_types.go
+++ b/proxmox/cluster/ha/resources/resources_types.go
@@ -7,7 +7,7 @@
 package resources
 
 import (
-	types2 "github.com/bpg/terraform-provider-proxmox/proxmox/types"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 )
 
 // HAResourceListResponseBody contains the body from a HA resource list response.
@@ -17,7 +17,7 @@ type HAResourceListResponseBody struct {
 
 // HAResourceListResponseData contains the data from a HA resource list response.
 type HAResourceListResponseData struct {
-	ID types2.HAResourceID `json:"sid"`
+	ID types.HAResourceID `json:"sid"`
 }
 
 // HAResourceGetResponseBody contains the body from a HA resource get response.
@@ -36,7 +36,7 @@ type HAResourceDataBase struct {
 	// Maximal number of service restart attempts.
 	MaxRestart *int64 `json:"max_restart" url:"max_restart,omitempty"`
 	// Requested resource state.
-	State types2.HAResourceState `json:"state" url:"state"`
+	State types.HAResourceState `json:"state" url:"state"`
 }
 
 // HAResourceGetResponseData contains data received from the HA resource API when requesting information about a single
@@ -44,9 +44,9 @@ type HAResourceDataBase struct {
 type HAResourceGetResponseData struct {
 	HAResourceDataBase
 	// Identifier of this resource
-	ID types2.HAResourceID `json:"sid"`
+	ID types.HAResourceID `json:"sid"`
 	// Type of this resource
-	Type types2.HAResourceType `json:"type"`
+	Type types.HAResourceType `json:"type"`
 	// SHA-1 digest of the resources' configuration.
 	Digest *string `json:"digest,omitempty"`
 }
@@ -55,9 +55,9 @@ type HAResourceGetResponseData struct {
 type HAResourceCreateRequestBody struct {
 	HAResourceDataBase
 	// Identifier of this resource
-	ID types2.HAResourceID `url:"sid"`
+	ID types.HAResourceID `url:"sid"`
 	// Type of this resource
-	Type *types2.HAResourceType `url:"type,omitempty"`
+	Type *types.HAResourceType `url:"type,omitempty"`
 	// SHA-1 digest of the resources' configuration.
 	Digest *string `url:"comment,omitempty"`
 }

--- a/proxmox/nodes/containers/containers_types.go
+++ b/proxmox/nodes/containers/containers_types.go
@@ -13,26 +13,26 @@ import (
 	"strconv"
 	"strings"
 
-	types2 "github.com/bpg/terraform-provider-proxmox/proxmox/types"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 )
 
 // CloneRequestBody contains the data for an container clone request.
 type CloneRequestBody struct {
-	BandwidthLimit *int               `json:"bwlimit,omitempty"     url:"bwlimit,omitempty"`
-	Description    *string            `json:"description,omitempty" url:"description,omitempty"`
-	FullCopy       *types2.CustomBool `json:"full,omitempty"        url:"full,omitempty,int"`
-	Hostname       *string            `json:"hostname,omitempty"    url:"hostname,omitempty"`
-	PoolID         *string            `json:"pool,omitempty"        url:"pool,omitempty"`
-	SnapshotName   *string            `json:"snapname,omitempty"    url:"snapname,omitempty"`
-	TargetNodeName *string            `json:"target,omitempty"      url:"target,omitempty"`
-	TargetStorage  *string            `json:"storage,omitempty"     url:"storage,omitempty"`
-	VMIDNew        int                `json:"newid"                 url:"newid"`
+	BandwidthLimit *int              `json:"bwlimit,omitempty"     url:"bwlimit,omitempty"`
+	Description    *string           `json:"description,omitempty" url:"description,omitempty"`
+	FullCopy       *types.CustomBool `json:"full,omitempty"        url:"full,omitempty,int"`
+	Hostname       *string           `json:"hostname,omitempty"    url:"hostname,omitempty"`
+	PoolID         *string           `json:"pool,omitempty"        url:"pool,omitempty"`
+	SnapshotName   *string           `json:"snapname,omitempty"    url:"snapname,omitempty"`
+	TargetNodeName *string           `json:"target,omitempty"      url:"target,omitempty"`
+	TargetStorage  *string           `json:"storage,omitempty"     url:"storage,omitempty"`
+	VMIDNew        int               `json:"newid"                 url:"newid"`
 }
 
 // CreateRequestBody contains the data for a user create request.
 type CreateRequestBody struct {
 	BandwidthLimit       *float64                    `json:"bwlimit,omitempty"              url:"bwlimit,omitempty"`
-	ConsoleEnabled       *types2.CustomBool          `json:"console,omitempty"              url:"console,omitempty,int"`
+	ConsoleEnabled       *types.CustomBool           `json:"console,omitempty"              url:"console,omitempty,int"`
 	ConsoleMode          *string                     `json:"cmode,omitempty"                url:"cmode,omitempty"`
 	CPUArchitecture      *string                     `json:"arch,omitempty"                 url:"arch,omitempty"`
 	CPUCores             *int                        `json:"cores,omitempty"                url:"cores,omitempty"`
@@ -45,10 +45,10 @@ type CreateRequestBody struct {
 	DNSDomain            *string                     `json:"searchdomain,omitempty"         url:"searchdomain,omitempty"`
 	DNSServer            *string                     `json:"nameserver,omitempty"           url:"nameserver,omitempty"`
 	Features             *CustomFeatures             `json:"features,omitempty"             url:"features,omitempty"`
-	Force                *types2.CustomBool          `json:"force,omitempty"                url:"force,omitempty,int"`
+	Force                *types.CustomBool           `json:"force,omitempty"                url:"force,omitempty,int"`
 	HookScript           *string                     `json:"hookscript,omitempty"           url:"hookscript,omitempty"`
 	Hostname             *string                     `json:"hostname,omitempty"             url:"hostname,omitempty"`
-	IgnoreUnpackErrors   *types2.CustomBool          `json:"ignore-unpack-errors,omitempty" url:"force,omitempty,int"`
+	IgnoreUnpackErrors   *types.CustomBool           `json:"ignore-unpack-errors,omitempty" url:"force,omitempty,int"`
 	Lock                 *string                     `json:"lock,omitempty"                 url:"lock,omitempty,int"`
 	MountPoints          CustomMountPointArray       `json:"mp,omitempty"                   url:"mp,omitempty,numbered"`
 	NetworkInterfaces    CustomNetworkInterfaceArray `json:"net,omitempty"                  url:"net,omitempty,numbered"`
@@ -56,43 +56,43 @@ type CreateRequestBody struct {
 	OSType               *string                     `json:"ostype,omitempty"               url:"ostype,omitempty"`
 	Password             *string                     `json:"password,omitempty"             url:"password,omitempty"`
 	PoolID               *string                     `json:"pool,omitempty"                 url:"pool,omitempty"`
-	Protection           *types2.CustomBool          `json:"protection,omitempty"           url:"protection,omitempty,int"`
-	Restore              *types2.CustomBool          `json:"restore,omitempty"              url:"restore,omitempty,int"`
+	Protection           *types.CustomBool           `json:"protection,omitempty"           url:"protection,omitempty,int"`
+	Restore              *types.CustomBool           `json:"restore,omitempty"              url:"restore,omitempty,int"`
 	RootFS               *CustomRootFS               `json:"rootfs,omitempty"               url:"rootfs,omitempty"`
 	SSHKeys              *CustomSSHKeys              `json:"ssh-public-keys,omitempty"      url:"ssh-public-keys,omitempty"`
-	Start                *types2.CustomBool          `json:"start,omitempty"                url:"start,omitempty,int"`
-	StartOnBoot          *types2.CustomBool          `json:"onboot,omitempty"               url:"onboot,omitempty,int"`
+	Start                *types.CustomBool           `json:"start,omitempty"                url:"start,omitempty,int"`
+	StartOnBoot          *types.CustomBool           `json:"onboot,omitempty"               url:"onboot,omitempty,int"`
 	StartupBehavior      *CustomStartupBehavior      `json:"startup,omitempty"              url:"startup,omitempty"`
 	Swap                 *int                        `json:"swap,omitempty"                 url:"swap,omitempty"`
 	Tags                 *string                     `json:"tags,omitempty"                 url:"tags,omitempty"`
-	Template             *types2.CustomBool          `json:"template,omitempty"             url:"template,omitempty,int"`
+	Template             *types.CustomBool           `json:"template,omitempty"             url:"template,omitempty,int"`
 	TTY                  *int                        `json:"tty,omitempty"                  url:"tty,omitempty"`
-	Unique               *types2.CustomBool          `json:"unique,omitempty"               url:"unique,omitempty,int"`
-	Unprivileged         *types2.CustomBool          `json:"unprivileged,omitempty"         url:"unprivileged,omitempty,int"`
+	Unique               *types.CustomBool           `json:"unique,omitempty"               url:"unique,omitempty,int"`
+	Unprivileged         *types.CustomBool           `json:"unprivileged,omitempty"         url:"unprivileged,omitempty,int"`
 	VMID                 *int                        `json:"vmid,omitempty"                 url:"vmid,omitempty"`
 }
 
 // CustomFeatures contains the values for the "features" property.
 type CustomFeatures struct {
-	FUSE       *types2.CustomBool `json:"fuse,omitempty"    url:"fuse,omitempty,int"`
-	KeyControl *types2.CustomBool `json:"keyctl,omitempty"  url:"keyctl,omitempty,int"`
-	MountTypes *[]string          `json:"mount,omitempty"   url:"mount,omitempty"`
-	Nesting    *types2.CustomBool `json:"nesting,omitempty" url:"nesting,omitempty,int"`
+	FUSE       *types.CustomBool `json:"fuse,omitempty"    url:"fuse,omitempty,int"`
+	KeyControl *types.CustomBool `json:"keyctl,omitempty"  url:"keyctl,omitempty,int"`
+	MountTypes *[]string         `json:"mount,omitempty"   url:"mount,omitempty"`
+	Nesting    *types.CustomBool `json:"nesting,omitempty" url:"nesting,omitempty,int"`
 }
 
 // CustomMountPoint contains the values for the "mp[n]" properties.
 type CustomMountPoint struct {
-	ACL          *types2.CustomBool `json:"acl,omitempty"          url:"acl,omitempty,int"`
-	Backup       *types2.CustomBool `json:"backup,omitempty"       url:"backup,omitempty,int"`
-	DiskSize     *string            `json:"size,omitempty"         url:"size,omitempty"` // read-only
-	Enabled      bool               `json:"-"                      url:"-"`
-	MountOptions *[]string          `json:"mountoptions,omitempty" url:"mountoptions,omitempty"`
-	MountPoint   string             `json:"mp"                     url:"mp"`
-	Quota        *types2.CustomBool `json:"quota,omitempty"        url:"quota,omitempty,int"`
-	ReadOnly     *types2.CustomBool `json:"ro,omitempty"           url:"ro,omitempty,int"`
-	Replicate    *types2.CustomBool `json:"replicate,omitempty"    url:"replicate,omitempty,int"`
-	Shared       *types2.CustomBool `json:"shared,omitempty"       url:"shared,omitempty,int"`
-	Volume       string             `json:"volume"                 url:"volume"`
+	ACL          *types.CustomBool `json:"acl,omitempty"          url:"acl,omitempty,int"`
+	Backup       *types.CustomBool `json:"backup,omitempty"       url:"backup,omitempty,int"`
+	DiskSize     *string           `json:"size,omitempty"         url:"size,omitempty"` // read-only
+	Enabled      bool              `json:"-"                      url:"-"`
+	MountOptions *[]string         `json:"mountoptions,omitempty" url:"mountoptions,omitempty"`
+	MountPoint   string            `json:"mp"                     url:"mp"`
+	Quota        *types.CustomBool `json:"quota,omitempty"        url:"quota,omitempty,int"`
+	ReadOnly     *types.CustomBool `json:"ro,omitempty"           url:"ro,omitempty,int"`
+	Replicate    *types.CustomBool `json:"replicate,omitempty"    url:"replicate,omitempty,int"`
+	Shared       *types.CustomBool `json:"shared,omitempty"       url:"shared,omitempty,int"`
+	Volume       string            `json:"volume"                 url:"volume"`
 }
 
 // CustomMountPointArray is an array of CustomMountPoint.
@@ -100,20 +100,20 @@ type CustomMountPointArray []CustomMountPoint
 
 // CustomNetworkInterface contains the values for the "net[n]" properties.
 type CustomNetworkInterface struct {
-	Bridge      *string            `json:"bridge,omitempty"   url:"bridge,omitempty"`
-	Enabled     bool               `json:"-"                  url:"-"`
-	Firewall    *types2.CustomBool `json:"firewall,omitempty" url:"firewall,omitempty,int"`
-	IPv4Address *string            `json:"ip,omitempty"       url:"ip,omitempty"`
-	IPv4Gateway *string            `json:"gw,omitempty"       url:"gw,omitempty"`
-	IPv6Address *string            `json:"ip6,omitempty"      url:"ip6,omitempty"`
-	IPv6Gateway *string            `json:"gw6,omitempty"      url:"gw6,omitempty"`
-	MACAddress  *string            `json:"hwaddr,omitempty"   url:"hwaddr,omitempty"`
-	MTU         *int               `json:"mtu,omitempty"      url:"mtu,omitempty"`
-	Name        string             `json:"name"               url:"name"`
-	RateLimit   *float64           `json:"rate,omitempty"     url:"rate,omitempty"`
-	Tag         *int               `json:"tag,omitempty"      url:"tag,omitempty"`
-	Trunks      *[]int             `json:"trunks,omitempty"   url:"trunks,omitempty"`
-	Type        *string            `json:"type,omitempty"     url:"type,omitempty"`
+	Bridge      *string           `json:"bridge,omitempty"   url:"bridge,omitempty"`
+	Enabled     bool              `json:"-"                  url:"-"`
+	Firewall    *types.CustomBool `json:"firewall,omitempty" url:"firewall,omitempty,int"`
+	IPv4Address *string           `json:"ip,omitempty"       url:"ip,omitempty"`
+	IPv4Gateway *string           `json:"gw,omitempty"       url:"gw,omitempty"`
+	IPv6Address *string           `json:"ip6,omitempty"      url:"ip6,omitempty"`
+	IPv6Gateway *string           `json:"gw6,omitempty"      url:"gw6,omitempty"`
+	MACAddress  *string           `json:"hwaddr,omitempty"   url:"hwaddr,omitempty"`
+	MTU         *int              `json:"mtu,omitempty"      url:"mtu,omitempty"`
+	Name        string            `json:"name"               url:"name"`
+	RateLimit   *float64          `json:"rate,omitempty"     url:"rate,omitempty"`
+	Tag         *int              `json:"tag,omitempty"      url:"tag,omitempty"`
+	Trunks      *[]int            `json:"trunks,omitempty"   url:"trunks,omitempty"`
+	Type        *string           `json:"type,omitempty"     url:"type,omitempty"`
 }
 
 // CustomNetworkInterfaceArray is an array of CustomNetworkInterface.
@@ -121,14 +121,14 @@ type CustomNetworkInterfaceArray []CustomNetworkInterface
 
 // CustomRootFS contains the values for the "rootfs" property.
 type CustomRootFS struct {
-	ACL          *types2.CustomBool `json:"acl,omitempty"          url:"acl,omitempty,int"`
-	Size         *types2.DiskSize   `json:"size,omitempty"         url:"size,omitempty"`
-	MountOptions *[]string          `json:"mountoptions,omitempty" url:"mountoptions,omitempty"`
-	Quota        *types2.CustomBool `json:"quota,omitempty"        url:"quota,omitempty,int"`
-	ReadOnly     *types2.CustomBool `json:"ro,omitempty"           url:"ro,omitempty,int"`
-	Replicate    *types2.CustomBool `json:"replicate,omitempty"    url:"replicate,omitempty,int"`
-	Shared       *types2.CustomBool `json:"shared,omitempty"       url:"shared,omitempty,int"`
-	Volume       string             `json:"volume"                 url:"volume"`
+	ACL          *types.CustomBool `json:"acl,omitempty"          url:"acl,omitempty,int"`
+	Size         *types.DiskSize   `json:"size,omitempty"         url:"size,omitempty"`
+	MountOptions *[]string         `json:"mountoptions,omitempty" url:"mountoptions,omitempty"`
+	Quota        *types.CustomBool `json:"quota,omitempty"        url:"quota,omitempty,int"`
+	ReadOnly     *types.CustomBool `json:"ro,omitempty"           url:"ro,omitempty,int"`
+	Replicate    *types.CustomBool `json:"replicate,omitempty"    url:"replicate,omitempty,int"`
+	Shared       *types.CustomBool `json:"shared,omitempty"       url:"shared,omitempty,int"`
+	Volume       string            `json:"volume"                 url:"volume"`
 }
 
 // CustomSSHKeys contains the values for the "ssh-public-keys" property.
@@ -153,11 +153,11 @@ type GetResponseBody struct {
 
 // GetResponseData contains the data from a user get response.
 type GetResponseData struct {
-	ConsoleEnabled    *types2.CustomBool      `json:"console,omitempty"`
+	ConsoleEnabled    *types.CustomBool       `json:"console,omitempty"`
 	ConsoleMode       *string                 `json:"cmode,omitempty"`
 	CPUArchitecture   *string                 `json:"arch,omitempty"`
 	CPUCores          *int                    `json:"cores,omitempty"`
-	CPULimit          *types2.CustomInt       `json:"cpulimit,omitempty"`
+	CPULimit          *types.CustomInt        `json:"cpulimit,omitempty"`
 	CPUUnits          *int                    `json:"cpuunits,omitempty"`
 	DedicatedMemory   *int                    `json:"memory,omitempty"`
 	Description       *string                 `json:"description,omitempty"`
@@ -167,7 +167,7 @@ type GetResponseData struct {
 	Features          *CustomFeatures         `json:"features,omitempty"`
 	HookScript        *string                 `json:"hookscript,omitempty"`
 	Hostname          *string                 `json:"hostname,omitempty"`
-	Lock              *types2.CustomBool      `json:"lock,omitempty"`
+	Lock              *types.CustomBool       `json:"lock,omitempty"`
 	LXCConfiguration  *[][2]string            `json:"lxc,omitempty"`
 	MountPoint0       *CustomMountPoint       `json:"mp0,omitempty"`
 	MountPoint1       *CustomMountPoint       `json:"mp1,omitempty"`
@@ -186,15 +186,15 @@ type GetResponseData struct {
 	NetworkInterface6 *CustomNetworkInterface `json:"net6,omitempty"`
 	NetworkInterface7 *CustomNetworkInterface `json:"net7,omitempty"`
 	OSType            *string                 `json:"ostype,omitempty"`
-	Protection        *types2.CustomBool      `json:"protection,omitempty"`
+	Protection        *types.CustomBool       `json:"protection,omitempty"`
 	RootFS            *CustomRootFS           `json:"rootfs,omitempty"`
-	StartOnBoot       *types2.CustomBool      `json:"onboot,omitempty"`
+	StartOnBoot       *types.CustomBool       `json:"onboot,omitempty"`
 	StartupBehavior   *CustomStartupBehavior  `json:"startup,omitempty"`
 	Swap              *int                    `json:"swap,omitempty"`
 	Tags              *string                 `json:"tags,omitempty"`
-	Template          *types2.CustomBool      `json:"template,omitempty"`
+	Template          *types.CustomBool       `json:"template,omitempty"`
 	TTY               *int                    `json:"tty,omitempty"`
-	Unprivileged      *types2.CustomBool      `json:"unprivileged,omitempty"`
+	Unprivileged      *types.CustomBool       `json:"unprivileged,omitempty"`
 }
 
 // GetStatusResponseBody contains the body from a container get status response.
@@ -228,8 +228,8 @@ type RebootRequestBody struct {
 
 // ShutdownRequestBody contains the body for a container shutdown request.
 type ShutdownRequestBody struct {
-	ForceStop *types2.CustomBool `json:"forceStop,omitempty" url:"forceStop,omitempty,int"`
-	Timeout   *int               `json:"timeout,omitempty"   url:"timeout,omitempty"`
+	ForceStop *types.CustomBool `json:"forceStop,omitempty" url:"forceStop,omitempty,int"`
+	Timeout   *int              `json:"timeout,omitempty"   url:"timeout,omitempty"`
 }
 
 // UpdateRequestBody contains the data for an user update request.
@@ -564,10 +564,10 @@ func (r *CustomFeatures) UnmarshalJSON(b []byte) error {
 		if len(v) == 2 {
 			switch v[0] {
 			case "fuse":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.FUSE = &bv
 			case "keyctl":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.KeyControl = &bv
 			case "mount":
 				if v[1] != "" {
@@ -578,7 +578,7 @@ func (r *CustomFeatures) UnmarshalJSON(b []byte) error {
 					r.MountTypes = &a
 				}
 			case "nesting":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.Nesting = &bv
 			}
 		}
@@ -606,10 +606,10 @@ func (r *CustomMountPoint) UnmarshalJSON(b []byte) error {
 		} else if len(v) == 2 {
 			switch v[0] {
 			case "acl":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.ACL = &bv
 			case "backup":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.Backup = &bv
 			case "mountoptions":
 				if v[1] != "" {
@@ -622,16 +622,16 @@ func (r *CustomMountPoint) UnmarshalJSON(b []byte) error {
 			case "mp":
 				r.MountPoint = v[1]
 			case "quota":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.Quota = &bv
 			case "ro":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.ReadOnly = &bv
 			case "replicate":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.Replicate = &bv
 			case "shared":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.Shared = &bv
 			case "size":
 				r.DiskSize = &v[1]
@@ -664,7 +664,7 @@ func (r *CustomNetworkInterface) UnmarshalJSON(b []byte) error {
 			case "bridge":
 				r.Bridge = &v[1]
 			case "firewall":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.Firewall = &bv
 			case "gw":
 				r.IPv4Gateway = &v[1]
@@ -745,7 +745,7 @@ func (r *CustomRootFS) UnmarshalJSON(b []byte) error {
 		} else if len(v) == 2 {
 			switch v[0] {
 			case "acl":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.ACL = &bv
 			case "mountoptions":
 				if v[1] != "" {
@@ -756,19 +756,19 @@ func (r *CustomRootFS) UnmarshalJSON(b []byte) error {
 					r.MountOptions = &a
 				}
 			case "quota":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.Quota = &bv
 			case "ro":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.ReadOnly = &bv
 			case "replicate":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.Replicate = &bv
 			case "shared":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.Shared = &bv
 			case "size":
-				r.Size = new(types2.DiskSize)
+				r.Size = new(types.DiskSize)
 				err := r.Size.UnmarshalJSON([]byte(v[1]))
 				if err != nil {
 					return fmt.Errorf("failed to unmarshal disk size: %w", err)

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -15,14 +15,14 @@ import (
 	"strconv"
 	"strings"
 
-	types2 "github.com/bpg/terraform-provider-proxmox/proxmox/types"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 )
 
 // CustomAgent handles QEMU agent parameters.
 type CustomAgent struct {
-	Enabled         *types2.CustomBool `json:"enabled,omitempty"   url:"enabled,int"`
-	TrimClonedDisks *types2.CustomBool `json:"fstrim_cloned_disks" url:"fstrim_cloned_disks,int"`
-	Type            *string            `json:"type"                url:"type"`
+	Enabled         *types.CustomBool `json:"enabled,omitempty"   url:"enabled,int"`
+	TrimClonedDisks *types.CustomBool `json:"fstrim_cloned_disks" url:"fstrim_cloned_disks,int"`
+	Type            *string           `json:"type"                url:"type"`
 }
 
 // CustomAudioDevice handles QEMU audio parameters.
@@ -73,33 +73,33 @@ type CustomCloudInitSSHKeys []string
 
 // CustomCPUEmulation handles QEMU CPU emulation parameters.
 type CustomCPUEmulation struct {
-	Flags      *[]string          `json:"flags,omitempty"        url:"flags,omitempty,semicolon"`
-	Hidden     *types2.CustomBool `json:"hidden,omitempty"       url:"hidden,omitempty,int"`
-	HVVendorID *string            `json:"hv-vendor-id,omitempty" url:"hv-vendor-id,omitempty"`
-	Type       string             `json:"cputype,omitempty"      url:"cputype,omitempty"`
+	Flags      *[]string         `json:"flags,omitempty"        url:"flags,omitempty,semicolon"`
+	Hidden     *types.CustomBool `json:"hidden,omitempty"       url:"hidden,omitempty,int"`
+	HVVendorID *string           `json:"hv-vendor-id,omitempty" url:"hv-vendor-id,omitempty"`
+	Type       string            `json:"cputype,omitempty"      url:"cputype,omitempty"`
 }
 
 // CustomEFIDisk handles QEMU EFI disk parameters.
 type CustomEFIDisk struct {
-	FileVolume      string             `json:"file"                        url:"file"`
-	Format          *string            `json:"format,omitempty"            url:"format,omitempty"`
-	Type            *string            `json:"efitype,omitempty"           url:"efitype,omitempty"`
-	PreEnrolledKeys *types2.CustomBool `json:"pre-enrolled-keys,omitempty" url:"pre-enrolled-keys,omitempty,int"`
+	FileVolume      string            `json:"file"                        url:"file"`
+	Format          *string           `json:"format,omitempty"            url:"format,omitempty"`
+	Type            *string           `json:"efitype,omitempty"           url:"efitype,omitempty"`
+	PreEnrolledKeys *types.CustomBool `json:"pre-enrolled-keys,omitempty" url:"pre-enrolled-keys,omitempty,int"`
 }
 
 // CustomNetworkDevice handles QEMU network device parameters.
 type CustomNetworkDevice struct {
-	Model      string             `json:"model"               url:"model"`
-	Bridge     *string            `json:"bridge,omitempty"    url:"bridge,omitempty"`
-	Enabled    bool               `json:"-"                   url:"-"`
-	Firewall   *types2.CustomBool `json:"firewall,omitempty"  url:"firewall,omitempty,int"`
-	LinkDown   *types2.CustomBool `json:"link_down,omitempty" url:"link_down,omitempty,int"`
-	MACAddress *string            `json:"macaddr,omitempty"   url:"macaddr,omitempty"`
-	Queues     *int               `json:"queues,omitempty"    url:"queues,omitempty"`
-	RateLimit  *float64           `json:"rate,omitempty"      url:"rate,omitempty"`
-	Tag        *int               `json:"tag,omitempty"       url:"tag,omitempty"`
-	MTU        *int               `json:"mtu,omitempty"       url:"mtu,omitempty"`
-	Trunks     []int              `json:"trunks,omitempty"    url:"trunks,omitempty"`
+	Model      string            `json:"model"               url:"model"`
+	Bridge     *string           `json:"bridge,omitempty"    url:"bridge,omitempty"`
+	Enabled    bool              `json:"-"                   url:"-"`
+	Firewall   *types.CustomBool `json:"firewall,omitempty"  url:"firewall,omitempty,int"`
+	LinkDown   *types.CustomBool `json:"link_down,omitempty" url:"link_down,omitempty,int"`
+	MACAddress *string           `json:"macaddr,omitempty"   url:"macaddr,omitempty"`
+	Queues     *int              `json:"queues,omitempty"    url:"queues,omitempty"`
+	RateLimit  *float64          `json:"rate,omitempty"      url:"rate,omitempty"`
+	Tag        *int              `json:"tag,omitempty"       url:"tag,omitempty"`
+	MTU        *int              `json:"mtu,omitempty"       url:"mtu,omitempty"`
+	Trunks     []int             `json:"trunks,omitempty"    url:"trunks,omitempty"`
 }
 
 // CustomNetworkDevices handles QEMU network device parameters.
@@ -118,13 +118,13 @@ type CustomNUMADevices []CustomNUMADevice
 
 // CustomPCIDevice handles QEMU host PCI device mapping parameters.
 type CustomPCIDevice struct {
-	DeviceIDs  *[]string          `json:"host,omitempty"    url:"host,omitempty,semicolon"`
-	Mapping    *string            `json:"mapping,omitempty" url:"mapping,omitempty"`
-	MDev       *string            `json:"mdev,omitempty"    url:"mdev,omitempty"`
-	PCIExpress *types2.CustomBool `json:"pcie,omitempty"    url:"pcie,omitempty,int"`
-	ROMBAR     *types2.CustomBool `json:"rombar,omitempty"  url:"rombar,omitempty,int"`
-	ROMFile    *string            `json:"romfile,omitempty" url:"romfile,omitempty"`
-	XVGA       *types2.CustomBool `json:"x-vga,omitempty"   url:"x-vga,omitempty,int"`
+	DeviceIDs  *[]string         `json:"host,omitempty"    url:"host,omitempty,semicolon"`
+	Mapping    *string           `json:"mapping,omitempty" url:"mapping,omitempty"`
+	MDev       *string           `json:"mdev,omitempty"    url:"mdev,omitempty"`
+	PCIExpress *types.CustomBool `json:"pcie,omitempty"    url:"pcie,omitempty,int"`
+	ROMBAR     *types.CustomBool `json:"rombar,omitempty"  url:"rombar,omitempty,int"`
+	ROMFile    *string           `json:"romfile,omitempty" url:"romfile,omitempty"`
+	XVGA       *types.CustomBool `json:"x-vga,omitempty"   url:"x-vga,omitempty,int"`
 }
 
 // CustomPCIDevices handles QEMU host PCI device mapping parameters.
@@ -141,20 +141,20 @@ type CustomSharedMemory struct {
 
 // CustomSMBIOS handles QEMU SMBIOS parameters.
 type CustomSMBIOS struct {
-	Base64       *types2.CustomBool `json:"base64,omitempty"       url:"base64,omitempty,int"`
-	Family       *string            `json:"family,omitempty"       url:"family,omitempty"`
-	Manufacturer *string            `json:"manufacturer,omitempty" url:"manufacturer,omitempty"`
-	Product      *string            `json:"product,omitempty"      url:"product,omitempty"`
-	Serial       *string            `json:"serial,omitempty"       url:"serial,omitempty"`
-	SKU          *string            `json:"sku,omitempty"          url:"sku,omitempty"`
-	UUID         *string            `json:"uuid,omitempty"         url:"uuid,omitempty"`
-	Version      *string            `json:"version,omitempty"      url:"version,omitempty"`
+	Base64       *types.CustomBool `json:"base64,omitempty"       url:"base64,omitempty,int"`
+	Family       *string           `json:"family,omitempty"       url:"family,omitempty"`
+	Manufacturer *string           `json:"manufacturer,omitempty" url:"manufacturer,omitempty"`
+	Product      *string           `json:"product,omitempty"      url:"product,omitempty"`
+	Serial       *string           `json:"serial,omitempty"       url:"serial,omitempty"`
+	SKU          *string           `json:"sku,omitempty"          url:"sku,omitempty"`
+	UUID         *string           `json:"uuid,omitempty"         url:"uuid,omitempty"`
+	Version      *string           `json:"version,omitempty"      url:"version,omitempty"`
 }
 
 // CustomSpiceEnhancements handles QEMU spice enhancement parameters.
 type CustomSpiceEnhancements struct {
-	FolderSharing  *types2.CustomBool `json:"foldersharing,omitempty"  url:"foldersharing,omitempty"`
-	VideoStreaming *string            `json:"videostreaming,omitempty" url:"videostreaming,omitempty"`
+	FolderSharing  *types.CustomBool `json:"foldersharing,omitempty"  url:"foldersharing,omitempty"`
+	VideoStreaming *string           `json:"videostreaming,omitempty" url:"videostreaming,omitempty"`
 }
 
 // CustomStartupOrder handles QEMU startup order parameters.
@@ -166,21 +166,21 @@ type CustomStartupOrder struct {
 
 // CustomStorageDevice handles QEMU SATA device parameters.
 type CustomStorageDevice struct {
-	AIO                     *string            `json:"aio,omitempty"         url:"aio,omitempty"`
-	BackupEnabled           *types2.CustomBool `json:"backup,omitempty"      url:"backup,omitempty,int"`
-	BurstableReadSpeedMbps  *int               `json:"mbps_rd_max,omitempty" url:"mbps_rd_max,omitempty"`
-	Cache                   *string            `json:"cache,omitempty"       url:"cache,omitempty"`
-	BurstableWriteSpeedMbps *int               `json:"mbps_wr_max,omitempty" url:"mbps_wr_max,omitempty"`
-	Discard                 *string            `json:"discard,omitempty"     url:"discard,omitempty"`
-	Enabled                 bool               `json:"-"                     url:"-"`
-	FileVolume              string             `json:"file"                  url:"file"`
-	Format                  *string            `json:"format,omitempty"      url:"format,omitempty"`
-	IOThread                *types2.CustomBool `json:"iothread,omitempty"    url:"iothread,omitempty,int"`
-	SSD                     *types2.CustomBool `json:"ssd,omitempty"         url:"ssd,omitempty,int"`
-	MaxReadSpeedMbps        *int               `json:"mbps_rd,omitempty"     url:"mbps_rd,omitempty"`
-	MaxWriteSpeedMbps       *int               `json:"mbps_wr,omitempty"     url:"mbps_wr,omitempty"`
-	Media                   *string            `json:"media,omitempty"       url:"media,omitempty"`
-	Size                    *types2.DiskSize   `json:"size,omitempty"        url:"size,omitempty"`
+	AIO                     *string           `json:"aio,omitempty"         url:"aio,omitempty"`
+	BackupEnabled           *types.CustomBool `json:"backup,omitempty"      url:"backup,omitempty,int"`
+	BurstableReadSpeedMbps  *int              `json:"mbps_rd_max,omitempty" url:"mbps_rd_max,omitempty"`
+	Cache                   *string           `json:"cache,omitempty"       url:"cache,omitempty"`
+	BurstableWriteSpeedMbps *int              `json:"mbps_wr_max,omitempty" url:"mbps_wr_max,omitempty"`
+	Discard                 *string           `json:"discard,omitempty"     url:"discard,omitempty"`
+	Enabled                 bool              `json:"-"                     url:"-"`
+	FileVolume              string            `json:"file"                  url:"file"`
+	Format                  *string           `json:"format,omitempty"      url:"format,omitempty"`
+	IOThread                *types.CustomBool `json:"iothread,omitempty"    url:"iothread,omitempty,int"`
+	SSD                     *types.CustomBool `json:"ssd,omitempty"         url:"ssd,omitempty,int"`
+	MaxReadSpeedMbps        *int              `json:"mbps_rd,omitempty"     url:"mbps_rd,omitempty"`
+	MaxWriteSpeedMbps       *int              `json:"mbps_wr,omitempty"     url:"mbps_wr,omitempty"`
+	Media                   *string           `json:"media,omitempty"       url:"media,omitempty"`
+	Size                    *types.DiskSize   `json:"size,omitempty"        url:"size,omitempty"`
 	Interface               *string
 	ID                      *string
 	FileID                  *string
@@ -192,8 +192,8 @@ type CustomStorageDevices map[string]CustomStorageDevice
 
 // CustomUSBDevice handles QEMU USB device parameters.
 type CustomUSBDevice struct {
-	HostDevice string             `json:"host"           url:"host"`
-	USB3       *types2.CustomBool `json:"usb3,omitempty" url:"usb3,omitempty,int"`
+	HostDevice string            `json:"host"           url:"host"`
+	USB3       *types.CustomBool `json:"usb3,omitempty" url:"usb3,omitempty,int"`
 }
 
 // CustomUSBDevices handles QEMU USB device parameters.
@@ -207,10 +207,10 @@ type CustomVGADevice struct {
 
 // CustomVirtualIODevice handles QEMU VirtIO device parameters.
 type CustomVirtualIODevice struct {
-	AIO           *string            `json:"aio,omitempty"    url:"aio,omitempty"`
-	BackupEnabled *types2.CustomBool `json:"backup,omitempty" url:"backup,omitempty,int"`
-	Enabled       bool               `json:"-"                url:"-"`
-	FileVolume    string             `json:"file"             url:"file"`
+	AIO           *string           `json:"aio,omitempty"    url:"aio,omitempty"`
+	BackupEnabled *types.CustomBool `json:"backup,omitempty" url:"backup,omitempty,int"`
+	Enabled       bool              `json:"-"                url:"-"`
+	FileVolume    string            `json:"file"             url:"file"`
 }
 
 // CustomVirtualIODevices handles QEMU VirtIO device parameters.
@@ -224,89 +224,89 @@ type CustomWatchdogDevice struct {
 
 // CloneRequestBody contains the data for an virtual machine clone request.
 type CloneRequestBody struct {
-	BandwidthLimit      *int               `json:"bwlimit,omitempty"     url:"bwlimit,omitempty"`
-	Description         *string            `json:"description,omitempty" url:"description,omitempty"`
-	FullCopy            *types2.CustomBool `json:"full,omitempty"        url:"full,omitempty,int"`
-	Name                *string            `json:"name,omitempty"        url:"name,omitempty"`
-	PoolID              *string            `json:"pool,omitempty"        url:"pool,omitempty"`
-	SnapshotName        *string            `json:"snapname,omitempty"    url:"snapname,omitempty"`
-	TargetNodeName      *string            `json:"target,omitempty"      url:"target,omitempty"`
-	TargetStorage       *string            `json:"storage,omitempty"     url:"storage,omitempty"`
-	TargetStorageFormat *string            `json:"format,omitempty"      url:"format,omitempty"`
-	VMIDNew             int                `json:"newid"                 url:"newid"`
+	BandwidthLimit      *int              `json:"bwlimit,omitempty"     url:"bwlimit,omitempty"`
+	Description         *string           `json:"description,omitempty" url:"description,omitempty"`
+	FullCopy            *types.CustomBool `json:"full,omitempty"        url:"full,omitempty,int"`
+	Name                *string           `json:"name,omitempty"        url:"name,omitempty"`
+	PoolID              *string           `json:"pool,omitempty"        url:"pool,omitempty"`
+	SnapshotName        *string           `json:"snapname,omitempty"    url:"snapname,omitempty"`
+	TargetNodeName      *string           `json:"target,omitempty"      url:"target,omitempty"`
+	TargetStorage       *string           `json:"storage,omitempty"     url:"storage,omitempty"`
+	TargetStorageFormat *string           `json:"format,omitempty"      url:"format,omitempty"`
+	VMIDNew             int               `json:"newid"                 url:"newid"`
 }
 
 // CreateRequestBody contains the data for a virtual machine create request.
 type CreateRequestBody struct {
-	ACPI                 *types2.CustomBool              `json:"acpi,omitempty"               url:"acpi,omitempty,int"`
-	Agent                *CustomAgent                    `json:"agent,omitempty"              url:"agent,omitempty"`
-	AllowReboot          *types2.CustomBool              `json:"reboot,omitempty"             url:"reboot,omitempty,int"`
-	AudioDevices         CustomAudioDevices              `json:"audio,omitempty"              url:"audio,omitempty"`
-	Autostart            *types2.CustomBool              `json:"autostart,omitempty"          url:"autostart,omitempty,int"`
-	BackupFile           *string                         `json:"archive,omitempty"            url:"archive,omitempty"`
-	BandwidthLimit       *int                            `json:"bwlimit,omitempty"            url:"bwlimit,omitempty"`
-	BIOS                 *string                         `json:"bios,omitempty"               url:"bios,omitempty"`
-	Boot                 *CustomBoot                     `json:"boot,omitempty"               url:"boot,omitempty"`
-	CDROM                *string                         `json:"cdrom,omitempty"              url:"cdrom,omitempty"`
-	CloudInitConfig      *CustomCloudInitConfig          `json:"cloudinit,omitempty"          url:"cloudinit,omitempty"`
-	CPUArchitecture      *string                         `json:"arch,omitempty"               url:"arch,omitempty"`
-	CPUCores             *int                            `json:"cores,omitempty"              url:"cores,omitempty"`
-	CPUEmulation         *CustomCPUEmulation             `json:"cpu,omitempty"                url:"cpu,omitempty"`
-	CPULimit             *int                            `json:"cpulimit,omitempty"           url:"cpulimit,omitempty"`
-	CPUSockets           *int                            `json:"sockets,omitempty"            url:"sockets,omitempty"`
-	CPUUnits             *int                            `json:"cpuunits,omitempty"           url:"cpuunits,omitempty"`
-	DedicatedMemory      *int                            `json:"memory,omitempty"             url:"memory,omitempty"`
-	Delete               []string                        `json:"delete,omitempty"             url:"delete,omitempty,comma"`
-	DeletionProtection   *types2.CustomBool              `json:"protection,omitempty"         url:"force,omitempty,int"`
-	Description          *string                         `json:"description,omitempty"        url:"description,omitempty"`
-	EFIDisk              *CustomEFIDisk                  `json:"efidisk0,omitempty"           url:"efidisk0,omitempty"`
-	FloatingMemory       *int                            `json:"balloon,omitempty"            url:"balloon,omitempty"`
-	FloatingMemoryShares *int                            `json:"shares,omitempty"             url:"shares,omitempty"`
-	Freeze               *types2.CustomBool              `json:"freeze,omitempty"             url:"freeze,omitempty,int"`
-	HookScript           *string                         `json:"hookscript,omitempty"         url:"hookscript,omitempty"`
-	Hotplug              types2.CustomCommaSeparatedList `json:"hotplug,omitempty"            url:"hotplug,omitempty,comma"`
-	Hugepages            *string                         `json:"hugepages,omitempty"          url:"hugepages,omitempty"`
-	IDEDevices           CustomStorageDevices            `json:"ide,omitempty"                url:",omitempty"`
-	KeyboardLayout       *string                         `json:"keyboard,omitempty"           url:"keyboard,omitempty"`
-	KVMArguments         *string                         `json:"args,omitempty"               url:"args,omitempty,space"`
-	KVMEnabled           *types2.CustomBool              `json:"kvm,omitempty"                url:"kvm,omitempty,int"`
-	LocalTime            *types2.CustomBool              `json:"localtime,omitempty"          url:"localtime,omitempty,int"`
-	Lock                 *string                         `json:"lock,omitempty"               url:"lock,omitempty"`
-	Machine              *string                         `json:"machine,omitempty"            url:"machine,omitempty"`
-	MigrateDowntime      *float64                        `json:"migrate_downtime,omitempty"   url:"migrate_downtime,omitempty"`
-	MigrateSpeed         *int                            `json:"migrate_speed,omitempty"      url:"migrate_speed,omitempty"`
-	Name                 *string                         `json:"name,omitempty"               url:"name,omitempty"`
-	NetworkDevices       CustomNetworkDevices            `json:"net,omitempty"                url:"net,omitempty"`
-	NUMADevices          CustomNUMADevices               `json:"numa_devices,omitempty"       url:"numa,omitempty"`
-	NUMAEnabled          *types2.CustomBool              `json:"numa,omitempty"               url:"numa,omitempty,int"`
-	OSType               *string                         `json:"ostype,omitempty"             url:"ostype,omitempty"`
-	Overwrite            *types2.CustomBool              `json:"force,omitempty"              url:"force,omitempty,int"`
-	PCIDevices           CustomPCIDevices                `json:"hostpci,omitempty"            url:"hostpci,omitempty"`
-	PoolID               *string                         `json:"pool,omitempty"               url:"pool,omitempty"`
-	Revert               *string                         `json:"revert,omitempty"             url:"revert,omitempty"`
-	SATADevices          CustomStorageDevices            `json:"sata,omitempty"               url:"sata,omitempty"`
-	SCSIDevices          CustomStorageDevices            `json:"scsi,omitempty"               url:"scsi,omitempty"`
-	SCSIHardware         *string                         `json:"scsihw,omitempty"             url:"scsihw,omitempty"`
-	SerialDevices        CustomSerialDevices             `json:"serial,omitempty"             url:"serial,omitempty"`
-	SharedMemory         *CustomSharedMemory             `json:"ivshmem,omitempty"            url:"ivshmem,omitempty"`
-	SkipLock             *types2.CustomBool              `json:"skiplock,omitempty"           url:"skiplock,omitempty,int"`
-	SMBIOS               *CustomSMBIOS                   `json:"smbios1,omitempty"            url:"smbios1,omitempty"`
-	SpiceEnhancements    *CustomSpiceEnhancements        `json:"spice_enhancements,omitempty" url:"spice_enhancements,omitempty"`
-	StartDate            *string                         `json:"startdate,omitempty"          url:"startdate,omitempty"`
-	StartOnBoot          *types2.CustomBool              `json:"onboot,omitempty"             url:"onboot,omitempty,int"`
-	StartupOrder         *CustomStartupOrder             `json:"startup,omitempty"            url:"startup,omitempty"`
-	TabletDeviceEnabled  *types2.CustomBool              `json:"tablet,omitempty"             url:"tablet,omitempty,int"`
-	Tags                 *string                         `json:"tags,omitempty"               url:"tags,omitempty"`
-	Template             *types2.CustomBool              `json:"template,omitempty"           url:"template,omitempty,int"`
-	TimeDriftFixEnabled  *types2.CustomBool              `json:"tdf,omitempty"                url:"tdf,omitempty,int"`
-	USBDevices           CustomUSBDevices                `json:"usb,omitempty"                url:"usb,omitempty"`
-	VGADevice            *CustomVGADevice                `json:"vga,omitempty"                url:"vga,omitempty"`
-	VirtualCPUCount      *int                            `json:"vcpus,omitempty"              url:"vcpus,omitempty"`
-	VirtualIODevices     CustomStorageDevices            `json:"virtio,omitempty"             url:"virtio,omitempty"`
-	VMGenerationID       *string                         `json:"vmgenid,omitempty"            url:"vmgenid,omitempty"`
-	VMID                 *int                            `json:"vmid,omitempty"               url:"vmid,omitempty"`
-	VMStateDatastoreID   *string                         `json:"vmstatestorage,omitempty"     url:"vmstatestorage,omitempty"`
-	WatchdogDevice       *CustomWatchdogDevice           `json:"watchdog,omitempty"           url:"watchdog,omitempty"`
+	ACPI                 *types.CustomBool              `json:"acpi,omitempty"               url:"acpi,omitempty,int"`
+	Agent                *CustomAgent                   `json:"agent,omitempty"              url:"agent,omitempty"`
+	AllowReboot          *types.CustomBool              `json:"reboot,omitempty"             url:"reboot,omitempty,int"`
+	AudioDevices         CustomAudioDevices             `json:"audio,omitempty"              url:"audio,omitempty"`
+	Autostart            *types.CustomBool              `json:"autostart,omitempty"          url:"autostart,omitempty,int"`
+	BackupFile           *string                        `json:"archive,omitempty"            url:"archive,omitempty"`
+	BandwidthLimit       *int                           `json:"bwlimit,omitempty"            url:"bwlimit,omitempty"`
+	BIOS                 *string                        `json:"bios,omitempty"               url:"bios,omitempty"`
+	Boot                 *CustomBoot                    `json:"boot,omitempty"               url:"boot,omitempty"`
+	CDROM                *string                        `json:"cdrom,omitempty"              url:"cdrom,omitempty"`
+	CloudInitConfig      *CustomCloudInitConfig         `json:"cloudinit,omitempty"          url:"cloudinit,omitempty"`
+	CPUArchitecture      *string                        `json:"arch,omitempty"               url:"arch,omitempty"`
+	CPUCores             *int                           `json:"cores,omitempty"              url:"cores,omitempty"`
+	CPUEmulation         *CustomCPUEmulation            `json:"cpu,omitempty"                url:"cpu,omitempty"`
+	CPULimit             *int                           `json:"cpulimit,omitempty"           url:"cpulimit,omitempty"`
+	CPUSockets           *int                           `json:"sockets,omitempty"            url:"sockets,omitempty"`
+	CPUUnits             *int                           `json:"cpuunits,omitempty"           url:"cpuunits,omitempty"`
+	DedicatedMemory      *int                           `json:"memory,omitempty"             url:"memory,omitempty"`
+	Delete               []string                       `json:"delete,omitempty"             url:"delete,omitempty,comma"`
+	DeletionProtection   *types.CustomBool              `json:"protection,omitempty"         url:"force,omitempty,int"`
+	Description          *string                        `json:"description,omitempty"        url:"description,omitempty"`
+	EFIDisk              *CustomEFIDisk                 `json:"efidisk0,omitempty"           url:"efidisk0,omitempty"`
+	FloatingMemory       *int                           `json:"balloon,omitempty"            url:"balloon,omitempty"`
+	FloatingMemoryShares *int                           `json:"shares,omitempty"             url:"shares,omitempty"`
+	Freeze               *types.CustomBool              `json:"freeze,omitempty"             url:"freeze,omitempty,int"`
+	HookScript           *string                        `json:"hookscript,omitempty"         url:"hookscript,omitempty"`
+	Hotplug              types.CustomCommaSeparatedList `json:"hotplug,omitempty"            url:"hotplug,omitempty,comma"`
+	Hugepages            *string                        `json:"hugepages,omitempty"          url:"hugepages,omitempty"`
+	IDEDevices           CustomStorageDevices           `json:"ide,omitempty"                url:",omitempty"`
+	KeyboardLayout       *string                        `json:"keyboard,omitempty"           url:"keyboard,omitempty"`
+	KVMArguments         *string                        `json:"args,omitempty"               url:"args,omitempty,space"`
+	KVMEnabled           *types.CustomBool              `json:"kvm,omitempty"                url:"kvm,omitempty,int"`
+	LocalTime            *types.CustomBool              `json:"localtime,omitempty"          url:"localtime,omitempty,int"`
+	Lock                 *string                        `json:"lock,omitempty"               url:"lock,omitempty"`
+	Machine              *string                        `json:"machine,omitempty"            url:"machine,omitempty"`
+	MigrateDowntime      *float64                       `json:"migrate_downtime,omitempty"   url:"migrate_downtime,omitempty"`
+	MigrateSpeed         *int                           `json:"migrate_speed,omitempty"      url:"migrate_speed,omitempty"`
+	Name                 *string                        `json:"name,omitempty"               url:"name,omitempty"`
+	NetworkDevices       CustomNetworkDevices           `json:"net,omitempty"                url:"net,omitempty"`
+	NUMADevices          CustomNUMADevices              `json:"numa_devices,omitempty"       url:"numa,omitempty"`
+	NUMAEnabled          *types.CustomBool              `json:"numa,omitempty"               url:"numa,omitempty,int"`
+	OSType               *string                        `json:"ostype,omitempty"             url:"ostype,omitempty"`
+	Overwrite            *types.CustomBool              `json:"force,omitempty"              url:"force,omitempty,int"`
+	PCIDevices           CustomPCIDevices               `json:"hostpci,omitempty"            url:"hostpci,omitempty"`
+	PoolID               *string                        `json:"pool,omitempty"               url:"pool,omitempty"`
+	Revert               *string                        `json:"revert,omitempty"             url:"revert,omitempty"`
+	SATADevices          CustomStorageDevices           `json:"sata,omitempty"               url:"sata,omitempty"`
+	SCSIDevices          CustomStorageDevices           `json:"scsi,omitempty"               url:"scsi,omitempty"`
+	SCSIHardware         *string                        `json:"scsihw,omitempty"             url:"scsihw,omitempty"`
+	SerialDevices        CustomSerialDevices            `json:"serial,omitempty"             url:"serial,omitempty"`
+	SharedMemory         *CustomSharedMemory            `json:"ivshmem,omitempty"            url:"ivshmem,omitempty"`
+	SkipLock             *types.CustomBool              `json:"skiplock,omitempty"           url:"skiplock,omitempty,int"`
+	SMBIOS               *CustomSMBIOS                  `json:"smbios1,omitempty"            url:"smbios1,omitempty"`
+	SpiceEnhancements    *CustomSpiceEnhancements       `json:"spice_enhancements,omitempty" url:"spice_enhancements,omitempty"`
+	StartDate            *string                        `json:"startdate,omitempty"          url:"startdate,omitempty"`
+	StartOnBoot          *types.CustomBool              `json:"onboot,omitempty"             url:"onboot,omitempty,int"`
+	StartupOrder         *CustomStartupOrder            `json:"startup,omitempty"            url:"startup,omitempty"`
+	TabletDeviceEnabled  *types.CustomBool              `json:"tablet,omitempty"             url:"tablet,omitempty,int"`
+	Tags                 *string                        `json:"tags,omitempty"               url:"tags,omitempty"`
+	Template             *types.CustomBool              `json:"template,omitempty"           url:"template,omitempty,int"`
+	TimeDriftFixEnabled  *types.CustomBool              `json:"tdf,omitempty"                url:"tdf,omitempty,int"`
+	USBDevices           CustomUSBDevices               `json:"usb,omitempty"                url:"usb,omitempty"`
+	VGADevice            *CustomVGADevice               `json:"vga,omitempty"                url:"vga,omitempty"`
+	VirtualCPUCount      *int                           `json:"vcpus,omitempty"              url:"vcpus,omitempty"`
+	VirtualIODevices     CustomStorageDevices           `json:"virtio,omitempty"             url:"virtio,omitempty"`
+	VMGenerationID       *string                        `json:"vmgenid,omitempty"            url:"vmgenid,omitempty"`
+	VMID                 *int                           `json:"vmid,omitempty"               url:"vmid,omitempty"`
+	VMStateDatastoreID   *string                        `json:"vmstatestorage,omitempty"     url:"vmstatestorage,omitempty"`
+	WatchdogDevice       *CustomWatchdogDevice          `json:"watchdog,omitempty"           url:"watchdog,omitempty"`
 }
 
 // CreateResponseBody contains the body from a create response.
@@ -358,137 +358,137 @@ type GetResponseBody struct {
 
 // GetResponseData contains the data from an virtual machine get response.
 type GetResponseData struct {
-	ACPI                 *types2.CustomBool               `json:"acpi,omitempty"`
-	Agent                *CustomAgent                     `json:"agent,omitempty"`
-	AllowReboot          *types2.CustomBool               `json:"reboot,omitempty"`
-	AudioDevice          *CustomAudioDevice               `json:"audio0,omitempty"`
-	Autostart            *types2.CustomBool               `json:"autostart,omitempty"`
-	BackupFile           *string                          `json:"archive,omitempty"`
-	BandwidthLimit       *int                             `json:"bwlimit,omitempty"`
-	BIOS                 *string                          `json:"bios,omitempty"`
-	BootDisk             *string                          `json:"bootdisk,omitempty"`
-	BootOrder            *string                          `json:"boot,omitempty"`
-	CDROM                *string                          `json:"cdrom,omitempty"`
-	CloudInitDNSDomain   *string                          `json:"searchdomain,omitempty"`
-	CloudInitDNSServer   *string                          `json:"nameserver,omitempty"`
-	CloudInitFiles       *CustomCloudInitFiles            `json:"cicustom,omitempty"`
-	CloudInitPassword    *string                          `json:"cipassword,omitempty"`
-	CloudInitSSHKeys     *CustomCloudInitSSHKeys          `json:"sshkeys,omitempty"`
-	CloudInitType        *string                          `json:"citype,omitempty"`
-	CloudInitUsername    *string                          `json:"ciuser,omitempty"`
-	CPUArchitecture      *string                          `json:"arch,omitempty"`
-	CPUCores             *int                             `json:"cores,omitempty"`
-	CPUEmulation         *CustomCPUEmulation              `json:"cpu,omitempty"`
-	CPULimit             *types2.CustomInt                `json:"cpulimit,omitempty"`
-	CPUSockets           *int                             `json:"sockets,omitempty"`
-	CPUUnits             *int                             `json:"cpuunits,omitempty"`
-	DedicatedMemory      *int                             `json:"memory,omitempty"`
-	DeletionProtection   *types2.CustomBool               `json:"protection,omitempty"`
-	Description          *string                          `json:"description,omitempty"`
-	EFIDisk              *CustomEFIDisk                   `json:"efidisk0,omitempty"`
-	FloatingMemory       *int                             `json:"balloon,omitempty"`
-	FloatingMemoryShares *int                             `json:"shares,omitempty"`
-	Freeze               *types2.CustomBool               `json:"freeze,omitempty"`
-	HookScript           *string                          `json:"hookscript,omitempty"`
-	Hotplug              *types2.CustomCommaSeparatedList `json:"hotplug,omitempty"`
-	Hugepages            *string                          `json:"hugepages,omitempty"`
-	IDEDevice0           *CustomStorageDevice             `json:"ide0,omitempty"`
-	IDEDevice1           *CustomStorageDevice             `json:"ide1,omitempty"`
-	IDEDevice2           *CustomStorageDevice             `json:"ide2,omitempty"`
-	IDEDevice3           *CustomStorageDevice             `json:"ide3,omitempty"`
-	IPConfig0            *CustomCloudInitIPConfig         `json:"ipconfig0,omitempty"`
-	IPConfig1            *CustomCloudInitIPConfig         `json:"ipconfig1,omitempty"`
-	IPConfig2            *CustomCloudInitIPConfig         `json:"ipconfig2,omitempty"`
-	IPConfig3            *CustomCloudInitIPConfig         `json:"ipconfig3,omitempty"`
-	IPConfig4            *CustomCloudInitIPConfig         `json:"ipconfig4,omitempty"`
-	IPConfig5            *CustomCloudInitIPConfig         `json:"ipconfig5,omitempty"`
-	IPConfig6            *CustomCloudInitIPConfig         `json:"ipconfig6,omitempty"`
-	IPConfig7            *CustomCloudInitIPConfig         `json:"ipconfig7,omitempty"`
-	KeyboardLayout       *string                          `json:"keyboard,omitempty"`
-	KVMArguments         *string                          `json:"args,omitempty"`
-	KVMEnabled           *types2.CustomBool               `json:"kvm,omitempty"`
-	LocalTime            *types2.CustomBool               `json:"localtime,omitempty"`
-	Lock                 *string                          `json:"lock,omitempty"`
-	Machine              *string                          `json:"machine,omitempty"`
-	MigrateDowntime      *float64                         `json:"migrate_downtime,omitempty"`
-	MigrateSpeed         *int                             `json:"migrate_speed,omitempty"`
-	Name                 *string                          `json:"name,omitempty"`
-	NetworkDevice0       *CustomNetworkDevice             `json:"net0,omitempty"`
-	NetworkDevice1       *CustomNetworkDevice             `json:"net1,omitempty"`
-	NetworkDevice2       *CustomNetworkDevice             `json:"net2,omitempty"`
-	NetworkDevice3       *CustomNetworkDevice             `json:"net3,omitempty"`
-	NetworkDevice4       *CustomNetworkDevice             `json:"net4,omitempty"`
-	NetworkDevice5       *CustomNetworkDevice             `json:"net5,omitempty"`
-	NetworkDevice6       *CustomNetworkDevice             `json:"net6,omitempty"`
-	NetworkDevice7       *CustomNetworkDevice             `json:"net7,omitempty"`
-	NUMADevices          *CustomNUMADevices               `json:"numa_devices,omitempty"`
-	NUMAEnabled          *types2.CustomBool               `json:"numa,omitempty"`
-	OSType               *string                          `json:"ostype,omitempty"`
-	Overwrite            *types2.CustomBool               `json:"force,omitempty"`
-	PCIDevice0           *CustomPCIDevice                 `json:"hostpci0,omitempty"`
-	PCIDevice1           *CustomPCIDevice                 `json:"hostpci1,omitempty"`
-	PCIDevice2           *CustomPCIDevice                 `json:"hostpci2,omitempty"`
-	PCIDevice3           *CustomPCIDevice                 `json:"hostpci3,omitempty"`
-	PoolID               *string                          `json:"pool,omitempty"               url:"pool,omitempty"`
-	Revert               *string                          `json:"revert,omitempty"`
-	SATADevice0          *CustomStorageDevice             `json:"sata0,omitempty"`
-	SATADevice1          *CustomStorageDevice             `json:"sata1,omitempty"`
-	SATADevice2          *CustomStorageDevice             `json:"sata2,omitempty"`
-	SATADevice3          *CustomStorageDevice             `json:"sata3,omitempty"`
-	SATADevice4          *CustomStorageDevice             `json:"sata4,omitempty"`
-	SATADevice5          *CustomStorageDevice             `json:"sata5,omitempty"`
-	SCSIDevice0          *CustomStorageDevice             `json:"scsi0,omitempty"`
-	SCSIDevice1          *CustomStorageDevice             `json:"scsi1,omitempty"`
-	SCSIDevice2          *CustomStorageDevice             `json:"scsi2,omitempty"`
-	SCSIDevice3          *CustomStorageDevice             `json:"scsi3,omitempty"`
-	SCSIDevice4          *CustomStorageDevice             `json:"scsi4,omitempty"`
-	SCSIDevice5          *CustomStorageDevice             `json:"scsi5,omitempty"`
-	SCSIDevice6          *CustomStorageDevice             `json:"scsi6,omitempty"`
-	SCSIDevice7          *CustomStorageDevice             `json:"scsi7,omitempty"`
-	SCSIDevice8          *CustomStorageDevice             `json:"scsi8,omitempty"`
-	SCSIDevice9          *CustomStorageDevice             `json:"scsi9,omitempty"`
-	SCSIDevice10         *CustomStorageDevice             `json:"scsi10,omitempty"`
-	SCSIDevice11         *CustomStorageDevice             `json:"scsi11,omitempty"`
-	SCSIDevice12         *CustomStorageDevice             `json:"scsi12,omitempty"`
-	SCSIDevice13         *CustomStorageDevice             `json:"scsi13,omitempty"`
-	SCSIHardware         *string                          `json:"scsihw,omitempty"`
-	SerialDevice0        *string                          `json:"serial0,omitempty"`
-	SerialDevice1        *string                          `json:"serial1,omitempty"`
-	SerialDevice2        *string                          `json:"serial2,omitempty"`
-	SerialDevice3        *string                          `json:"serial3,omitempty"`
-	SharedMemory         *CustomSharedMemory              `json:"ivshmem,omitempty"`
-	SkipLock             *types2.CustomBool               `json:"skiplock,omitempty"`
-	SMBIOS               *CustomSMBIOS                    `json:"smbios1,omitempty"`
-	SpiceEnhancements    *CustomSpiceEnhancements         `json:"spice_enhancements,omitempty"`
-	StartDate            *string                          `json:"startdate,omitempty"`
-	StartOnBoot          *types2.CustomBool               `json:"onboot,omitempty"`
-	StartupOrder         *CustomStartupOrder              `json:"startup,omitempty"`
-	TabletDeviceEnabled  *types2.CustomBool               `json:"tablet,omitempty"`
-	Tags                 *string                          `json:"tags,omitempty"`
-	Template             *types2.CustomBool               `json:"template,omitempty"`
-	TimeDriftFixEnabled  *types2.CustomBool               `json:"tdf,omitempty"`
-	USBDevices           *CustomUSBDevices                `json:"usb,omitempty"`
-	VGADevice            *CustomVGADevice                 `json:"vga,omitempty"`
-	VirtualCPUCount      *int                             `json:"vcpus,omitempty"`
-	VirtualIODevice0     *CustomStorageDevice             `json:"virtio0,omitempty"`
-	VirtualIODevice1     *CustomStorageDevice             `json:"virtio1,omitempty"`
-	VirtualIODevice2     *CustomStorageDevice             `json:"virtio2,omitempty"`
-	VirtualIODevice3     *CustomStorageDevice             `json:"virtio3,omitempty"`
-	VirtualIODevice4     *CustomStorageDevice             `json:"virtio4,omitempty"`
-	VirtualIODevice5     *CustomStorageDevice             `json:"virtio5,omitempty"`
-	VirtualIODevice6     *CustomStorageDevice             `json:"virtio6,omitempty"`
-	VirtualIODevice7     *CustomStorageDevice             `json:"virtio7,omitempty"`
-	VirtualIODevice8     *CustomStorageDevice             `json:"virtio8,omitempty"`
-	VirtualIODevice9     *CustomStorageDevice             `json:"virtio9,omitempty"`
-	VirtualIODevice10    *CustomStorageDevice             `json:"virtio10,omitempty"`
-	VirtualIODevice11    *CustomStorageDevice             `json:"virtio11,omitempty"`
-	VirtualIODevice12    *CustomStorageDevice             `json:"virtio12,omitempty"`
-	VirtualIODevice13    *CustomStorageDevice             `json:"virtio13,omitempty"`
-	VirtualIODevice14    *CustomStorageDevice             `json:"virtio14,omitempty"`
-	VirtualIODevice15    *CustomStorageDevice             `json:"virtio15,omitempty"`
-	VMGenerationID       *string                          `json:"vmgenid,omitempty"`
-	VMStateDatastoreID   *string                          `json:"vmstatestorage,omitempty"`
-	WatchdogDevice       *CustomWatchdogDevice            `json:"watchdog,omitempty"`
+	ACPI                 *types.CustomBool               `json:"acpi,omitempty"`
+	Agent                *CustomAgent                    `json:"agent,omitempty"`
+	AllowReboot          *types.CustomBool               `json:"reboot,omitempty"`
+	AudioDevice          *CustomAudioDevice              `json:"audio0,omitempty"`
+	Autostart            *types.CustomBool               `json:"autostart,omitempty"`
+	BackupFile           *string                         `json:"archive,omitempty"`
+	BandwidthLimit       *int                            `json:"bwlimit,omitempty"`
+	BIOS                 *string                         `json:"bios,omitempty"`
+	BootDisk             *string                         `json:"bootdisk,omitempty"`
+	BootOrder            *string                         `json:"boot,omitempty"`
+	CDROM                *string                         `json:"cdrom,omitempty"`
+	CloudInitDNSDomain   *string                         `json:"searchdomain,omitempty"`
+	CloudInitDNSServer   *string                         `json:"nameserver,omitempty"`
+	CloudInitFiles       *CustomCloudInitFiles           `json:"cicustom,omitempty"`
+	CloudInitPassword    *string                         `json:"cipassword,omitempty"`
+	CloudInitSSHKeys     *CustomCloudInitSSHKeys         `json:"sshkeys,omitempty"`
+	CloudInitType        *string                         `json:"citype,omitempty"`
+	CloudInitUsername    *string                         `json:"ciuser,omitempty"`
+	CPUArchitecture      *string                         `json:"arch,omitempty"`
+	CPUCores             *int                            `json:"cores,omitempty"`
+	CPUEmulation         *CustomCPUEmulation             `json:"cpu,omitempty"`
+	CPULimit             *types.CustomInt                `json:"cpulimit,omitempty"`
+	CPUSockets           *int                            `json:"sockets,omitempty"`
+	CPUUnits             *int                            `json:"cpuunits,omitempty"`
+	DedicatedMemory      *int                            `json:"memory,omitempty"`
+	DeletionProtection   *types.CustomBool               `json:"protection,omitempty"`
+	Description          *string                         `json:"description,omitempty"`
+	EFIDisk              *CustomEFIDisk                  `json:"efidisk0,omitempty"`
+	FloatingMemory       *int                            `json:"balloon,omitempty"`
+	FloatingMemoryShares *int                            `json:"shares,omitempty"`
+	Freeze               *types.CustomBool               `json:"freeze,omitempty"`
+	HookScript           *string                         `json:"hookscript,omitempty"`
+	Hotplug              *types.CustomCommaSeparatedList `json:"hotplug,omitempty"`
+	Hugepages            *string                         `json:"hugepages,omitempty"`
+	IDEDevice0           *CustomStorageDevice            `json:"ide0,omitempty"`
+	IDEDevice1           *CustomStorageDevice            `json:"ide1,omitempty"`
+	IDEDevice2           *CustomStorageDevice            `json:"ide2,omitempty"`
+	IDEDevice3           *CustomStorageDevice            `json:"ide3,omitempty"`
+	IPConfig0            *CustomCloudInitIPConfig        `json:"ipconfig0,omitempty"`
+	IPConfig1            *CustomCloudInitIPConfig        `json:"ipconfig1,omitempty"`
+	IPConfig2            *CustomCloudInitIPConfig        `json:"ipconfig2,omitempty"`
+	IPConfig3            *CustomCloudInitIPConfig        `json:"ipconfig3,omitempty"`
+	IPConfig4            *CustomCloudInitIPConfig        `json:"ipconfig4,omitempty"`
+	IPConfig5            *CustomCloudInitIPConfig        `json:"ipconfig5,omitempty"`
+	IPConfig6            *CustomCloudInitIPConfig        `json:"ipconfig6,omitempty"`
+	IPConfig7            *CustomCloudInitIPConfig        `json:"ipconfig7,omitempty"`
+	KeyboardLayout       *string                         `json:"keyboard,omitempty"`
+	KVMArguments         *string                         `json:"args,omitempty"`
+	KVMEnabled           *types.CustomBool               `json:"kvm,omitempty"`
+	LocalTime            *types.CustomBool               `json:"localtime,omitempty"`
+	Lock                 *string                         `json:"lock,omitempty"`
+	Machine              *string                         `json:"machine,omitempty"`
+	MigrateDowntime      *float64                        `json:"migrate_downtime,omitempty"`
+	MigrateSpeed         *int                            `json:"migrate_speed,omitempty"`
+	Name                 *string                         `json:"name,omitempty"`
+	NetworkDevice0       *CustomNetworkDevice            `json:"net0,omitempty"`
+	NetworkDevice1       *CustomNetworkDevice            `json:"net1,omitempty"`
+	NetworkDevice2       *CustomNetworkDevice            `json:"net2,omitempty"`
+	NetworkDevice3       *CustomNetworkDevice            `json:"net3,omitempty"`
+	NetworkDevice4       *CustomNetworkDevice            `json:"net4,omitempty"`
+	NetworkDevice5       *CustomNetworkDevice            `json:"net5,omitempty"`
+	NetworkDevice6       *CustomNetworkDevice            `json:"net6,omitempty"`
+	NetworkDevice7       *CustomNetworkDevice            `json:"net7,omitempty"`
+	NUMADevices          *CustomNUMADevices              `json:"numa_devices,omitempty"`
+	NUMAEnabled          *types.CustomBool               `json:"numa,omitempty"`
+	OSType               *string                         `json:"ostype,omitempty"`
+	Overwrite            *types.CustomBool               `json:"force,omitempty"`
+	PCIDevice0           *CustomPCIDevice                `json:"hostpci0,omitempty"`
+	PCIDevice1           *CustomPCIDevice                `json:"hostpci1,omitempty"`
+	PCIDevice2           *CustomPCIDevice                `json:"hostpci2,omitempty"`
+	PCIDevice3           *CustomPCIDevice                `json:"hostpci3,omitempty"`
+	PoolID               *string                         `json:"pool,omitempty"               url:"pool,omitempty"`
+	Revert               *string                         `json:"revert,omitempty"`
+	SATADevice0          *CustomStorageDevice            `json:"sata0,omitempty"`
+	SATADevice1          *CustomStorageDevice            `json:"sata1,omitempty"`
+	SATADevice2          *CustomStorageDevice            `json:"sata2,omitempty"`
+	SATADevice3          *CustomStorageDevice            `json:"sata3,omitempty"`
+	SATADevice4          *CustomStorageDevice            `json:"sata4,omitempty"`
+	SATADevice5          *CustomStorageDevice            `json:"sata5,omitempty"`
+	SCSIDevice0          *CustomStorageDevice            `json:"scsi0,omitempty"`
+	SCSIDevice1          *CustomStorageDevice            `json:"scsi1,omitempty"`
+	SCSIDevice2          *CustomStorageDevice            `json:"scsi2,omitempty"`
+	SCSIDevice3          *CustomStorageDevice            `json:"scsi3,omitempty"`
+	SCSIDevice4          *CustomStorageDevice            `json:"scsi4,omitempty"`
+	SCSIDevice5          *CustomStorageDevice            `json:"scsi5,omitempty"`
+	SCSIDevice6          *CustomStorageDevice            `json:"scsi6,omitempty"`
+	SCSIDevice7          *CustomStorageDevice            `json:"scsi7,omitempty"`
+	SCSIDevice8          *CustomStorageDevice            `json:"scsi8,omitempty"`
+	SCSIDevice9          *CustomStorageDevice            `json:"scsi9,omitempty"`
+	SCSIDevice10         *CustomStorageDevice            `json:"scsi10,omitempty"`
+	SCSIDevice11         *CustomStorageDevice            `json:"scsi11,omitempty"`
+	SCSIDevice12         *CustomStorageDevice            `json:"scsi12,omitempty"`
+	SCSIDevice13         *CustomStorageDevice            `json:"scsi13,omitempty"`
+	SCSIHardware         *string                         `json:"scsihw,omitempty"`
+	SerialDevice0        *string                         `json:"serial0,omitempty"`
+	SerialDevice1        *string                         `json:"serial1,omitempty"`
+	SerialDevice2        *string                         `json:"serial2,omitempty"`
+	SerialDevice3        *string                         `json:"serial3,omitempty"`
+	SharedMemory         *CustomSharedMemory             `json:"ivshmem,omitempty"`
+	SkipLock             *types.CustomBool               `json:"skiplock,omitempty"`
+	SMBIOS               *CustomSMBIOS                   `json:"smbios1,omitempty"`
+	SpiceEnhancements    *CustomSpiceEnhancements        `json:"spice_enhancements,omitempty"`
+	StartDate            *string                         `json:"startdate,omitempty"`
+	StartOnBoot          *types.CustomBool               `json:"onboot,omitempty"`
+	StartupOrder         *CustomStartupOrder             `json:"startup,omitempty"`
+	TabletDeviceEnabled  *types.CustomBool               `json:"tablet,omitempty"`
+	Tags                 *string                         `json:"tags,omitempty"`
+	Template             *types.CustomBool               `json:"template,omitempty"`
+	TimeDriftFixEnabled  *types.CustomBool               `json:"tdf,omitempty"`
+	USBDevices           *CustomUSBDevices               `json:"usb,omitempty"`
+	VGADevice            *CustomVGADevice                `json:"vga,omitempty"`
+	VirtualCPUCount      *int                            `json:"vcpus,omitempty"`
+	VirtualIODevice0     *CustomStorageDevice            `json:"virtio0,omitempty"`
+	VirtualIODevice1     *CustomStorageDevice            `json:"virtio1,omitempty"`
+	VirtualIODevice2     *CustomStorageDevice            `json:"virtio2,omitempty"`
+	VirtualIODevice3     *CustomStorageDevice            `json:"virtio3,omitempty"`
+	VirtualIODevice4     *CustomStorageDevice            `json:"virtio4,omitempty"`
+	VirtualIODevice5     *CustomStorageDevice            `json:"virtio5,omitempty"`
+	VirtualIODevice6     *CustomStorageDevice            `json:"virtio6,omitempty"`
+	VirtualIODevice7     *CustomStorageDevice            `json:"virtio7,omitempty"`
+	VirtualIODevice8     *CustomStorageDevice            `json:"virtio8,omitempty"`
+	VirtualIODevice9     *CustomStorageDevice            `json:"virtio9,omitempty"`
+	VirtualIODevice10    *CustomStorageDevice            `json:"virtio10,omitempty"`
+	VirtualIODevice11    *CustomStorageDevice            `json:"virtio11,omitempty"`
+	VirtualIODevice12    *CustomStorageDevice            `json:"virtio12,omitempty"`
+	VirtualIODevice13    *CustomStorageDevice            `json:"virtio13,omitempty"`
+	VirtualIODevice14    *CustomStorageDevice            `json:"virtio14,omitempty"`
+	VirtualIODevice15    *CustomStorageDevice            `json:"virtio15,omitempty"`
+	VMGenerationID       *string                         `json:"vmgenid,omitempty"`
+	VMStateDatastoreID   *string                         `json:"vmstatestorage,omitempty"`
+	WatchdogDevice       *CustomWatchdogDevice           `json:"watchdog,omitempty"`
 }
 
 // GetStatusResponseBody contains the body from a VM get status response.
@@ -498,19 +498,19 @@ type GetStatusResponseBody struct {
 
 // GetStatusResponseData contains the data from a VM get status response.
 type GetStatusResponseData struct {
-	AgentEnabled     *types2.CustomBool `json:"agent,omitempty"`
-	CPUCount         *float64           `json:"cpus,omitempty"`
-	Lock             *string            `json:"lock,omitempty"`
-	MemoryAllocation *int               `json:"maxmem,omitempty"`
-	Name             *string            `json:"name,omitempty"`
-	PID              *int               `json:"pid,omitempty"`
-	QMPStatus        *string            `json:"qmpstatus,omitempty"`
-	RootDiskSize     *int               `json:"maxdisk,omitempty"`
-	SpiceSupport     *types2.CustomBool `json:"spice,omitempty"`
-	Status           string             `json:"status,omitempty"`
-	Tags             *string            `json:"tags,omitempty"`
-	Uptime           *int               `json:"uptime,omitempty"`
-	VMID             *int               `json:"vmid,omitempty"`
+	AgentEnabled     *types.CustomBool `json:"agent,omitempty"`
+	CPUCount         *float64          `json:"cpus,omitempty"`
+	Lock             *string           `json:"lock,omitempty"`
+	MemoryAllocation *int              `json:"maxmem,omitempty"`
+	Name             *string           `json:"name,omitempty"`
+	PID              *int              `json:"pid,omitempty"`
+	QMPStatus        *string           `json:"qmpstatus,omitempty"`
+	RootDiskSize     *int              `json:"maxdisk,omitempty"`
+	SpiceSupport     *types.CustomBool `json:"spice,omitempty"`
+	Status           string            `json:"status,omitempty"`
+	Tags             *string           `json:"tags,omitempty"`
+	Uptime           *int              `json:"uptime,omitempty"`
+	VMID             *int              `json:"vmid,omitempty"`
 }
 
 // ListResponseBody contains the body from a virtual machine list response.
@@ -527,10 +527,10 @@ type ListResponseData struct {
 
 // MigrateRequestBody contains the body for a VM migration request.
 type MigrateRequestBody struct {
-	OnlineMigration *types2.CustomBool `json:"online,omitempty"           url:"online,omitempty,int"`
-	TargetNode      string             `json:"target"                     url:"target"`
-	TargetStorage   *string            `json:"targetstorage,omitempty"    url:"targetstorage,omitempty"`
-	WithLocalDisks  *types2.CustomBool `json:"with-local-disks,omitempty" url:"with-local-disks,omitempty,int"`
+	OnlineMigration *types.CustomBool `json:"online,omitempty"           url:"online,omitempty,int"`
+	TargetNode      string            `json:"target"                     url:"target"`
+	TargetStorage   *string           `json:"targetstorage,omitempty"    url:"targetstorage,omitempty"`
+	WithLocalDisks  *types.CustomBool `json:"with-local-disks,omitempty" url:"with-local-disks,omitempty,int"`
 }
 
 // MigrateResponseBody contains the body from a VM migrate response.
@@ -540,12 +540,12 @@ type MigrateResponseBody struct {
 
 // MoveDiskRequestBody contains the body for a VM move disk request.
 type MoveDiskRequestBody struct {
-	BandwidthLimit      *int               `json:"bwlimit,omitempty" url:"bwlimit,omitempty"`
-	DeleteOriginalDisk  *types2.CustomBool `json:"delete,omitempty"  url:"delete,omitempty,int"`
-	Digest              *string            `json:"digest,omitempty"  url:"digest,omitempty"`
-	Disk                string             `json:"disk"              url:"disk"`
-	TargetStorage       string             `json:"storage"           url:"storage"`
-	TargetStorageFormat *string            `json:"format,omitempty"  url:"format,omitempty"`
+	BandwidthLimit      *int              `json:"bwlimit,omitempty" url:"bwlimit,omitempty"`
+	DeleteOriginalDisk  *types.CustomBool `json:"delete,omitempty"  url:"delete,omitempty,int"`
+	Digest              *string           `json:"digest,omitempty"  url:"digest,omitempty"`
+	Disk                string            `json:"disk"              url:"disk"`
+	TargetStorage       string            `json:"storage"           url:"storage"`
+	TargetStorageFormat *string           `json:"format,omitempty"  url:"format,omitempty"`
 }
 
 // MoveDiskResponseBody contains the body from a VM move disk response.
@@ -565,18 +565,18 @@ type RebootResponseBody struct {
 
 // ResizeDiskRequestBody contains the body for a VM resize disk request.
 type ResizeDiskRequestBody struct {
-	Digest   *string            `json:"digest,omitempty"   url:"digest,omitempty"`
-	Disk     string             `json:"disk"               url:"disk"`
-	Size     types2.DiskSize    `json:"size"               url:"size"`
-	SkipLock *types2.CustomBool `json:"skiplock,omitempty" url:"skiplock,omitempty,int"`
+	Digest   *string           `json:"digest,omitempty"   url:"digest,omitempty"`
+	Disk     string            `json:"disk"               url:"disk"`
+	Size     types.DiskSize    `json:"size"               url:"size"`
+	SkipLock *types.CustomBool `json:"skiplock,omitempty" url:"skiplock,omitempty,int"`
 }
 
 // ShutdownRequestBody contains the body for a VM shutdown request.
 type ShutdownRequestBody struct {
-	ForceStop  *types2.CustomBool `json:"forceStop,omitempty"  url:"forceStop,omitempty,int"`
-	KeepActive *types2.CustomBool `json:"keepActive,omitempty" url:"keepActive,omitempty,int"`
-	SkipLock   *types2.CustomBool `json:"skipLock,omitempty"   url:"skipLock,omitempty,int"`
-	Timeout    *int               `json:"timeout,omitempty"    url:"timeout,omitempty"`
+	ForceStop  *types.CustomBool `json:"forceStop,omitempty"  url:"forceStop,omitempty,int"`
+	KeepActive *types.CustomBool `json:"keepActive,omitempty" url:"keepActive,omitempty,int"`
+	SkipLock   *types.CustomBool `json:"skipLock,omitempty"   url:"skipLock,omitempty,int"`
+	Timeout    *int              `json:"timeout,omitempty"    url:"timeout,omitempty"`
 }
 
 // ShutdownResponseBody contains the body from a VM shutdown response.
@@ -1292,15 +1292,15 @@ func (r *CustomAgent) UnmarshalJSON(b []byte) error {
 		v := strings.Split(strings.TrimSpace(p), "=")
 
 		if len(v) == 1 {
-			enabled := types2.CustomBool(v[0] == "1")
+			enabled := types.CustomBool(v[0] == "1")
 			r.Enabled = &enabled
 		} else if len(v) == 2 {
 			switch v[0] {
 			case "enabled":
-				enabled := types2.CustomBool(v[1] == "1")
+				enabled := types.CustomBool(v[1] == "1")
 				r.Enabled = &enabled
 			case "fstrim_cloned_disks":
-				fstrim := types2.CustomBool(v[1] == "1")
+				fstrim := types.CustomBool(v[1] == "1")
 				r.TrimClonedDisks = &fstrim
 			case "type":
 				r.Type = &v[1]
@@ -1475,7 +1475,7 @@ func (r *CustomCPUEmulation) UnmarshalJSON(b []byte) error {
 					r.Flags = &f
 				}
 			case "hidden":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.Hidden = &bv
 			case "hv-vendor-id":
 				r.HVVendorID = &v[1]
@@ -1513,7 +1513,7 @@ func (r *CustomEFIDisk) UnmarshalJSON(b []byte) error {
 				t := strings.ToLower(v[1])
 				r.Type = &t
 			case "pre-enrolled-keys":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.PreEnrolledKeys = &bv
 			}
 		}
@@ -1541,10 +1541,10 @@ func (r *CustomNetworkDevice) UnmarshalJSON(b []byte) error {
 			case "bridge":
 				r.Bridge = &v[1]
 			case "firewall":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.Firewall = &bv
 			case "link_down":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.LinkDown = &bv
 			case "macaddr":
 				r.MACAddress = &v[1]
@@ -1629,15 +1629,15 @@ func (r *CustomPCIDevice) UnmarshalJSON(b []byte) error {
 			case "mdev":
 				r.MDev = &v[1]
 			case "pcie":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.PCIExpress = &bv
 			case "rombar":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.ROMBAR = &bv
 			case "romfile":
 				r.ROMFile = &v[1]
 			case "x-vga":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.XVGA = &bv
 			}
 		}
@@ -1693,7 +1693,7 @@ func (r *CustomSMBIOS) UnmarshalJSON(b []byte) error {
 		if len(v) == 2 {
 			switch v[0] {
 			case "base64":
-				base64 := types2.CustomBool(v[1] == "1")
+				base64 := types.CustomBool(v[1] == "1")
 				r.Base64 = &base64
 			case "family":
 				r.Family = &v[1]
@@ -1787,7 +1787,7 @@ func (r *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 				r.AIO = &v[1]
 
 			case "backup":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.BackupEnabled = &bv
 
 			case "file":
@@ -1825,7 +1825,7 @@ func (r *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 				r.Media = &v[1]
 
 			case "size":
-				r.Size = new(types2.DiskSize)
+				r.Size = new(types.DiskSize)
 				err := r.Size.UnmarshalJSON([]byte(v[1]))
 				if err != nil {
 					return fmt.Errorf("failed to unmarshal disk size: %w", err)
@@ -1835,11 +1835,11 @@ func (r *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 				r.Format = &v[1]
 
 			case "iothread":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.IOThread = &bv
 
 			case "ssd":
-				bv := types2.CustomBool(v[1] == "1")
+				bv := types.CustomBool(v[1] == "1")
 				r.SSD = &bv
 
 			case "discard":

--- a/proxmox/nodes/vms/vms_types_test.go
+++ b/proxmox/nodes/vms/vms_types_test.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	types2 "github.com/bpg/terraform-provider-proxmox/proxmox/types"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 )
 
 func TestCustomStorageDevice_UnmarshalJSON(t *testing.T) {
 	t.Parallel()
 
-	ds8gig := types2.DiskSizeFromGigabytes(8)
+	ds8gig := types.DiskSizeFromGigabytes(8)
 	tests := []struct {
 		name    string
 		line    string
@@ -28,26 +28,26 @@ func TestCustomStorageDevice_UnmarshalJSON(t *testing.T) {
 			name: "simple volume",
 			line: `"local-lvm:vm-2041-disk-0,discard=on,ssd=1,iothread=1,size=8G,cache=writeback"`,
 			want: &CustomStorageDevice{
-				Cache:      types2.StrPtr("writeback"),
-				Discard:    types2.StrPtr("on"),
+				Cache:      types.StrPtr("writeback"),
+				Discard:    types.StrPtr("on"),
 				Enabled:    true,
 				FileVolume: "local-lvm:vm-2041-disk-0",
-				IOThread:   types2.BoolPtr(true),
+				IOThread:   types.BoolPtr(true),
 				Size:       &ds8gig,
-				SSD:        types2.BoolPtr(true),
+				SSD:        types.BoolPtr(true),
 			},
 		},
 		{
 			name: "raw volume type",
 			line: `"nfs:2041/vm-2041-disk-0.raw,discard=ignore,ssd=1,iothread=1,size=8G"`,
 			want: &CustomStorageDevice{
-				Discard:    types2.StrPtr("ignore"),
+				Discard:    types.StrPtr("ignore"),
 				Enabled:    true,
 				FileVolume: "nfs:2041/vm-2041-disk-0.raw",
-				Format:     types2.StrPtr("raw"),
-				IOThread:   types2.BoolPtr(true),
+				Format:     types.StrPtr("raw"),
+				IOThread:   types.BoolPtr(true),
 				Size:       &ds8gig,
-				SSD:        types2.BoolPtr(true),
+				SSD:        types.BoolPtr(true),
 			},
 		},
 	}
@@ -80,10 +80,10 @@ func TestCustomPCIDevice_UnmarshalJSON(t *testing.T) {
 			want: &CustomPCIDevice{
 				DeviceIDs:  &[]string{"0000:81:00.2"},
 				MDev:       nil,
-				PCIExpress: types2.BoolPtr(false),
-				ROMBAR:     types2.BoolPtr(true),
+				PCIExpress: types.BoolPtr(false),
+				ROMBAR:     types.BoolPtr(true),
 				ROMFile:    nil,
-				XVGA:       types2.BoolPtr(false),
+				XVGA:       types.BoolPtr(false),
 			},
 		},
 		{
@@ -92,10 +92,10 @@ func TestCustomPCIDevice_UnmarshalJSON(t *testing.T) {
 			want: &CustomPCIDevice{
 				DeviceIDs:  &[]string{"81:00.4"},
 				MDev:       nil,
-				PCIExpress: types2.BoolPtr(false),
-				ROMBAR:     types2.BoolPtr(true),
+				PCIExpress: types.BoolPtr(false),
+				ROMBAR:     types.BoolPtr(true),
 				ROMFile:    nil,
-				XVGA:       types2.BoolPtr(false),
+				XVGA:       types.BoolPtr(false),
 			},
 		},
 		{
@@ -103,12 +103,12 @@ func TestCustomPCIDevice_UnmarshalJSON(t *testing.T) {
 			line: `"mapping=mappeddevice,pcie=0,rombar=1,x-vga=0"`,
 			want: &CustomPCIDevice{
 				DeviceIDs:  nil,
-				Mapping:    types2.StrPtr("mappeddevice"),
+				Mapping:    types.StrPtr("mappeddevice"),
 				MDev:       nil,
-				PCIExpress: types2.BoolPtr(false),
-				ROMBAR:     types2.BoolPtr(true),
+				PCIExpress: types.BoolPtr(false),
+				ROMBAR:     types.BoolPtr(true),
 				ROMFile:    nil,
-				XVGA:       types2.BoolPtr(false),
+				XVGA:       types.BoolPtr(false),
 			},
 		},
 	}

--- a/proxmoxtf/resource/container.go
+++ b/proxmoxtf/resource/container.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/containers"
-	types2 "github.com/bpg/terraform-provider-proxmox/proxmox/types"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/validator"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/structure"
@@ -821,7 +821,7 @@ func containerCreateClone(ctx context.Context, d *schema.ResourceData, m interfa
 		vmID = *vmIDNew
 	}
 
-	fullCopy := types2.CustomBool(true)
+	fullCopy := types.CustomBool(true)
 
 	cloneBody := &containers.CloneRequestBody{
 		FullCopy: &fullCopy,
@@ -874,7 +874,7 @@ func containerCreateClone(ctx context.Context, d *schema.ResourceData, m interfa
 	if len(console) > 0 {
 		consoleBlock := console[0].(map[string]interface{})
 
-		consoleEnabled := types2.CustomBool(
+		consoleEnabled := types.CustomBool(
 			consoleBlock[mkResourceVirtualEnvironmentContainerConsoleEnabled].(bool),
 		)
 		consoleMode := consoleBlock[mkResourceVirtualEnvironmentContainerConsoleMode].(string)
@@ -1029,7 +1029,7 @@ func containerCreateClone(ctx context.Context, d *schema.ResourceData, m interfa
 
 		bridge := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceBridge].(string)
 		enabled := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceEnabled].(bool)
-		firewall := types2.CustomBool(
+		firewall := types.CustomBool(
 			networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall].(bool),
 		)
 		macAddress := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceMACAddress].(string)
@@ -1113,7 +1113,7 @@ func containerCreateClone(ctx context.Context, d *schema.ResourceData, m interfa
 		updateBody.Tags = &tagString
 	}
 
-	template := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentContainerTemplate).(bool))
+	template := types.CustomBool(d.Get(mkResourceVirtualEnvironmentContainerTemplate).(bool))
 
 	//nolint:gosimple
 	if template != dvResourceVirtualEnvironmentContainerTemplate {
@@ -1155,7 +1155,7 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m interf
 		return diag.FromErr(err)
 	}
 
-	consoleEnabled := types2.CustomBool(
+	consoleEnabled := types.CustomBool(
 		consoleBlock[mkResourceVirtualEnvironmentContainerConsoleEnabled].(bool),
 	)
 	consoleMode := consoleBlock[mkResourceVirtualEnvironmentContainerConsoleMode].(string)
@@ -1213,9 +1213,9 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m interf
 		return diag.FromErr(err)
 	}
 
-	nesting := types2.CustomBool(featuresBlock[mkResourceVirtualEnvironmentContainerFeaturesNesting].(bool))
-	keyctl := types2.CustomBool(featuresBlock[mkResourceVirtualEnvironmentContainerFeaturesKeyControl].(bool))
-	fuse := types2.CustomBool(featuresBlock[mkResourceVirtualEnvironmentContainerFeaturesFUSE].(bool))
+	nesting := types.CustomBool(featuresBlock[mkResourceVirtualEnvironmentContainerFeaturesNesting].(bool))
+	keyctl := types.CustomBool(featuresBlock[mkResourceVirtualEnvironmentContainerFeaturesKeyControl].(bool))
+	fuse := types.CustomBool(featuresBlock[mkResourceVirtualEnvironmentContainerFeaturesFUSE].(bool))
 
 	features := containers.CustomFeatures{
 		Nesting:    &nesting,
@@ -1329,14 +1329,14 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m interf
 		mountPointMap := mp.(map[string]interface{})
 		mountPointObject := containers.CustomMountPoint{}
 
-		acl := types2.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointACL].(bool))
-		backup := types2.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointBackup].(bool))
+		acl := types.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointACL].(bool))
+		backup := types.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointBackup].(bool))
 		mountOptions := mountPointMap[mkResourceVirtualEnvironmentContainerMountPointMountOptions].([]interface{})
 		path := mountPointMap[mkResourceVirtualEnvironmentContainerMountPointPath].(string)
-		quota := types2.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointQuota].(bool))
-		readOnly := types2.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointReadOnly].(bool))
-		replicate := types2.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointReplicate].(bool))
-		shared := types2.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointShared].(bool))
+		quota := types.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointQuota].(bool))
+		readOnly := types.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointReadOnly].(bool))
+		replicate := types.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointReplicate].(bool))
+		shared := types.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointShared].(bool))
 		size := mountPointMap[mkResourceVirtualEnvironmentContainerMountPointSize].(string)
 		volume := mountPointMap[mkResourceVirtualEnvironmentContainerMountPointVolume].(string)
 
@@ -1349,9 +1349,9 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m interf
 		mountPointObject.Shared = &shared
 
 		if len(size) > 0 {
-			var ds types2.DiskSize
+			var ds types.DiskSize
 
-			ds, err = types2.ParseDiskSize(size)
+			ds, err = types.ParseDiskSize(size)
 			if err != nil {
 				return diag.Errorf("invalid disk size: %s", err.Error())
 			}
@@ -1447,10 +1447,10 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m interf
 	operatingSystemType := operatingSystemBlock[mkResourceVirtualEnvironmentContainerOperatingSystemType].(string)
 
 	poolID := d.Get(mkResourceVirtualEnvironmentContainerPoolID).(string)
-	started := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentContainerStarted).(bool))
+	started := types.CustomBool(d.Get(mkResourceVirtualEnvironmentContainerStarted).(bool))
 	tags := d.Get(mkResourceVirtualEnvironmentContainerTags).([]interface{})
-	template := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentContainerTemplate).(bool))
-	unprivileged := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentContainerUnprivileged).(bool))
+	template := types.CustomBool(d.Get(mkResourceVirtualEnvironmentContainerTemplate).(bool))
+	unprivileged := types.CustomBool(d.Get(mkResourceVirtualEnvironmentContainerUnprivileged).(bool))
 	vmID := d.Get(mkResourceVirtualEnvironmentContainerVMID).(int)
 
 	if vmID == -1 {
@@ -1775,7 +1775,7 @@ func containerRead(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		}
 	} else if len(currentConsole) > 0 ||
 		//nolint:lll
-		console[mkResourceVirtualEnvironmentContainerConsoleEnabled] != types2.CustomBool(dvResourceVirtualEnvironmentContainerConsoleEnabled) ||
+		console[mkResourceVirtualEnvironmentContainerConsoleEnabled] != types.CustomBool(dvResourceVirtualEnvironmentContainerConsoleEnabled) ||
 		console[mkResourceVirtualEnvironmentContainerConsoleMode] != dvResourceVirtualEnvironmentContainerConsoleMode ||
 		console[mkResourceVirtualEnvironmentContainerConsoleTTYCount] != dvResourceVirtualEnvironmentContainerConsoleTTYCount {
 		err := d.Set(mkResourceVirtualEnvironmentContainerConsole, []interface{}{console})
@@ -2291,7 +2291,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m interface{})
 	description := d.Get(mkResourceVirtualEnvironmentContainerDescription).(string)
 	updateBody.Description = &description
 
-	template := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentContainerTemplate).(bool))
+	template := types.CustomBool(d.Get(mkResourceVirtualEnvironmentContainerTemplate).(bool))
 
 	if d.HasChange(mkResourceVirtualEnvironmentContainerTemplate) {
 		updateBody.Template = &template
@@ -2310,7 +2310,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m interface{})
 			return diag.FromErr(err)
 		}
 
-		consoleEnabled := types2.CustomBool(
+		consoleEnabled := types.CustomBool(
 			consoleBlock[mkResourceVirtualEnvironmentContainerConsoleEnabled].(bool),
 		)
 		consoleMode := consoleBlock[mkResourceVirtualEnvironmentContainerConsoleMode].(string)
@@ -2454,14 +2454,14 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m interface{})
 			mountPointMap := mp.(map[string]interface{})
 			mountPointObject := containers.CustomMountPoint{}
 
-			acl := types2.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointACL].(bool))
-			backup := types2.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointBackup].(bool))
+			acl := types.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointACL].(bool))
+			backup := types.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointBackup].(bool))
 			mountOptions := mountPointMap[mkResourceVirtualEnvironmentContainerMountPointMountOptions].([]interface{})
 			path := mountPointMap[mkResourceVirtualEnvironmentContainerMountPointPath].(string)
-			quota := types2.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointQuota].(bool))
-			readOnly := types2.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointReadOnly].(bool))
-			replicate := types2.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointReplicate].(bool))
-			shared := types2.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointShared].(bool))
+			quota := types.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointQuota].(bool))
+			readOnly := types.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointReadOnly].(bool))
+			replicate := types.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointReplicate].(bool))
+			shared := types.CustomBool(mountPointMap[mkResourceVirtualEnvironmentContainerMountPointShared].(bool))
 			volume := mountPointMap[mkResourceVirtualEnvironmentContainerMountPointVolume].(string)
 
 			mountPointObject.ACL = &acl
@@ -2515,7 +2515,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m interface{})
 
 			bridge := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceBridge].(string)
 			enabled := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceEnabled].(bool)
-			firewall := types2.CustomBool(
+			firewall := types.CustomBool(
 				networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall].(bool),
 			)
 			macAddress := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceMACAddress].(string)
@@ -2631,7 +2631,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m interface{})
 				return diag.FromErr(e)
 			}
 		} else {
-			forceStop := types2.CustomBool(true)
+			forceStop := types.CustomBool(true)
 			shutdownTimeout := 300
 
 			e = containerAPI.ShutdownContainer(ctx, &containers.ShutdownRequestBody{
@@ -2691,7 +2691,7 @@ func containerDelete(ctx context.Context, d *schema.ResourceData, m interface{})
 	}
 
 	if status.Status != "stopped" {
-		forceStop := types2.CustomBool(true)
+		forceStop := types.CustomBool(true)
 		shutdownTimeout := 300
 
 		err = containerAPI.ShutdownContainer(

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -28,7 +28,7 @@ import (
 	"github.com/bpg/terraform-provider-proxmox/proxmox/cluster"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/pools"
-	types2 "github.com/bpg/terraform-provider-proxmox/proxmox/types"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/validator"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/structure"
@@ -1619,7 +1619,7 @@ func vmStart(ctx context.Context, vmAPI *vms.Client, d *schema.ResourceData) dia
 func vmShutdown(ctx context.Context, vmAPI *vms.Client, d *schema.ResourceData) diag.Diagnostics {
 	tflog.Debug(ctx, "Shutting down VM")
 
-	forceStop := types2.CustomBool(true)
+	forceStop := types.CustomBool(true)
 	shutdownTimeout := d.Get(mkResourceVirtualEnvironmentVMTimeoutShutdownVM).(int)
 
 	e := vmAPI.ShutdownVM(ctx, &vms.ShutdownRequestBody{
@@ -1671,7 +1671,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		}
 	}
 
-	fullCopy := types2.CustomBool(cloneFull)
+	fullCopy := types.CustomBool(cloneFull)
 
 	cloneBody := &vms.CloneRequestBody{
 		FullCopy: &fullCopy,
@@ -1752,7 +1752,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 			}
 
 			// Migrate to target node
-			withLocalDisks := types2.CustomBool(true)
+			withLocalDisks := types.CustomBool(true)
 			migrateBody := &vms.MigrateRequestBody{
 				TargetNode:     nodeName,
 				WithLocalDisks: &withLocalDisks,
@@ -1786,7 +1786,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 	}
 
 	// Now that the virtual machine has been cloned, we need to perform some modifications.
-	acpi := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentVMACPI).(bool))
+	acpi := types.CustomBool(d.Get(mkResourceVirtualEnvironmentVMACPI).(bool))
 	agent := d.Get(mkResourceVirtualEnvironmentVMAgent).([]interface{})
 	audioDevices := vmGetAudioDeviceList(d)
 
@@ -1802,9 +1802,9 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 	networkDevice := d.Get(mkResourceVirtualEnvironmentVMNetworkDevice).([]interface{})
 	operatingSystem := d.Get(mkResourceVirtualEnvironmentVMOperatingSystem).([]interface{})
 	serialDevice := d.Get(mkResourceVirtualEnvironmentVMSerialDevice).([]interface{})
-	onBoot := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentVMOnBoot).(bool))
-	tabletDevice := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentVMTabletDevice).(bool))
-	template := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentVMTemplate).(bool))
+	onBoot := types.CustomBool(d.Get(mkResourceVirtualEnvironmentVMOnBoot).(bool))
+	tabletDevice := types.CustomBool(d.Get(mkResourceVirtualEnvironmentVMTabletDevice).(bool))
+	template := types.CustomBool(d.Get(mkResourceVirtualEnvironmentVMTemplate).(bool))
 	vga := d.Get(mkResourceVirtualEnvironmentVMVGA).([]interface{})
 
 	updateBody := &vms.UpdateRequestBody{
@@ -1823,10 +1823,10 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 	if len(agent) > 0 {
 		agentBlock := agent[0].(map[string]interface{})
 
-		agentEnabled := types2.CustomBool(
+		agentEnabled := types.CustomBool(
 			agentBlock[mkResourceVirtualEnvironmentVMAgentEnabled].(bool),
 		)
-		agentTrim := types2.CustomBool(agentBlock[mkResourceVirtualEnvironmentVMAgentTrim].(bool))
+		agentTrim := types.CustomBool(agentBlock[mkResourceVirtualEnvironmentVMAgentTrim].(bool))
 		agentType := agentBlock[mkResourceVirtualEnvironmentVMAgentType].(string)
 
 		updateBody.Agent = &vms.CustomAgent{
@@ -1892,7 +1892,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		cpuCores := cpuBlock[mkResourceVirtualEnvironmentVMCPUCores].(int)
 		cpuFlags := cpuBlock[mkResourceVirtualEnvironmentVMCPUFlags].([]interface{})
 		cpuHotplugged := cpuBlock[mkResourceVirtualEnvironmentVMCPUHotplugged].(int)
-		cpuNUMA := types2.CustomBool(cpuBlock[mkResourceVirtualEnvironmentVMCPUNUMA].(bool))
+		cpuNUMA := types.CustomBool(cpuBlock[mkResourceVirtualEnvironmentVMCPUNUMA].(bool))
 		cpuSockets := cpuBlock[mkResourceVirtualEnvironmentVMCPUSockets].(int)
 		cpuType := cpuBlock[mkResourceVirtualEnvironmentVMCPUType].(string)
 		cpuUnits := cpuBlock[mkResourceVirtualEnvironmentVMCPUUnits].(int)
@@ -2127,7 +2127,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 			)
 		}
 
-		deleteOriginalDisk := types2.CustomBool(true)
+		deleteOriginalDisk := types.CustomBool(true)
 
 		diskMoveBody := &vms.MoveDiskRequestBody{
 			DeleteOriginalDisk: &deleteOriginalDisk,
@@ -2137,7 +2137,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 
 		diskResizeBody := &vms.ResizeDiskRequestBody{
 			Disk: diskInterface,
-			Size: types2.DiskSizeFromGigabytes(diskSize),
+			Size: types.DiskSizeFromGigabytes(diskSize),
 		}
 
 		moveDisk := false
@@ -2198,7 +2198,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 			)
 		}
 
-		deleteOriginalDisk := types2.CustomBool(true)
+		deleteOriginalDisk := types.CustomBool(true)
 
 		diskMoveBody := &vms.MoveDiskRequestBody{
 			DeleteOriginalDisk: &deleteOriginalDisk,
@@ -2239,7 +2239,7 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 
 	resource := VM()
 
-	acpi := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentVMACPI).(bool))
+	acpi := types.CustomBool(d.Get(mkResourceVirtualEnvironmentVMACPI).(bool))
 
 	agentBlock, err := structure.GetSchemaBlock(
 		resource,
@@ -2252,10 +2252,10 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		return diag.FromErr(err)
 	}
 
-	agentEnabled := types2.CustomBool(
+	agentEnabled := types.CustomBool(
 		agentBlock[mkResourceVirtualEnvironmentVMAgentEnabled].(bool),
 	)
-	agentTrim := types2.CustomBool(agentBlock[mkResourceVirtualEnvironmentVMAgentTrim].(bool))
+	agentTrim := types.CustomBool(agentBlock[mkResourceVirtualEnvironmentVMAgentTrim].(bool))
 	agentType := agentBlock[mkResourceVirtualEnvironmentVMAgentType].(string)
 
 	kvmArguments := d.Get(mkResourceVirtualEnvironmentVMKVMArguments).(string)
@@ -2303,7 +2303,7 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 	cpuFlags := cpuBlock[mkResourceVirtualEnvironmentVMCPUFlags].([]interface{})
 	cpuHotplugged := cpuBlock[mkResourceVirtualEnvironmentVMCPUHotplugged].(int)
 	cpuSockets := cpuBlock[mkResourceVirtualEnvironmentVMCPUSockets].(int)
-	cpuNUMA := types2.CustomBool(cpuBlock[mkResourceVirtualEnvironmentVMCPUNUMA].(bool))
+	cpuNUMA := types.CustomBool(cpuBlock[mkResourceVirtualEnvironmentVMCPUNUMA].(bool))
 	cpuType := cpuBlock[mkResourceVirtualEnvironmentVMCPUType].(string)
 	cpuUnits := cpuBlock[mkResourceVirtualEnvironmentVMCPUUnits].(int)
 
@@ -2322,7 +2322,7 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		datastoreID, _ := block[mkResourceVirtualEnvironmentVMEFIDiskDatastoreID].(string)
 		fileFormat, _ := block[mkResourceVirtualEnvironmentVMEFIDiskFileFormat].(string)
 		efiType, _ := block[mkResourceVirtualEnvironmentVMEFIDiskType].(string)
-		preEnrolledKeys := types2.CustomBool(block[mkResourceVirtualEnvironmentVMEFIDiskPreEnrolledKeys].(bool))
+		preEnrolledKeys := types.CustomBool(block[mkResourceVirtualEnvironmentVMEFIDiskPreEnrolledKeys].(bool))
 
 		if fileFormat == "" {
 			fileFormat = dvResourceVirtualEnvironmentVMEFIDiskFileFormat
@@ -2404,9 +2404,9 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 
 	startupOrder := vmGetStartupOrder(d)
 
-	onBoot := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentVMOnBoot).(bool))
-	tabletDevice := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentVMTabletDevice).(bool))
-	template := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentVMTemplate).(bool))
+	onBoot := types.CustomBool(d.Get(mkResourceVirtualEnvironmentVMOnBoot).(bool))
+	tabletDevice := types.CustomBool(d.Get(mkResourceVirtualEnvironmentVMTabletDevice).(bool))
+	template := types.CustomBool(d.Get(mkResourceVirtualEnvironmentVMTemplate).(bool))
 
 	vgaDevice, err := vmGetVGADeviceObject(d)
 	if err != nil {
@@ -2633,8 +2633,8 @@ func vmCreateCustomDisks(ctx context.Context, d *schema.ResourceData, m interfac
 		size, _ := block[mkResourceVirtualEnvironmentVMDiskSize].(int)
 		speed := block[mkResourceVirtualEnvironmentVMDiskSpeed].([]interface{})
 		diskInterface, _ := block[mkResourceVirtualEnvironmentVMDiskInterface].(string)
-		ioThread := types2.CustomBool(block[mkResourceVirtualEnvironmentVMDiskIOThread].(bool))
-		ssd := types2.CustomBool(block[mkResourceVirtualEnvironmentVMDiskSSD].(bool))
+		ioThread := types.CustomBool(block[mkResourceVirtualEnvironmentVMDiskIOThread].(bool))
+		ssd := types.CustomBool(block[mkResourceVirtualEnvironmentVMDiskSSD].(bool))
 		discard, _ := block[mkResourceVirtualEnvironmentVMDiskDiscard].(string)
 		cache, _ := block[mkResourceVirtualEnvironmentVMDiskCache].(string)
 
@@ -2998,8 +2998,8 @@ func vmGetDiskDeviceObjects(
 		fileID, _ := block[mkResourceVirtualEnvironmentVMDiskFileID].(string)
 		size, _ := block[mkResourceVirtualEnvironmentVMDiskSize].(int)
 		diskInterface, _ := block[mkResourceVirtualEnvironmentVMDiskInterface].(string)
-		ioThread := types2.CustomBool(block[mkResourceVirtualEnvironmentVMDiskIOThread].(bool))
-		ssd := types2.CustomBool(block[mkResourceVirtualEnvironmentVMDiskSSD].(bool))
+		ioThread := types.CustomBool(block[mkResourceVirtualEnvironmentVMDiskIOThread].(bool))
+		ssd := types.CustomBool(block[mkResourceVirtualEnvironmentVMDiskSSD].(bool))
 		discard := block[mkResourceVirtualEnvironmentVMDiskDiscard].(string)
 		cache := block[mkResourceVirtualEnvironmentVMDiskCache].(string)
 
@@ -3027,7 +3027,7 @@ func vmGetDiskDeviceObjects(
 		diskDevice.Interface = &diskInterface
 		diskDevice.Format = &fileFormat
 		diskDevice.FileID = &fileID
-		diskSize := types2.DiskSizeFromGigabytes(size)
+		diskSize := types.DiskSizeFromGigabytes(size)
 		diskDevice.Size = &diskSize
 		diskDevice.SizeInt = &size
 		diskDevice.IOThread = &ioThread
@@ -3100,7 +3100,7 @@ func vmGetEfiDisk(d *schema.ResourceData, disk []interface{}) *vms.CustomEFIDisk
 		datastoreID, _ := block[mkResourceVirtualEnvironmentVMEFIDiskDatastoreID].(string)
 		fileFormat, _ := block[mkResourceVirtualEnvironmentVMEFIDiskFileFormat].(string)
 		efiType, _ := block[mkResourceVirtualEnvironmentVMEFIDiskType].(string)
-		preEnrolledKeys := types2.CustomBool(block[mkResourceVirtualEnvironmentVMEFIDiskPreEnrolledKeys].(bool))
+		preEnrolledKeys := types.CustomBool(block[mkResourceVirtualEnvironmentVMEFIDiskPreEnrolledKeys].(bool))
 
 		// special case for efi disk, the size is ignored, see docs for more info
 		efiDiskConfig.FileVolume = fmt.Sprintf("%s:1", datastoreID)
@@ -3131,7 +3131,7 @@ func vmGetEfiDiskAsStorageDevice(d *schema.ResourceData, disk []interface{}) (*v
 		}
 
 		if efiDisk.Type != nil {
-			ds, err := types2.ParseDiskSize(*efiDisk.Type)
+			ds, err := types.ParseDiskSize(*efiDisk.Type)
 			if err != nil {
 				return nil, fmt.Errorf("invalid efi disk type: %s", err.Error())
 			}
@@ -3154,12 +3154,12 @@ func vmGetHostPCIDeviceObjects(d *schema.ResourceData) vms.CustomPCIDevices {
 
 		ids, _ := block[mkResourceVirtualEnvironmentVMHostPCIDeviceID].(string)
 		mdev, _ := block[mkResourceVirtualEnvironmentVMHostPCIDeviceMDev].(string)
-		pcie := types2.CustomBool(block[mkResourceVirtualEnvironmentVMHostPCIDevicePCIE].(bool))
-		rombar := types2.CustomBool(
+		pcie := types.CustomBool(block[mkResourceVirtualEnvironmentVMHostPCIDevicePCIE].(bool))
+		rombar := types.CustomBool(
 			block[mkResourceVirtualEnvironmentVMHostPCIDeviceROMBAR].(bool),
 		)
 		romfile, _ := block[mkResourceVirtualEnvironmentVMHostPCIDeviceROMFile].(string)
-		xvga := types2.CustomBool(block[mkResourceVirtualEnvironmentVMHostPCIDeviceXVGA].(bool))
+		xvga := types.CustomBool(block[mkResourceVirtualEnvironmentVMHostPCIDeviceXVGA].(bool))
 		mapping, _ := block[mkResourceVirtualEnvironmentVMHostPCIDeviceMapping].(string)
 
 		device := vms.CustomPCIDevice{
@@ -3199,7 +3199,7 @@ func vmGetNetworkDeviceObjects(d *schema.ResourceData) vms.CustomNetworkDevices 
 
 		bridge := block[mkResourceVirtualEnvironmentVMNetworkDeviceBridge].(string)
 		enabled := block[mkResourceVirtualEnvironmentVMNetworkDeviceEnabled].(bool)
-		firewall := types2.CustomBool(block[mkResourceVirtualEnvironmentVMNetworkDeviceFirewall].(bool))
+		firewall := types.CustomBool(block[mkResourceVirtualEnvironmentVMNetworkDeviceFirewall].(bool))
 		macAddress := block[mkResourceVirtualEnvironmentVMNetworkDeviceMACAddress].(string)
 		model := block[mkResourceVirtualEnvironmentVMNetworkDeviceModel].(string)
 		rateLimit := block[mkResourceVirtualEnvironmentVMNetworkDeviceRateLimit].(float64)
@@ -3275,7 +3275,7 @@ func vmGetSMBIOS(d *schema.ResourceData) *vms.CustomSMBIOS {
 	//nolint:nestif
 	if len(smbiosSections) > 0 {
 		smbiosBlock := smbiosSections[0].(map[string]interface{})
-		b64 := types2.CustomBool(true)
+		b64 := types.CustomBool(true)
 		family, _ := smbiosBlock[mkResourceVirtualEnvironmentVMSMBIOSFamily].(string)
 		manufacturer, _ := smbiosBlock[mkResourceVirtualEnvironmentVMSMBIOSManufacturer].(string)
 		product, _ := smbiosBlock[mkResourceVirtualEnvironmentVMSMBIOSProduct].(string)
@@ -3323,7 +3323,7 @@ func vmGetSMBIOS(d *schema.ResourceData) *vms.CustomSMBIOS {
 		}
 
 		if smbios.UUID == nil || *smbios.UUID == "" {
-			smbios.UUID = types2.StrPtr(uuid.New().String())
+			smbios.UUID = types.StrPtr(uuid.New().String())
 		}
 
 		return &smbios
@@ -3405,7 +3405,7 @@ func vmGetVGADeviceObject(d *schema.ResourceData) (*vms.CustomVGADevice, error) 
 		return nil, err
 	}
 
-	vgaEnabled := types2.CustomBool(vgaBlock[mkResourceVirtualEnvironmentVMAgentEnabled].(bool))
+	vgaEnabled := types.CustomBool(vgaBlock[mkResourceVirtualEnvironmentVMAgentEnabled].(bool))
 	vgaMemory := vgaBlock[mkResourceVirtualEnvironmentVMVGAMemory].(int)
 	vgaType := vgaBlock[mkResourceVirtualEnvironmentVMVGAType].(string)
 
@@ -4857,12 +4857,12 @@ func vmUpdatePool(
 
 	oldPool := oldPoolValue.(string)
 	newPool := newPoolValue.(string)
-	vmList := (types2.CustomCommaSeparatedList)([]string{strconv.Itoa(vmID)})
+	vmList := (types.CustomCommaSeparatedList)([]string{strconv.Itoa(vmID)})
 
 	tflog.Debug(ctx, fmt.Sprintf("Moving VM %d from pool '%s' to pool '%s'", vmID, oldPool, newPool))
 
 	if oldPool != "" {
-		trueValue := types2.CustomBool(true)
+		trueValue := types.CustomBool(true)
 		poolUpdate := &pools.PoolUpdateRequestBody{
 			VMs:    &vmList,
 			Delete: &trueValue,
@@ -4914,7 +4914,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 		vmAPI := api.Node(oldNodeName).VM(vmID)
 
 		migrateTimeout := d.Get(mkResourceVirtualEnvironmentVMTimeoutMigrate).(int)
-		trueValue := types2.CustomBool(true)
+		trueValue := types.CustomBool(true)
 		migrateBody := &vms.MigrateRequestBody{
 			TargetNode:      nodeName,
 			WithLocalDisks:  &trueValue,
@@ -4958,7 +4958,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 
 	// Prepare the new primitive configuration values.
 	if d.HasChange(mkResourceVirtualEnvironmentVMACPI) {
-		acpi := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentVMACPI).(bool))
+		acpi := types.CustomBool(d.Get(mkResourceVirtualEnvironmentVMACPI).(bool))
 		updateBody.ACPI = &acpi
 		rebootRequired = true
 	}
@@ -4981,7 +4981,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 	}
 
 	if d.HasChange(mkResourceVirtualEnvironmentVMOnBoot) {
-		startOnBoot := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentVMOnBoot).(bool))
+		startOnBoot := types.CustomBool(d.Get(mkResourceVirtualEnvironmentVMOnBoot).(bool))
 		updateBody.StartOnBoot = &startOnBoot
 	}
 
@@ -5011,12 +5011,12 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 	}
 
 	if d.HasChange(mkResourceVirtualEnvironmentVMTabletDevice) {
-		tabletDevice := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentVMTabletDevice).(bool))
+		tabletDevice := types.CustomBool(d.Get(mkResourceVirtualEnvironmentVMTabletDevice).(bool))
 		updateBody.TabletDeviceEnabled = &tabletDevice
 		rebootRequired = true
 	}
 
-	template := types2.CustomBool(d.Get(mkResourceVirtualEnvironmentVMTemplate).(bool))
+	template := types.CustomBool(d.Get(mkResourceVirtualEnvironmentVMTemplate).(bool))
 
 	if d.HasChange(mkResourceVirtualEnvironmentVMTemplate) {
 		updateBody.Template = &template
@@ -5036,10 +5036,10 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 			return diag.FromErr(err)
 		}
 
-		agentEnabled := types2.CustomBool(
+		agentEnabled := types.CustomBool(
 			agentBlock[mkResourceVirtualEnvironmentVMAgentEnabled].(bool),
 		)
-		agentTrim := types2.CustomBool(agentBlock[mkResourceVirtualEnvironmentVMAgentTrim].(bool))
+		agentTrim := types.CustomBool(agentBlock[mkResourceVirtualEnvironmentVMAgentTrim].(bool))
 		agentType := agentBlock[mkResourceVirtualEnvironmentVMAgentType].(string)
 
 		updateBody.Agent = &vms.CustomAgent{
@@ -5151,7 +5151,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 		cpuCores := cpuBlock[mkResourceVirtualEnvironmentVMCPUCores].(int)
 		cpuFlags := cpuBlock[mkResourceVirtualEnvironmentVMCPUFlags].([]interface{})
 		cpuHotplugged := cpuBlock[mkResourceVirtualEnvironmentVMCPUHotplugged].(int)
-		cpuNUMA := types2.CustomBool(cpuBlock[mkResourceVirtualEnvironmentVMCPUNUMA].(bool))
+		cpuNUMA := types.CustomBool(cpuBlock[mkResourceVirtualEnvironmentVMCPUNUMA].(bool))
 		cpuSockets := cpuBlock[mkResourceVirtualEnvironmentVMCPUSockets].(int)
 		cpuType := cpuBlock[mkResourceVirtualEnvironmentVMCPUType].(string)
 		cpuUnits := cpuBlock[mkResourceVirtualEnvironmentVMCPUUnits].(int)
@@ -5568,7 +5568,7 @@ func vmUpdateDiskLocationAndSize(
 				}
 
 				if *oldDisk.ID != *diskNewEntries[prefix][oldKey].ID {
-					deleteOriginalDisk := types2.CustomBool(true)
+					deleteOriginalDisk := types.CustomBool(true)
 
 					diskMoveBodies = append(
 						diskMoveBodies,


### PR DESCRIPTION
They were accidentally added in #536

### Contributor's Note
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
