### PR TITLE
fix(vm): better check for disk ownership

### DIFF
--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -224,7 +224,17 @@ func (r CustomStorageDevice) IsOwnedBy(vmID int) bool {
 		return false
 	}
 
-	return strings.HasPrefix(*pathInDatastore, fmt.Sprintf("vm-%d-", vmID))
+	// ZFS uses "local-zfs:vm-123-disk-0"
+	if strings.HasPrefix(*pathInDatastore, fmt.Sprintf("vm-%d-", vmID)) {
+		return true
+	}
+
+	// directory uses "local:123/vm-123-disk-0"
+	if strings.HasPrefix(*pathInDatastore, fmt.Sprintf("%d/vm-%d-", vmID, vmID)) {
+		return true
+	}
+
+	return false
 }
 
 // CustomStorageDevices handles QEMU SATA device parameters.


### PR DESCRIPTION
Storage using .raw or .qcow2 files uses additional element in path, which is not present in ZFS storage.
Support both patterns when determining disk ownership.

This fixes #632

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected. 

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
Reproduced the error in #632, worked after the fix.

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #632

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
