### PR TITLE
feat(vm): Add support for setting the VM TPM State device

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -65,6 +65,10 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
     type = "l26"
   }
 
+  tpm_state {
+    version = "v2.0"
+  }
+
   serial_device {}
 }
 
@@ -287,6 +291,11 @@ output "ubuntu_vm_public_key" {
       distribution-specific and Microsoft Standard keys enrolled, if used with
       EFI type=`4m`. Ignored for VMs with cpu.architecture=`aarch64` (defaults
       to `false`).
+- `tpm_state` - (Optional) The TPM state device.
+  - `datastore_id` (Optional) The identifier for the datastore to create
+      the disk in (defaults to `local-lvm`).
+  - `version` (Optional) TPM state device version. Can be `v1.2` or `v2.0`.
+      (defaults to `v2.0`).
 - `hostpci` - (Optional) A host PCI device mapping (multiple blocks supported).
   - `device` - (Required) The PCI device name for Proxmox, in form
       of `hostpciX` where `X` is a sequential number from 0 to 3.

--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -33,6 +33,11 @@ resource "proxmox_virtual_environment_vm" "example_template" {
     type         = "4m"
   }
 
+  tpm_state {
+    datastore_id = local.datastore_id
+    version      = "v2.0"
+  }
+
   #  disk {
   #    datastore_id = local.datastore_id
   #    file_id      = proxmox_virtual_environment_file.ubuntu_cloud_image.id

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -241,9 +241,8 @@ type CustomStorageDevices map[string]CustomStorageDevice
 
 // CustomTPMState handles QEMU TPM state parameters.
 type CustomTPMState struct {
-	FileVolume string          `json:"file"              url:"file"`
-	Size       *types.DiskSize `json:"size,omitempty"    url:"size,omitempty"`
-	Version    *string         `json:"version,omitempty" url:"version,omitempty"`
+	FileVolume string  `json:"file"              url:"file"`
+	Version    *string `json:"version,omitempty" url:"version,omitempty"`
 }
 
 // CustomUSBDevice handles QEMU USB device parameters.
@@ -1242,6 +1241,21 @@ func (r CustomStorageDevices) EncodeValues(_ string, v *url.Values) error {
 	return nil
 }
 
+// EncodeValues converts a CustomTPMState struct to a URL vlaue.
+func (r CustomTPMState) EncodeValues(key string, v *url.Values) error {
+	values := []string{
+		fmt.Sprintf("file=%s", r.FileVolume),
+	}
+
+	if r.Version != nil {
+		values = append(values, fmt.Sprintf("version=%s", *r.Version))
+	}
+
+	v.Add(key, strings.Join(values, ","))
+
+	return nil
+}
+
 // EncodeValues converts a CustomUSBDevice struct to a URL vlaue.
 func (r CustomUSBDevice) EncodeValues(key string, v *url.Values) error {
 	if r.HostDevice == nil && r.Mapping == nil {
@@ -1709,6 +1723,33 @@ func (r *CustomPCIDevice) UnmarshalJSON(b []byte) error {
 			case "x-vga":
 				bv := types.CustomBool(v[1] == "1")
 				r.XVGA = &bv
+			}
+		}
+	}
+
+	return nil
+}
+
+// UnmarshalJSON converts a CustomTPMState string to an object.
+func (r *CustomTPMState) UnmarshalJSON(b []byte) error {
+	var s string
+
+	if err := json.Unmarshal(b, &s); err != nil {
+		return fmt.Errorf("failed to unmarshal CustomTPMState: %w", err)
+	}
+
+	pairs := strings.Split(s, ",")
+
+	for _, p := range pairs {
+		v := strings.Split(strings.TrimSpace(p), "=")
+		if len(v) == 1 {
+			r.FileVolume = v[0]
+		} else if len(v) == 2 {
+			switch v[0] {
+			case "file":
+				r.FileVolume = v[1]
+			case "version":
+				r.Version = &v[1]
 			}
 		}
 	}

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -239,6 +239,13 @@ func (r CustomStorageDevice) IsOwnedBy(vmID int) bool {
 // CustomStorageDevices handles QEMU SATA device parameters.
 type CustomStorageDevices map[string]CustomStorageDevice
 
+// CustomTPMState handles QEMU TPM state parameters.
+type CustomTPMState struct {
+	FileVolume string          `json:"file"              url:"file"`
+	Size       *types.DiskSize `json:"size,omitempty"    url:"size,omitempty"`
+	Version    *string         `json:"version,omitempty" url:"version,omitempty"`
+}
+
 // CustomUSBDevice handles QEMU USB device parameters.
 type CustomUSBDevice struct {
 	HostDevice *string           `json:"host"              url:"host"`
@@ -349,6 +356,7 @@ type CreateRequestBody struct {
 	Tags                 *string                        `json:"tags,omitempty"               url:"tags,omitempty"`
 	Template             *types.CustomBool              `json:"template,omitempty"           url:"template,omitempty,int"`
 	TimeDriftFixEnabled  *types.CustomBool              `json:"tdf,omitempty"                url:"tdf,omitempty,int"`
+	TPMState             *CustomTPMState                `json:"tpmstate0,omitempty"          url:"tpmstate0,omitempty"`
 	USBDevices           CustomUSBDevices               `json:"usb,omitempty"                url:"usb,omitempty"`
 	VGADevice            *CustomVGADevice               `json:"vga,omitempty"                url:"vga,omitempty"`
 	VirtualCPUCount      *int                           `json:"vcpus,omitempty"              url:"vcpus,omitempty"`
@@ -517,6 +525,7 @@ type GetResponseData struct {
 	Tags                 *string                         `json:"tags,omitempty"`
 	Template             *types.CustomBool               `json:"template,omitempty"`
 	TimeDriftFixEnabled  *types.CustomBool               `json:"tdf,omitempty"`
+	TPMState             *CustomTPMState                 `json:"tpmstate0,omitempty"`
 	USBDevice0           *CustomUSBDevice                `json:"usb0,omitempty"`
 	USBDevice1           *CustomUSBDevice                `json:"usb1,omitempty"`
 	USBDevice2           *CustomUSBDevice                `json:"usb2,omitempty"`

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -3394,26 +3394,25 @@ func vmGetTPMState(d *schema.ResourceData, disk []interface{}) *vms.CustomTPMSta
 	return tmpStateConfig
 }
 
-func vmGetTPMStateAsStorageDevice(d *schema.ResourceData, disk []interface{}) (*vms.CustomStorageDevice, error) {
+func vmGetTPMStateAsStorageDevice(d *schema.ResourceData, disk []interface{}) *vms.CustomStorageDevice {
 	tmpState := vmGetTPMState(d, disk)
 
 	var storageDevice *vms.CustomStorageDevice
 
 	if tmpState != nil {
 		id := "0"
-		baseDiskInterface := "tmpstate"
+		baseDiskInterface := "tpmstate"
 		diskInterface := fmt.Sprint(baseDiskInterface, id)
 
 		storageDevice = &vms.CustomStorageDevice{
 			Enabled:    true,
 			FileVolume: tmpState.FileVolume,
-			Size:       tmpState.Size,
 			Interface:  &diskInterface,
 			ID:         &id,
 		}
 	}
 
-	return storageDevice, nil
+	return storageDevice
 }
 
 func vmGetHostPCIDeviceObjects(d *schema.ResourceData) vms.CustomPCIDevices {
@@ -4261,7 +4260,6 @@ func vmReadCustom(
 		}
 	}
 
-	//nolint:nestif
 	if vmConfig.TPMState != nil {
 		tpmState := map[string]interface{}{}
 
@@ -5974,15 +5972,8 @@ func vmUpdateDiskLocationAndSize(
 		if d.HasChange(mkResourceVirtualEnvironmentVMTPMState) {
 			diskOld, diskNew := d.GetChange(mkResourceVirtualEnvironmentVMTPMState)
 
-			oldTMPState, e := vmGetTPMStateAsStorageDevice(d, diskOld.([]interface{}))
-			if e != nil {
-				return diag.FromErr(e)
-			}
-
-			newTPMState, e := vmGetTPMStateAsStorageDevice(d, diskNew.([]interface{}))
-			if e != nil {
-				return diag.FromErr(e)
-			}
+			oldTMPState := vmGetTPMStateAsStorageDevice(d, diskOld.([]interface{}))
+			newTPMState := vmGetTPMStateAsStorageDevice(d, diskNew.([]interface{}))
 
 			if oldTMPState != nil {
 				baseDiskInterface := diskDigitPrefix(*oldTMPState.Interface)

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -3383,12 +3383,12 @@ func vmGetTPMState(d *schema.ResourceData, disk []interface{}) *vms.CustomTPMSta
 
 		block := tpmState[0].(map[string]interface{})
 		datastoreID, _ := block[mkResourceVirtualEnvironmentVMTPMStateDatastoreID].(string)
-		version, _ := block[mkResourceVirtualEnvironmentVMTPMState].(*string)
+		version, _ := block[mkResourceVirtualEnvironmentVMTPMStateVersion].(string)
 
 		// use the special syntax STORAGE_ID:SIZE_IN_GiB to allocate a new volume.
 		// NB SIZE_IN_GiB is ignored, see docs for more info.
 		tpmStateConfig.FileVolume = fmt.Sprintf("%s:1", datastoreID)
-		tpmStateConfig.Version = version
+		tpmStateConfig.Version = &version
 	}
 
 	return tpmStateConfig


### PR DESCRIPTION
Add support for setting the VM TPM State hardware.

Please feel free to squash all the commits.

The TPM State hardware can be declared as:

```hcl
resource "proxmox_virtual_environment_vm" "example" {
  tpm_state {
    datastore_id = "local-lvm"
    version      = "v2.0"
  }
  ...
}
```

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected. 

I've partially executed the example (see error after the screenshot). Here's the screenshot of the example created VM that shows it with the TPM State device:

![image](https://github.com/bpg/terraform-provider-proxmox/assets/43356/5b1d7eaa-67e8-469f-922c-00ae550e599b)

Here's the error (which seems not related to this PR):

```
╷
│ Error: error updating container: received an HTTP 400 response - Reason: Parameter verification failed. (mp0: unable to hotplug mp0: directory '/mnt/bindmounts/shared' does not exist)
│ 
│   with proxmox_virtual_environment_container.example,
│   on resource_virtual_environment_container.tf line 52, in resource "proxmox_virtual_environment_container" "example":
│   52: resource "proxmox_virtual_environment_container" "example" {
│ 
╵
```

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Given the following terraform program:

```hcl
resource "proxmox_virtual_environment_vm" "template" {
  name      = "gh-743-template"
  node_name = "pve"
  vm_id     = 7430
  started   = false
  template  = true
}

resource "proxmox_virtual_environment_vm" "a" {
  depends_on = [proxmox_virtual_environment_vm.template]
  name       = "gh-743-a"
  node_name  = "pve"
  vm_id      = 7431
  clone {
    vm_id = proxmox_virtual_environment_vm.template.vm_id
  }
  tpm_state {
    datastore_id = "local-lvm"
    version      = "v2.0"
  }
  started = false
}

resource "proxmox_virtual_environment_vm" "b" {
  depends_on = [proxmox_virtual_environment_vm.a]
  name       = "gh-743-b"
  node_name  = "pve"
  vm_id      = 7432
  clone {
    vm_id = proxmox_virtual_environment_vm.a.vm_id
  }
  tpm_state {
    datastore_id = "local-lvm"
    version      = "v2.0"
  }
  started = false
}
```

`terraform apply` looks like:

```console
$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # proxmox_virtual_environment_vm.a will be created
  + resource "proxmox_virtual_environment_vm" "a" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "gh-743-a"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + reboot                  = false
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = 7431

      + clone {
          + full    = true
          + retries = 1
          + vm_id   = 7430
        }

      + tpm_state {
          + datastore_id = "local-lvm"
          + version      = "v2.0"
        }
    }

  # proxmox_virtual_environment_vm.b will be created
  + resource "proxmox_virtual_environment_vm" "b" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "gh-743-b"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + reboot                  = false
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = 7432

      + clone {
          + full    = true
          + retries = 1
          + vm_id   = 7431
        }

      + tpm_state {
          + datastore_id = "local-lvm"
          + version      = "v2.0"
        }
    }

  # proxmox_virtual_environment_vm.template will be created
  + resource "proxmox_virtual_environment_vm" "template" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "gh-743-template"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + reboot                  = false
      + scsi_hardware           = "virtio-scsi-pci"
      + tablet_device           = true
      + template                = true
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = 7430
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

proxmox_virtual_environment_vm.template: Creating...
proxmox_virtual_environment_vm.template: Creation complete after 1s [id=7430]
proxmox_virtual_environment_vm.a: Creating...
proxmox_virtual_environment_vm.a: Creation complete after 1s [id=7431]
proxmox_virtual_environment_vm.b: Creating...
proxmox_virtual_environment_vm.b: Creation complete after 5s [id=7432]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```

And the end result in Proxmox looks like:

![image](https://github.com/bpg/terraform-provider-proxmox/assets/43356/832126f8-65e6-486a-a231-8caea497504a)

![image](https://github.com/bpg/terraform-provider-proxmox/assets/43356/a024c65a-73d9-4bac-a647-f4b885b320ba)

![image](https://github.com/bpg/terraform-provider-proxmox/assets/43356/b3591868-c116-4cfe-86c6-0d2cd4ff5c88)

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #453

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
