### PR TITLE
fix(file): handle missing file on state refresh

### DIFF
--- a/fwprovider/tests/resource_file_test.go
+++ b/fwprovider/tests/resource_file_test.go
@@ -9,13 +9,14 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/brianvoe/gofakeit/v6"
 	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/stretchr/testify/require"
@@ -170,6 +171,8 @@ func createFile(t *testing.T, namePattern string, content string) *os.File {
 }
 
 func deleteSnippet(t *testing.T, fname string) {
+	t.Helper()
+
 	err := getNodesClient().DeleteDatastoreFile(context.Background(), "local", fmt.Sprintf("snippets/%s", fname))
 	require.NoError(t, err)
 }

--- a/fwprovider/tests/resource_file_test.go
+++ b/fwprovider/tests/resource_file_test.go
@@ -9,6 +9,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"github.com/brianvoe/gofakeit/v6"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -16,7 +17,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/stretchr/testify/require"
 
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	accTestFileName = "proxmox_virtual_environment_file.test"
+	accTestFileRawName = "proxmox_virtual_environment_file.test_raw"
+	accTestFileName    = "proxmox_virtual_environment_file.test"
 )
 
 type nodeResolver struct {
@@ -94,8 +95,11 @@ func TestAccResourceFile(t *testing.T) {
 			},
 			// Update testing
 			{
-				Config: testAccResourceFileSnippetRawUpdatedConfig(snippetRaw),
-				Check:  testAccResourceFileSnippetUpdatedCheck(snippetRaw),
+				PreConfig: func() {
+					deleteSnippet(t, filepath.Base(snippetFile1.Name()))
+				},
+				Config: testAccResourceFileSnippetUpdateConfig(snippetFile1.Name()),
+				Check:  testAccResourceFileSnippetUpdatedCheck(snippetFile1.Name()),
 			},
 			// ImportState testing
 			{
@@ -165,9 +169,14 @@ func createFile(t *testing.T, namePattern string, content string) *os.File {
 	return f
 }
 
+func deleteSnippet(t *testing.T, fname string) {
+	err := getNodesClient().DeleteDatastoreFile(context.Background(), "local", fmt.Sprintf("snippets/%s", fname))
+	require.NoError(t, err)
+}
+
 func testAccResourceFileSnippetRawCreatedConfig(fname string) string {
 	return fmt.Sprintf(`
-resource "proxmox_virtual_environment_file" "test" {
+resource "proxmox_virtual_environment_file" "test_raw" {
   content_type = "snippets"
   datastore_id = "local"
   node_name    = "%s"
@@ -223,11 +232,11 @@ resource "proxmox_virtual_environment_file" "test" {
 
 func testAccResourceFileSnippetRawCreatedCheck(fname string) resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
-		resource.TestCheckResourceAttr(accTestFileName, "content_type", "snippets"),
-		resource.TestCheckResourceAttr(accTestFileName, "file_name", fname),
-		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.file_name", fname),
-		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.data", "test snippet\n"),
-		resource.TestCheckResourceAttr(accTestFileName, "id", fmt.Sprintf("local:snippets/%s", fname)),
+		resource.TestCheckResourceAttr(accTestFileRawName, "content_type", "snippets"),
+		resource.TestCheckResourceAttr(accTestFileRawName, "file_name", fname),
+		resource.TestCheckResourceAttr(accTestFileRawName, "source_raw.0.file_name", fname),
+		resource.TestCheckResourceAttr(accTestFileRawName, "source_raw.0.data", "test snippet\n"),
+		resource.TestCheckResourceAttr(accTestFileRawName, "id", fmt.Sprintf("local:snippets/%s", fname)),
 	)
 }
 
@@ -239,19 +248,13 @@ func testAccResourceFileCreatedCheck(ctype string, fname string) resource.TestCh
 	)
 }
 
-func testAccResourceFileSnippetRawUpdatedConfig(fname string) string {
+func testAccResourceFileSnippetUpdateConfig(fname string) string {
 	return fmt.Sprintf(`
 resource "proxmox_virtual_environment_file" "test" {
-  content_type = "snippets"
   datastore_id = "local"
   node_name    = "%s"
-
-  source_raw {
-    data = <<EOF
-test snippet - updated
-    EOF
-
-    file_name = "%s"
+  source_file {
+    path = "%s"
   }
 }
 	`, accTestNodeName, fname)
@@ -260,9 +263,7 @@ test snippet - updated
 func testAccResourceFileSnippetUpdatedCheck(fname string) resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
 		resource.TestCheckResourceAttr(accTestFileName, "content_type", "snippets"),
-		resource.TestCheckResourceAttr(accTestFileName, "file_name", fname),
-		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.file_name", fname),
-		resource.TestCheckResourceAttr(accTestFileName, "source_raw.0.data", "test snippet - updated\n"),
-		resource.TestCheckResourceAttr(accTestFileName, "id", fmt.Sprintf("local:snippets/%s", fname)),
+		resource.TestCheckResourceAttr(accTestFileName, "file_name", filepath.Base(fname)),
+		resource.TestCheckResourceAttr(accTestFileName, "id", fmt.Sprintf("local:%s/%s", "snippets", filepath.Base(fname))),
 	)
 }

--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -780,8 +780,9 @@ func fileRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 	}
 
 	if !found {
-		diags = append(diags, diag.Errorf("no such file: %q", d.Id())...)
-		return diags
+		// an empty ID is used to signal that the resource does not exist when provider reads the state
+		// back after creation, or on the state refresh.
+		d.SetId("")
 	}
 
 	return nil


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected. 

### Proof of Work

- `terraform apply` this plan:
  ```terraform
  resource "proxmox_virtual_environment_file" "test_file" {
    content_type = "snippets"
    datastore_id = "local"
    node_name    = "pve"
  
    source_file {
      path = "https://raw.githubusercontent.com/yaml/yaml-test-suite/main/src/229Q.yaml"
    }
  }
  ```
- delete file `229Q.yaml` from `snippets`
- run `terraform apply` again

Before the fix:
```
proxmox_virtual_environment_file.test_file: Refreshing state... [id=local:snippets/229Q.yaml]
╷
│ Error: no such file: "local:snippets/229Q.yaml"
│ 
│   with proxmox_virtual_environment_file.test_file,
│   on main.tf line 31, in resource "proxmox_virtual_environment_file" "test_file":
│   31: resource "proxmox_virtual_environment_file" "test_file" {
│ 
╵
```
After the fix:
```
proxmox_virtual_environment_file.test_file: Refreshing state... [id=local:snippets/229Q.yaml]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # proxmox_virtual_environment_file.test_file will be created
  + resource "proxmox_virtual_environment_file" "test_file" {
      + content_type           = "snippets"
      + datastore_id           = "local"
      + file_modification_date = (known after apply)
      + file_name              = (known after apply)
      + file_size              = (known after apply)
      + file_tag               = (known after apply)
      + id                     = (known after apply)
      + node_name              = "pve"
      + overwrite              = true
      + timeout_upload         = 1800

      + source_file {
          + changed  = false
          + insecure = false
          + path     = "https://raw.githubusercontent.com/yaml/yaml-test-suite/main/src/229Q.yaml"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_file.test_file: Creating...
proxmox_virtual_environment_file.test_file: Creation complete after 1s [id=local:snippets/229Q.yaml]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

```

<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #643

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
