### PR TITLE
fix(provider): sanitize PVE endpoint value

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -186,7 +186,8 @@ Proxmox `provider` block:
 
 - `endpoint` - (Required) The endpoint for the Proxmox Virtual Environment
   API (can also be sourced from `PROXMOX_VE_ENDPOINT`). Usually this is
-  `https://<your-cluster-endpoint>:8006/`.
+  `https://<your-cluster-endpoint>:8006/`. **Do not** include `/api2/json` at
+  the end.
 - `insecure` - (Optional) Whether to skip the TLS verification step (can
   also be sourced from `PROXMOX_VE_INSECURE`). If omitted, defaults
   to `false`.

--- a/proxmox/api/client.go
+++ b/proxmox/api/client.go
@@ -84,6 +84,9 @@ func NewConnection(endpoint string, insecure bool) (*Connection, error) {
 		transport = logging.NewLoggingHTTPTransport(transport)
 	}
 
+	// make sure the path does not contain "/api2/json"
+	u.Path = ""
+
 	return &Connection{
 		endpoint: strings.TrimRight(u.String(), "/"),
 		httpClient: &http.Client{


### PR DESCRIPTION
Ignore `/api2/json` path in case it is present in the endpoint.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected. 

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #547

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
