### PR TITLE
fix(vm): resize image once imported 

### DIFF
--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -2809,12 +2809,10 @@ func vmCreateCustomDisks(ctx context.Context, d *schema.ResourceData, m interfac
 			fmt.Sprintf(`file_path_tmp="%s"`, filePathTmp),
 			fmt.Sprintf(`vm_id="%d"`, vmID),
 			`source_image=$(pvesm path "$file_id")`,
-			`cp "$source_image" "$file_path_tmp"`,
-			`qemu-img resize -f "$file_format" "$file_path_tmp" "${disk_size}G"`,
-			`imported_disk="$(qm importdisk "$vm_id" "$file_path_tmp" "$datastore_id_target" -format $file_format | grep "unused0" | cut -d ":" -f 3 | cut -d "'" -f 1)"`,
+			`imported_disk="$(qm importdisk "$vm_id" "$source_image" "$datastore_id_target" -format $file_format | grep "unused0" | cut -d ":" -f 3 | cut -d "'" -f 1)"`,
 			`disk_id="${datastore_id_target}:$imported_disk${disk_options}"`,
 			`qm set "$vm_id" "-${disk_interface}" "$disk_id"`,
-			`rm -f "$file_path_tmp"`,
+			`qm resize "$vm_id" "${disk_interface}" "${disk_size}G"`,
 		)
 
 		importedDiskCount++


### PR DESCRIPTION
Re-work order of when we resize image. First import disk and then resize. This was resize should be quicker
See #737 

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [X] I have ran `make example` to verify that the change works as expected. 


<!---
BEGIN_COMMIT_OVERRIDE
fix(vm): resize image once imported (#753)
END_COMMIT_OVERRIDE
--->
