### PR TITLE
fix(vm): unable to clone as non-root due to `hook_script`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,9 @@
         "qcow",
         "virtio"
     ],
+    "go.lintTool": "golangci-lint",
+    "go.lintFlags": [
+        "--fast",
+    ],
     "go.testEnvFile": "${workspaceFolder}/test.env",
 }

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -2132,12 +2132,11 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 
 	hookScript := d.Get(mkResourceVirtualEnvironmentVMHookScriptFileID).(string)
 	currentHookScript := vmConfig.HookScript
+
 	if len(hookScript) > 0 {
 		updateBody.HookScript = &hookScript
-	} else {
-		if currentHookScript != nil {
-			del = append(del, "hookscript")
-		}
+	} else if currentHookScript != nil {
+		del = append(del, "hookscript")
 	}
 
 	updateBody.Delete = del


### PR DESCRIPTION
Provider throws an error when cloning if authenticated as non-root with PVE.

Example template:
```hcl
resource "proxmox_virtual_environment_vm" "vm_template" {
  name      = "template"
  node_name = "pve"

  started  = false
  template = true
}


resource "proxmox_virtual_environment_vm" "vm_cloned" {
  depends_on = [proxmox_virtual_environment_vm.vm_template]
  name       = "test"
  node_name  = "pve"

  clone {
    vm_id = proxmox_virtual_environment_vm.vm_template.id
  }

  started = false
}
``` 

Error:
```
proxmox_virtual_environment_vm.vm_cloned: Creating...
╷
│ Error: error updating VM: received an HTTP 500 response - Reason: only root can set 'hookscript' config
│
│   with proxmox_virtual_environment_vm.vm_cloned,
│   on main.tf line 11, in resource "proxmox_virtual_environment_vm" "vm_cloned":
│   11: resource "proxmox_virtual_environment_vm" "vm_cloned" {
│
```

Regression from #733 

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected. 

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

The example template applied without error. 

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #733 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
