### PR TITLE
fix(vm): set FileVolume for disks with file_id

### DIFF
--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -3053,17 +3053,17 @@ func vmGetDiskDeviceObjects(
 		}
 		if fileID != "" {
 			diskDevice.Enabled = false
-		} else {
-			if pathInDatastore != "" {
-				if datastoreID != "" {
-					diskDevice.FileVolume = fmt.Sprintf("%s:%s", datastoreID, pathInDatastore)
-				} else {
-					// FileVolume is absolute path in the host filesystem
-					diskDevice.FileVolume = pathInDatastore
-				}
+		}
+
+		if pathInDatastore != "" {
+			if datastoreID != "" {
+				diskDevice.FileVolume = fmt.Sprintf("%s:%s", datastoreID, pathInDatastore)
 			} else {
-				diskDevice.FileVolume = fmt.Sprintf("%s:%d", datastoreID, size)
+				// FileVolume is absolute path in the host filesystem
+				diskDevice.FileVolume = pathInDatastore
 			}
+		} else {
+			diskDevice.FileVolume = fmt.Sprintf("%s:%d", datastoreID, size)
 		}
 
 		diskDevice.ID = &datastoreID


### PR DESCRIPTION
Disks imported using `file_id` argument do not have FileVolume set, that makes PathInDatastore return an empty string, which makes IsOwnedBy return fales for any vm id.

The end result is the inability to resize imported disks, this fixes it.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected. 

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
Successfully  resized 
```terraform
 disk {
    datastore_id = var.vm_datastore

    file_format = "raw"
    file_id     = "${proxmox_virtual_environment_file.debian_12_genericcloud.datastore_id}:${proxmox_virtual_environment_file.debian_12_genericcloud.content_type}/${proxmox_virtual_environment_file.debian_12_genericcloud.file_name}"
  
    interface = "virtio0"
    size      = 10
  }
```
to
```terraform
 disk {
    datastore_id = var.vm_datastore

    file_format = "raw"
    file_id     = "${proxmox_virtual_environment_file.debian_12_genericcloud.datastore_id}:${proxmox_virtual_environment_file.debian_12_genericcloud.content_type}/${proxmox_virtual_environment_file.debian_12_genericcloud.file_name}"
  
    interface = "virtio0"
    size      = 11
  }
```
on a branch with both #633 and this PR applied.

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #0632, #0633

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
