### PR TITLE
fix(lxc): create container when authenticated with API token

### DIFF
--- a/proxmoxtf/resource/container.go
+++ b/proxmoxtf/resource/container.go
@@ -1226,10 +1226,18 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m interf
 	keyctl := types.CustomBool(featuresBlock[mkResourceVirtualEnvironmentContainerFeaturesKeyControl].(bool))
 	fuse := types.CustomBool(featuresBlock[mkResourceVirtualEnvironmentContainerFeaturesFUSE].(bool))
 
-	features := containers.CustomFeatures{
-		Nesting:    &nesting,
-		KeyControl: &keyctl,
-		FUSE:       &fuse,
+	features := containers.CustomFeatures{}
+
+	if nesting {
+		features.Nesting = &nesting
+	}
+
+	if keyctl {
+		features.KeyControl = &keyctl
+	}
+
+	if fuse {
+		features.FUSE = &fuse
 	}
 
 	initialization := d.Get(mkResourceVirtualEnvironmentContainerInitialization).([]interface{})
@@ -1567,12 +1575,7 @@ func containerCreateStart(ctx context.Context, d *schema.ResourceData, m interfa
 
 	containerAPI := api.Node(nodeName).Container(vmID)
 
-	// Start the container and wait for it to reach a running state before continuing.
-	err = containerAPI.StartContainer(ctx, 60)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
+	// A container was started by the create operation, so wait for it to be running.
 	err = containerAPI.WaitForContainerState(ctx, "running", 120, 5)
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
And also fix container startup behaviour: "error starting container ... - already running"

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected. 

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
<img width="1177" alt="Screenshot 2023-10-08 at 8 12 28 PM" src="https://github.com/bpg/terraform-provider-proxmox/assets/627562/668a575f-3aa1-4227-a769-ab51aec4399e">

Separately tested changing `started = true|false` in the initial template and at re-aplly 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #609 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
