### PR TITLE
fix(vm): panic at read when cloud-init drive is on directory storage

### DIFF
--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -187,8 +187,8 @@ type CustomStorageDevice struct {
 }
 
 // PathInDatastore returns path part of FileVolume or nil if it is not yet allocated.
-func (r CustomStorageDevice) PathInDatastore() *string {
-	probablyDatastoreID, pathInDatastore, hasDatastoreID := strings.Cut(r.FileVolume, ":")
+func (d CustomStorageDevice) PathInDatastore() *string {
+	probablyDatastoreID, pathInDatastore, hasDatastoreID := strings.Cut(d.FileVolume, ":")
 	if !hasDatastoreID {
 		// when no ':' separator is found, 'Cut' places the whole string to 'probablyDatastoreID',
 		// we want it in 'pathInDatastore' (as it is absolute filesystem path)
@@ -215,8 +215,8 @@ func (r CustomStorageDevice) PathInDatastore() *string {
 }
 
 // IsOwnedBy returns true, if CustomStorageDevice is owned by given VM. Not yet allocated volumes are not owned by any VM.
-func (r CustomStorageDevice) IsOwnedBy(vmID int) bool {
-	pathInDatastore := r.PathInDatastore()
+func (d CustomStorageDevice) IsOwnedBy(vmID int) bool {
+	pathInDatastore := d.PathInDatastore()
 	if pathInDatastore == nil {
 		// not yet allocated volume, consider disk not owned by any VM
 		// NOTE: if needed, create IsOwnedByOtherThan(vmId) instead of changing this return value.
@@ -234,6 +234,12 @@ func (r CustomStorageDevice) IsOwnedBy(vmID int) bool {
 	}
 
 	return false
+}
+
+// IsCloudInitDrive returns true, if CustomStorageDevice is a cloud-init drive.
+func (d CustomStorageDevice) IsCloudInitDrive(vmID int) bool {
+	return d.Media != nil && *d.Media == "cdrom" &&
+		strings.Contains(d.FileVolume, fmt.Sprintf("vm-%d-cloudinit", vmID))
 }
 
 // CustomStorageDevices handles QEMU SATA device parameters.

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -1160,73 +1160,73 @@ func (r CustomStartupOrder) EncodeValues(key string, v *url.Values) error {
 }
 
 // EncodeValues converts a CustomStorageDevice struct to a URL vlaue.
-func (r CustomStorageDevice) EncodeValues(key string, v *url.Values) error {
+func (d CustomStorageDevice) EncodeValues(key string, v *url.Values) error {
 	values := []string{
-		fmt.Sprintf("file=%s", r.FileVolume),
+		fmt.Sprintf("file=%s", d.FileVolume),
 	}
 
-	if r.AIO != nil {
-		values = append(values, fmt.Sprintf("aio=%s", *r.AIO))
+	if d.AIO != nil {
+		values = append(values, fmt.Sprintf("aio=%s", *d.AIO))
 	}
 
-	if r.BackupEnabled != nil {
-		if *r.BackupEnabled {
+	if d.BackupEnabled != nil {
+		if *d.BackupEnabled {
 			values = append(values, "backup=1")
 		} else {
 			values = append(values, "backup=0")
 		}
 	}
 
-	if r.BurstableReadSpeedMbps != nil {
-		values = append(values, fmt.Sprintf("mbps_rd_max=%d", *r.BurstableReadSpeedMbps))
+	if d.BurstableReadSpeedMbps != nil {
+		values = append(values, fmt.Sprintf("mbps_rd_max=%d", *d.BurstableReadSpeedMbps))
 	}
 
-	if r.BurstableWriteSpeedMbps != nil {
-		values = append(values, fmt.Sprintf("mbps_wr_max=%d", *r.BurstableWriteSpeedMbps))
+	if d.BurstableWriteSpeedMbps != nil {
+		values = append(values, fmt.Sprintf("mbps_wr_max=%d", *d.BurstableWriteSpeedMbps))
 	}
 
-	if r.Format != nil {
-		values = append(values, fmt.Sprintf("format=%s", *r.Format))
+	if d.Format != nil {
+		values = append(values, fmt.Sprintf("format=%s", *d.Format))
 	}
 
-	if r.MaxReadSpeedMbps != nil {
-		values = append(values, fmt.Sprintf("mbps_rd=%d", *r.MaxReadSpeedMbps))
+	if d.MaxReadSpeedMbps != nil {
+		values = append(values, fmt.Sprintf("mbps_rd=%d", *d.MaxReadSpeedMbps))
 	}
 
-	if r.MaxWriteSpeedMbps != nil {
-		values = append(values, fmt.Sprintf("mbps_wr=%d", *r.MaxWriteSpeedMbps))
+	if d.MaxWriteSpeedMbps != nil {
+		values = append(values, fmt.Sprintf("mbps_wr=%d", *d.MaxWriteSpeedMbps))
 	}
 
-	if r.Media != nil {
-		values = append(values, fmt.Sprintf("media=%s", *r.Media))
+	if d.Media != nil {
+		values = append(values, fmt.Sprintf("media=%s", *d.Media))
 	}
 
-	if r.Size != nil {
-		values = append(values, fmt.Sprintf("size=%s", *r.Size))
+	if d.Size != nil {
+		values = append(values, fmt.Sprintf("size=%s", *d.Size))
 	}
 
-	if r.IOThread != nil {
-		if *r.IOThread {
+	if d.IOThread != nil {
+		if *d.IOThread {
 			values = append(values, "iothread=1")
 		} else {
 			values = append(values, "iothread=0")
 		}
 	}
 
-	if r.SSD != nil {
-		if *r.SSD {
+	if d.SSD != nil {
+		if *d.SSD {
 			values = append(values, "ssd=1")
 		} else {
 			values = append(values, "ssd=0")
 		}
 	}
 
-	if r.Discard != nil && *r.Discard != "" {
-		values = append(values, fmt.Sprintf("discard=%s", *r.Discard))
+	if d.Discard != nil && *d.Discard != "" {
+		values = append(values, fmt.Sprintf("discard=%s", *d.Discard))
 	}
 
-	if r.Cache != nil && *r.Cache != "" {
-		values = append(values, fmt.Sprintf("cache=%s", *r.Cache))
+	if d.Cache != nil && *d.Cache != "" {
+		values = append(values, fmt.Sprintf("cache=%s", *d.Cache))
 	}
 
 	v.Add(key, strings.Join(values, ","))
@@ -1235,8 +1235,8 @@ func (r CustomStorageDevice) EncodeValues(key string, v *url.Values) error {
 }
 
 // EncodeValues converts a CustomStorageDevices array to multiple URL values.
-func (r CustomStorageDevices) EncodeValues(_ string, v *url.Values) error {
-	for s, d := range r {
+func (d CustomStorageDevices) EncodeValues(_ string, v *url.Values) error {
+	for s, d := range d {
 		if d.Enabled {
 			if err := d.EncodeValues(s, v); err != nil {
 				return fmt.Errorf("error encoding storage device %s: %w", s, err)
@@ -1907,7 +1907,7 @@ func (r *CustomStartupOrder) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalJSON converts a CustomStorageDevice string to an object.
-func (r *CustomStorageDevice) UnmarshalJSON(b []byte) error {
+func (d *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 	var s string
 
 	if err := json.Unmarshal(b, &s); err != nil {
@@ -1921,24 +1921,24 @@ func (r *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 
 		//nolint:nestif
 		if len(v) == 1 {
-			r.FileVolume = v[0]
+			d.FileVolume = v[0]
 
 			ext := filepath.Ext(v[0])
 			if ext != "" {
 				format := string([]byte(ext)[1:])
-				r.Format = &format
+				d.Format = &format
 			}
 		} else if len(v) == 2 {
 			switch v[0] {
 			case "aio":
-				r.AIO = &v[1]
+				d.AIO = &v[1]
 
 			case "backup":
 				bv := types.CustomBool(v[1] == "1")
-				r.BackupEnabled = &bv
+				d.BackupEnabled = &bv
 
 			case "file":
-				r.FileVolume = v[1]
+				d.FileVolume = v[1]
 
 			case "mbps_rd":
 				iv, err := strconv.Atoi(v[1])
@@ -1946,59 +1946,59 @@ func (r *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 					return fmt.Errorf("failed to convert mbps_rd to int: %w", err)
 				}
 
-				r.MaxReadSpeedMbps = &iv
+				d.MaxReadSpeedMbps = &iv
 			case "mbps_rd_max":
 				iv, err := strconv.Atoi(v[1])
 				if err != nil {
 					return fmt.Errorf("failed to convert mbps_rd_max to int: %w", err)
 				}
 
-				r.BurstableReadSpeedMbps = &iv
+				d.BurstableReadSpeedMbps = &iv
 			case "mbps_wr":
 				iv, err := strconv.Atoi(v[1])
 				if err != nil {
 					return fmt.Errorf("failed to convert mbps_wr to int: %w", err)
 				}
 
-				r.MaxWriteSpeedMbps = &iv
+				d.MaxWriteSpeedMbps = &iv
 			case "mbps_wr_max":
 				iv, err := strconv.Atoi(v[1])
 				if err != nil {
 					return fmt.Errorf("failed to convert mbps_wr_max to int: %w", err)
 				}
 
-				r.BurstableWriteSpeedMbps = &iv
+				d.BurstableWriteSpeedMbps = &iv
 			case "media":
-				r.Media = &v[1]
+				d.Media = &v[1]
 
 			case "size":
-				r.Size = new(types.DiskSize)
-				err := r.Size.UnmarshalJSON([]byte(v[1]))
+				d.Size = new(types.DiskSize)
+				err := d.Size.UnmarshalJSON([]byte(v[1]))
 				if err != nil {
 					return fmt.Errorf("failed to unmarshal disk size: %w", err)
 				}
 
 			case "format":
-				r.Format = &v[1]
+				d.Format = &v[1]
 
 			case "iothread":
 				bv := types.CustomBool(v[1] == "1")
-				r.IOThread = &bv
+				d.IOThread = &bv
 
 			case "ssd":
 				bv := types.CustomBool(v[1] == "1")
-				r.SSD = &bv
+				d.SSD = &bv
 
 			case "discard":
-				r.Discard = &v[1]
+				d.Discard = &v[1]
 
 			case "cache":
-				r.Cache = &v[1]
+				d.Cache = &v[1]
 			}
 		}
 	}
 
-	r.Enabled = true
+	d.Enabled = true
 
 	return nil
 }

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -1662,10 +1662,7 @@ func findExistingCloudInitDrive(vmConfig *vms.GetResponseData, vmID int, default
 		vmConfig.IDEDevice0, vmConfig.IDEDevice1, vmConfig.IDEDevice2, vmConfig.IDEDevice3,
 	}
 	for i, device := range devices {
-		if device != nil && device.Enabled && device.Media != nil && *device.Media == "cdrom" && strings.Contains(
-			device.FileVolume,
-			fmt.Sprintf("vm-%d-cloudinit", vmID),
-		) {
+		if device != nil && device.Enabled && device.IsCloudInitDrive(vmID) {
 			return fmt.Sprintf("ide%d", i)
 		}
 	}
@@ -4110,7 +4107,7 @@ func vmReadCustom(
 			continue
 		}
 
-		if strings.HasSuffix(dd.FileVolume, fmt.Sprintf("vm-%d-cloudinit", vmID)) {
+		if dd.IsCloudInitDrive(vmID) {
 			continue
 		}
 


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
This configuration now works after the fix
```hcl
  initialization {
    datastore_id = "local"
    interface    = "scsi2"
    ip_config {
      ipv4 {
        address = "dhcp"
      }
    }
  }
```

```
...

      + initialization {
          + datastore_id      = "local"
          + interface         = "scsi2"
          + user_data_file_id = (known after apply)

          + ip_config {
              + ipv4 {
                  + address = "dhcp"
                }
            }
        }

      + memory {
          + dedicated = 2048
          + floating  = 0
          + shared    = 0
        }

      + network_device {
          + bridge      = "vmbr0"
          + enabled     = true
          + firewall    = false
          + mac_address = (known after apply)
          + model       = "virtio"
          + mtu         = 0
          + queues      = 0
          + rate_limit  = 0
          + vlan_id     = 0
        }

      + operating_system {
          + type = "l26"
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_file.ubuntu_cloud_image: Creating...
proxmox_virtual_environment_file.cloud_config: Creating...
proxmox_virtual_environment_file.cloud_config: Creation complete after 0s [id=local:snippets/cloud-config.yaml]
proxmox_virtual_environment_file.ubuntu_cloud_image: Still creating... [10s elapsed]
proxmox_virtual_environment_file.ubuntu_cloud_image: Still creating... [20s elapsed]
proxmox_virtual_environment_file.ubuntu_cloud_image: Still creating... [30s elapsed]
proxmox_virtual_environment_file.ubuntu_cloud_image: Still creating... [40s elapsed]
proxmox_virtual_environment_file.ubuntu_cloud_image: Creation complete after 47s [id=local:iso/jammy-server-cloudimg-amd64.img]
proxmox_virtual_environment_vm.ubuntu_vm: Creating...
proxmox_virtual_environment_vm.ubuntu_vm: Still creating... [10s elapsed]
proxmox_virtual_environment_vm.ubuntu_vm: Still creating... [20s elapsed]
proxmox_virtual_environment_vm.ubuntu_vm: Still creating... [30s elapsed]
proxmox_virtual_environment_vm.ubuntu_vm: Still creating... [40s elapsed]
proxmox_virtual_environment_vm.ubuntu_vm: Still creating... [50s elapsed]
proxmox_virtual_environment_vm.ubuntu_vm: Creation complete after 51s [id=1000]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```
<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #796

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
