### PR TITLE
feat(file): add optional `overwrite` flag to the file resource

### DIFF
--- a/docs/resources/virtual_environment_file.md
+++ b/docs/resources/virtual_environment_file.md
@@ -65,6 +65,8 @@ EOF
     - `vztmpl`
 - `datastore_id` - (Required) The datastore id.
 - `node_name` - (Required) The node name.
+- `overwrite` - (Optional) Whether to overwrite an existing file (defaults to
+  `true`).
 - `source_file` - (Optional) The source file (conflicts with `source_raw`).
     - `checksum` - (Optional) The SHA256 checksum of the source file.
     - `file_name` - (Optional) The file name to use instead of the source file
@@ -96,19 +98,22 @@ You must ensure that you have at least `Size-in-MB * 2 + 1` MB of storage space
 available (twice the size plus overhead because a multipart payload needs to be
 created as another temporary file).
 
-If the specified file already exists, the resource will unconditionally replace
-it and take ownership of the resource. On destruction, the file will be deleted
-as if it did not exist before.
+By default, if the specified file already exists, the resource will
+unconditionally replace it and take ownership of the resource. On destruction,
+the file will be deleted as if it did not exist before. If you want to prevent
+the resource from replacing the file, set `overwrite` to `false`.
 
 ## Import
 
 Instances can be imported using the `node_name`, `datastore_id`, `content_type`
 and the `file_name` in the following format:
+
 ```
 <node_name>:<datastore_id>/<content_type>/<file_name>
 ```
 
 Example:
+
 ```bash
 $ terraform import proxmox_virtual_environment_file.cloud_config pve/local:snippets/example.cloud-config.yaml
 ```

--- a/fwprovider/tests/resource_file_test.go
+++ b/fwprovider/tests/resource_file_test.go
@@ -42,11 +42,11 @@ func TestAccResourceFile(t *testing.T) {
 			// 	ImportStateIdPrefix: "local:snippets/",
 			// 	ImportStateId:       fmt.Sprintf("local:snippets/%s", snippet),
 			// },
-			// // Update testing
-			// {
-			// 	Config: testAccResourceLinuxVLANUpdatedConfig(iface, vlan1, ipV4cidr),
-			// 	Check:  testAccResourceLinuxVLANUpdatedCheck(iface, vlan1, ipV4cidr),
-			// },
+			// Update testing
+			{
+				Config: testAccResourceFileUpdatedConfig(snippet),
+				Check:  testAccResourceFileUpdatedCheck(snippet),
+			},
 		},
 	})
 }
@@ -74,6 +74,35 @@ func testAccResourceFileCreatedCheck(fname string) resource.TestCheckFunc {
 		resource.TestCheckResourceAttr(accTestFileName, "content_type", "snippets"),
 		// resource.TestCheckResourceAttr(accTestFileName, "file_name", fname),
 		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.file_name", fname),
+		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.data", "test snippet\n"),
 		resource.TestCheckResourceAttr(accTestFileName, "id", fmt.Sprintf("local:snippets/%s", fname)),
+	)
+}
+
+func testAccResourceFileUpdatedConfig(fname string) string {
+	return fmt.Sprintf(`
+resource "proxmox_virtual_environment_file" "test" {
+  content_type = "snippets"
+  datastore_id = "local"
+  node_name    = "%s"
+
+  source_raw {
+    data = <<EOF
+test snippet - updated
+    EOF
+
+    file_name = "%s-upd"
+  }
+}
+	`, accTestNodeName, fname)
+}
+
+func testAccResourceFileUpdatedCheck(fname string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(accTestFileName, "content_type", "snippets"),
+		// resource.TestCheckResourceAttr(accTestFileName, "file_name", fname),
+		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.file_name", fname+"-upd"),
+		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.data", "test snippet - updated\n"),
+		resource.TestCheckResourceAttr(accTestFileName, "id", fmt.Sprintf("local:snippets/%s-upd", fname)),
 	)
 }

--- a/fwprovider/tests/resource_file_test.go
+++ b/fwprovider/tests/resource_file_test.go
@@ -62,9 +62,10 @@ func TestAccResourceFile(t *testing.T) {
 				// RefreshState: true,
 			},
 			{
-				Config:  testAccResourceFileCreatedConfig(snippetFile.Name()),
-				Check:   testAccResourceFileCreatedCheck("snippets", snippetFile.Name()),
-				Destroy: false,
+				Config:                    testAccResourceFileCreatedConfig(snippetFile.Name()),
+				Check:                     testAccResourceFileCreatedCheck("snippets", snippetFile.Name()),
+				Destroy:                   false,
+				PreventPostDestroyRefresh: true,
 			},
 			{
 				Config: testAccResourceFileCreatedConfig(snippetURL),
@@ -79,12 +80,17 @@ func TestAccResourceFile(t *testing.T) {
 				ExpectError: regexp.MustCompile("please specify .* - not both"),
 			},
 			// // ImportState testing
-			// {
-			// 	ResourceName:      accTestFileName,
-			// 	ImportState:       true,
-			// 	ImportStateVerify: true,
-			// 	ImportStateId:     fmt.Sprintf("pve/local:snippets/%s", filepath.Base(snippetFile.Name())),
-			// },
+			{
+				ResourceName:      accTestFileName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("pve/local:snippets/%s", filepath.Base(snippetFile.Name())),
+				SkipFunc: func() (bool, error) {
+					// TODO: add a file to the snippets directory outside of terraform
+					// and then import it here
+					return true, nil
+				},
+			},
 			// Update testing
 			{
 				Config: testAccResourceFileSnippetRawUpdatedConfig(snippetRaw),

--- a/fwprovider/tests/resource_file_test.go
+++ b/fwprovider/tests/resource_file_test.go
@@ -1,0 +1,79 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const (
+	accTestFileName = "proxmox_virtual_environment_file.test"
+)
+
+func TestAccResourceFile(t *testing.T) {
+	t.Parallel()
+
+	accProviders := testAccMuxProviders(context.Background(), t)
+
+	snippet := fmt.Sprintf("snippet-%s.txt", gofakeit.Word())
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: accProviders,
+		Steps: []resource.TestStep{
+			// Upload a snippet file from a raw source
+			{
+				Config: testAccResourceFileCreatedConfig(snippet),
+				Check:  testAccResourceFileCreatedCheck(snippet),
+			},
+			// ImportState testing
+			// {
+			// 	ResourceName:        accTestFileName,
+			// 	ImportState:         true,
+			// 	ImportStateVerify:   true,
+			// 	ImportStateIdPrefix: "local:snippets/",
+			// 	ImportStateId:       fmt.Sprintf("local:snippets/%s", snippet),
+			// },
+			// // Update testing
+			// {
+			// 	Config: testAccResourceLinuxVLANUpdatedConfig(iface, vlan1, ipV4cidr),
+			// 	Check:  testAccResourceLinuxVLANUpdatedCheck(iface, vlan1, ipV4cidr),
+			// },
+		},
+	})
+}
+
+func testAccResourceFileCreatedConfig(fname string) string {
+	return fmt.Sprintf(`
+resource "proxmox_virtual_environment_file" "test" {
+  content_type = "snippets"
+  datastore_id = "local"
+  node_name    = "%s"
+
+  source_raw {
+    data = <<EOF
+test snippet
+    EOF
+
+    file_name = "%s"
+  }
+}
+	`, accTestNodeName, fname)
+}
+
+func testAccResourceFileCreatedCheck(fname string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(accTestFileName, "content_type", "snippets"),
+		// resource.TestCheckResourceAttr(accTestFileName, "file_name", fname),
+		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.file_name", fname),
+		resource.TestCheckResourceAttr(accTestFileName, "id", fmt.Sprintf("local:snippets/%s", fname)),
+	)
+}

--- a/fwprovider/tests/resource_file_test.go
+++ b/fwprovider/tests/resource_file_test.go
@@ -9,10 +9,14 @@ package tests
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -24,34 +28,73 @@ func TestAccResourceFile(t *testing.T) {
 
 	accProviders := testAccMuxProviders(context.Background(), t)
 
-	snippet := fmt.Sprintf("snippet-%s.txt", gofakeit.Word())
+	snippetRaw := fmt.Sprintf("snippet-raw-%s.txt", gofakeit.Word())
+	snippetURL := "https://raw.githubusercontent.com/yaml/yaml-test-suite/main/src/229Q.yaml"
+
+	snippetFile, err := os.CreateTemp("", "snippet-file-*.yaml")
+	require.NoError(t, err)
+
+	defer snippetFile.Close()
+
+	_, err = snippetFile.WriteString("test snippet - file\n")
+	require.NoError(t, err)
+
+	snippetFileISO, err := os.CreateTemp("", "snippet-file-*.iso")
+	require.NoError(t, err)
+
+	defer snippetFile.Close()
+
+	_, err = snippetFile.WriteString("pretend it is an ISO")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = os.Remove(snippetFile.Name())
+		_ = os.Remove(snippetFileISO.Name())
+	})
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: accProviders,
 		Steps: []resource.TestStep{
 			// Upload a snippet file from a raw source
 			{
-				Config: testAccResourceFileCreatedConfig(snippet),
-				Check:  testAccResourceFileCreatedCheck(snippet),
+				Config: testAccResourceFileSnippetRawCreatedConfig(snippetRaw),
+				Check:  testAccResourceFileSnippetRawCreatedCheck(snippetRaw),
+				// RefreshState: true,
 			},
-			// ImportState testing
+			{
+				Config:  testAccResourceFileCreatedConfig(snippetFile.Name()),
+				Check:   testAccResourceFileCreatedCheck("snippets", snippetFile.Name()),
+				Destroy: false,
+			},
+			{
+				Config: testAccResourceFileCreatedConfig(snippetURL),
+				Check:  testAccResourceFileCreatedCheck("snippets", snippetURL),
+			},
+			{
+				Config: testAccResourceFileCreatedConfig(snippetFileISO.Name()),
+				Check:  testAccResourceFileCreatedCheck("iso", snippetFileISO.Name()),
+			},
+			{
+				Config:      testAccResourceFileWrongSourceCreatedConfig(),
+				ExpectError: regexp.MustCompile("please specify .* - not both"),
+			},
+			// // ImportState testing
 			// {
-			// 	ResourceName:        accTestFileName,
-			// 	ImportState:         true,
-			// 	ImportStateVerify:   true,
-			// 	ImportStateIdPrefix: "local:snippets/",
-			// 	ImportStateId:       fmt.Sprintf("local:snippets/%s", snippet),
+			// 	ResourceName:      accTestFileName,
+			// 	ImportState:       true,
+			// 	ImportStateVerify: true,
+			// 	ImportStateId:     fmt.Sprintf("pve/local:snippets/%s", filepath.Base(snippetFile.Name())),
 			// },
 			// Update testing
 			{
-				Config: testAccResourceFileUpdatedConfig(snippet),
-				Check:  testAccResourceFileUpdatedCheck(snippet),
+				Config: testAccResourceFileSnippetRawUpdatedConfig(snippetRaw),
+				Check:  testAccResourceFileSnippetUpdatedCheck(snippetRaw),
 			},
 		},
 	})
 }
 
-func testAccResourceFileCreatedConfig(fname string) string {
+func testAccResourceFileSnippetRawCreatedConfig(fname string) string {
 	return fmt.Sprintf(`
 resource "proxmox_virtual_environment_file" "test" {
   content_type = "snippets"
@@ -69,17 +112,57 @@ test snippet
 	`, accTestNodeName, fname)
 }
 
-func testAccResourceFileCreatedCheck(fname string) resource.TestCheckFunc {
+func testAccResourceFileCreatedConfig(fname string) string {
+	return fmt.Sprintf(`
+resource "proxmox_virtual_environment_file" "test" {
+  datastore_id = "local"
+  node_name    = "%s"
+
+  source_file {
+    path = "%s"
+  }
+}
+	`, accTestNodeName, fname)
+}
+
+func testAccResourceFileWrongSourceCreatedConfig() string {
+	return fmt.Sprintf(`
+resource "proxmox_virtual_environment_file" "test" {
+  datastore_id = "local"
+  node_name    = "%s"
+
+  source_raw {
+    data = <<EOF
+test snippet
+    EOF
+	file_name = "foo.txt"
+  }
+  source_file {
+    path = "bar.txt"
+  }
+}
+	`, accTestNodeName)
+}
+
+func testAccResourceFileSnippetRawCreatedCheck(fname string) resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(accTestFileName, "content_type", "snippets"),
-		// resource.TestCheckResourceAttr(accTestFileName, "file_name", fname),
+		resource.TestCheckResourceAttr(accTestFileName, "file_name", fname),
 		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.file_name", fname),
 		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.data", "test snippet\n"),
 		resource.TestCheckResourceAttr(accTestFileName, "id", fmt.Sprintf("local:snippets/%s", fname)),
 	)
 }
 
-func testAccResourceFileUpdatedConfig(fname string) string {
+func testAccResourceFileCreatedCheck(ctype string, fname string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(accTestFileName, "content_type", ctype),
+		resource.TestCheckResourceAttr(accTestFileName, "file_name", filepath.Base(fname)),
+		resource.TestCheckResourceAttr(accTestFileName, "id", fmt.Sprintf("local:%s/%s", ctype, filepath.Base(fname))),
+	)
+}
+
+func testAccResourceFileSnippetRawUpdatedConfig(fname string) string {
 	return fmt.Sprintf(`
 resource "proxmox_virtual_environment_file" "test" {
   content_type = "snippets"
@@ -91,18 +174,18 @@ resource "proxmox_virtual_environment_file" "test" {
 test snippet - updated
     EOF
 
-    file_name = "%s-upd"
+    file_name = "%s"
   }
 }
 	`, accTestNodeName, fname)
 }
 
-func testAccResourceFileUpdatedCheck(fname string) resource.TestCheckFunc {
+func testAccResourceFileSnippetUpdatedCheck(fname string) resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(accTestFileName, "content_type", "snippets"),
 		// resource.TestCheckResourceAttr(accTestFileName, "file_name", fname),
-		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.file_name", fname+"-upd"),
+		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.file_name", fname),
 		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.data", "test snippet - updated\n"),
-		resource.TestCheckResourceAttr(accTestFileName, "id", fmt.Sprintf("local:snippets/%s-upd", fname)),
+		resource.TestCheckResourceAttr(accTestFileName, "id", fmt.Sprintf("local:snippets/%s", fname)),
 	)
 }

--- a/fwprovider/tests/resource_file_test.go
+++ b/fwprovider/tests/resource_file_test.go
@@ -48,10 +48,11 @@ func TestAccResourceFile(t *testing.T) {
 	snippetFile2 := createFile(t, "snippet-file-2-*.yaml", "test snippet 2 - file")
 	fileISO := createFile(t, "file-*.iso", "pretend it is an ISO")
 
-	uploadSnippetFile(t, snippetFile2)
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: accProviders,
+		PreCheck: func() {
+			uploadSnippetFile(t, snippetFile2)
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceFileSnippetRawCreatedConfig(snippetRaw),
@@ -259,7 +260,7 @@ test snippet - updated
 func testAccResourceFileSnippetUpdatedCheck(fname string) resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(accTestFileName, "content_type", "snippets"),
-		// resource.TestCheckResourceAttr(accTestFileName, "file_name", fname),
+		resource.TestCheckResourceAttr(accTestFileName, "file_name", fname),
 		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.file_name", fname),
 		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.data", "test snippet - updated\n"),
 		resource.TestCheckResourceAttr(accTestFileName, "id", fmt.Sprintf("local:snippets/%s", fname)),

--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -743,7 +743,7 @@ func fileRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 	}
 
 	if !found {
-		diags = append(diags, diag.Errorf("cannot read file %q after upload", d.Id())...)
+		diags = append(diags, diag.Errorf("no such file: %q", d.Id())...)
 		return diags
 	}
 


### PR DESCRIPTION
The new `overwrite` attribute acontrol over files overwrite in the `proxmox_virtual_environment_file` resource.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected. 

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

**By default**, `proxmox_virtual_environment_file` resource has `overwrite = true`, and if a file with the same name already exists in the target datastore, the provider will overwrite it with printing a warning in the console:
<img width="726" alt="Screenshot 2023-09-28 at 9 45 09 PM" src="https://github.com/bpg/terraform-provider-proxmox/assets/627562/98c4ff20-6f83-4511-8a9b-2bed7076cbf6">

If `overwrite = false`, the provider will throw an error:
<img width="745" alt="Screenshot 2023-09-28 at 9 40 55 PM" src="https://github.com/bpg/terraform-provider-proxmox/assets/627562/80f0be33-dc00-49b6-860d-f2063afc624c">

The file being overwritten can be any datastore file, including those deployed outside of the Terraform plan.

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #571

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
