### PR TITLE
fix(vm): memory size datatype conversion causing `null` on read

### DIFF
--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -4390,13 +4390,13 @@ func vmReadCustom(
 	memory := map[string]interface{}{}
 
 	if vmConfig.DedicatedMemory != nil {
-		memory[mkResourceVirtualEnvironmentVMMemoryDedicated] = *vmConfig.DedicatedMemory
+		memory[mkResourceVirtualEnvironmentVMMemoryDedicated] = int(*vmConfig.DedicatedMemory)
 	} else {
 		memory[mkResourceVirtualEnvironmentVMMemoryDedicated] = 0
 	}
 
 	if vmConfig.FloatingMemory != nil {
-		memory[mkResourceVirtualEnvironmentVMMemoryFloating] = *vmConfig.FloatingMemory
+		memory[mkResourceVirtualEnvironmentVMMemoryFloating] = int(*vmConfig.FloatingMemory)
 	} else {
 		memory[mkResourceVirtualEnvironmentVMMemoryFloating] = 0
 	}


### PR DESCRIPTION
PR #694 has introduced a datatype change `int` -> `int64` for [memory values](https://github.com/bpg/terraform-provider-proxmox/pull/694/files#diff-2f1b4764b499dad0e71c1d1ec4643ab8ecb1b91e24e00c6e4bbe3ecd9c242a89L436) in `GetResponseData` struct, which is used when provider reads VM state from PVE. However, `int64` does not play well with the SDK type `schema.TypeInt` used by the schema attributes, causing `null` values on read.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected. 

### Proof of Work
Create a minimal VM template, apply. Then call `terraform apply` again.

Before the fix:
<img width="1016" alt="Screenshot 2023-11-12 at 9 36 56 PM" src="https://github.com/bpg/terraform-provider-proxmox/assets/627562/1265477c-efff-487c-9954-9252439b69c1">

After the fix:
<img width="1036" alt="Screenshot 2023-11-12 at 9 37 40 PM" src="https://github.com/bpg/terraform-provider-proxmox/assets/627562/ea044a3e-5200-4fcc-ab29-b2f45a26a172">


<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000 | Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
