### PR TITLE
fix(provider): allow FQDN for `ssh.node.address` in provider's config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -209,6 +209,6 @@ Proxmox `provider` block:
   - `node` - (Optional) The node configuration for the SSH connection. Can be
       specified multiple times to provide configuration fo multiple nodes.
     - `name` - (Required) The name of the node.
-    - `address` - (Required) The IP address of the node.
+    - `address` - (Required) The FQDN/IP address of the node.
     - `port` - (Optional) SSH port of the node. Defaults to 22.
 - `tmp_dir` - (Optional) Use custom temporary directory. (can also be sourced from `PROXMOX_VE_TMPDIR`)

--- a/proxmoxtf/provider/schema.go
+++ b/proxmoxtf/provider/schema.go
@@ -155,7 +155,7 @@ func createSchema() map[string]*schema.Schema {
 									Type:         schema.TypeString,
 									Required:     true,
 									Description:  "The address of the Proxmox VE node.",
-									ValidateFunc: validation.IsIPAddress,
+									ValidateFunc: validation.StringIsNotEmpty,
 								},
 								mkProviderSSHNodePort: {
 									Type:         schema.TypeInt,


### PR DESCRIPTION
It is now possible to use an FQDN instead of an IP Address when the SSH node is configured

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work

```hcl
variable "pm_nodes" {
  type = list(object({
    name    = string
    address = string
    port    = number
  }))
}

provider "proxmox" {
  endpoint = "https://${var.pm_host}:${var.pm_webport}/"
  username = "${var.pm_user}@pam"
  password = var.pm_password
  insecure = true
  tmp_dir  = "${path.module}"
  ssh {
    agent = true
    dynamic "node" {
      for_each = var.pm_nodes
      content {
        name    = node.value.name
        address = node.value.address
        port    = node.value.port
      }
    }
  }
}
```

in the example, the node address variable can be also an FQDN instead of an IP address.


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #812

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
