### PR TITLE
fix(vm): MAC address validator should allow lowercase hex

### DIFF
--- a/proxmoxtf/resource/validator/network.go
+++ b/proxmoxtf/resource/validator/network.go
@@ -16,23 +16,23 @@ import (
 
 // MACAddress is a schema validation function for MAC address.
 func MACAddress() schema.SchemaValidateDiagFunc {
-	return validation.ToDiagFunc(func(i interface{}, k string) ([]string, []error) {
+	return validation.ToDiagFunc(func(i interface{}, path string) ([]string, []error) {
 		v, ok := i.(string)
 
 		var ws []string
 		var es []error
 
 		if !ok {
-			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			es = append(es, fmt.Errorf("expected type of %q to be string", path))
 			return ws, es
 		}
 
 		if v != "" {
-			r := regexp.MustCompile(`^[A-Z\d]{2}(:[A-Z\d]{2}){5}$`)
+			r := regexp.MustCompile(`^[A-Fa-f0-9]{2}(:[A-Fa-f0-9]{2}){5}$`)
 			ok := r.MatchString(v)
 
 			if !ok {
-				es = append(es, fmt.Errorf("expected %s to be a valid MAC address (A0:B1:C2:D3:E4:F5), got %s", k, v))
+				es = append(es, fmt.Errorf("expected %q to be a valid MAC address (A0:B1:C2:D3:E4:F5), got %q", path, v))
 				return ws, es
 			}
 		}

--- a/proxmoxtf/resource/validator/network_test.go
+++ b/proxmoxtf/resource/validator/network_test.go
@@ -7,8 +7,9 @@
 package validator
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestMACAddress(t *testing.T) {

--- a/proxmoxtf/resource/validator/network_test.go
+++ b/proxmoxtf/resource/validator/network_test.go
@@ -1,0 +1,45 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package validator
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMACAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		valid bool
+	}{
+		{"empty", "", true},
+		{"invalid", "invalid", false},
+		{"invalid: no dashes", "38-f9-d3-4b-f5-51", false},
+		{"valid", "38:f9:d3:4b:f5:51", true},
+		{"valid", "38:F9:D3:4B:F5:51", true},
+		{"valid", "00:15:5d:00:09:03", true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := MACAddress()
+			res := f(tt.value, nil)
+
+			if tt.valid {
+				require.Empty(t, res, "validate: '%s'", tt.value)
+			} else {
+				require.NotEmpty(t, res, "validate: '%s'", tt.value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected. 

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #656

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
