### PR TITLE
feat(vm, lxc): add new `initialization.dns.servers` param to vm and container

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -129,7 +129,8 @@ output "ubuntu_container_public_key" {
 - `initialization` - (Optional) The initialization configuration.
   - `dns` - (Optional) The DNS configuration.
     - `domain` - (Optional) The DNS search domain.
-    - `server` - (Optional) The DNS server.
+    - `server` - (Optional) The DNS server. The `server` attribute is deprecated and will be removed in a future release. Please use the `servers` attribute instead.
+    - `servers` - (Optional) The list of DNS servers.
   - `hostname` - (Optional) The hostname.
   - `ip_config` - (Optional) The IP configuration (one block per network
       device).

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -331,7 +331,8 @@ output "ubuntu_vm_public_key" {
       otherwise defaults to `ide2`.
   - `dns` - (Optional) The DNS configuration.
     - `domain` - (Optional) The DNS search domain.
-    - `server` - (Optional) The DNS server.
+    - `server` - (Optional) The DNS server. The `server` attribute is deprecated and will be removed in a future release. Please use the `servers` attribute instead.
+    - `servers` - (Optional) The list of DNS servers.
   - `ip_config` - (Optional) The IP configuration (one block per network
       device).
     - `ipv4` - (Optional) The IPv4 configuration.

--- a/example/resource_virtual_environment_container.tf
+++ b/example/resource_virtual_environment_container.tf
@@ -15,7 +15,7 @@ resource "proxmox_virtual_environment_container" "example_template" {
 
   initialization {
     dns {
-      server = "1.1.1.1"
+      servers = ["1.1.1.1", "8.8.8.8"]
     }
 
     hostname = "terraform-provider-proxmox-example-lxc-template"
@@ -72,7 +72,7 @@ resource "proxmox_virtual_environment_container" "example" {
   mount_point {
     // bind mount, requires root@pam
     volume = "/mnt/bindmounts/shared"
-    path    = "/shared"
+    path   = "/shared"
   }
 
   node_name = data.proxmox_virtual_environment_nodes.example.names[0]

--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -67,7 +67,7 @@ resource "proxmox_virtual_environment_vm" "example_template" {
     interface    = "scsi4"
 
     dns {
-      server = "1.1.1.1"
+      servers = ["1.1.1.1", "8.8.8.8"]
     }
 
     ip_config {
@@ -154,7 +154,7 @@ resource "proxmox_virtual_environment_vm" "example" {
     interface = "scsi4"
 
     dns {
-      server = "8.8.8.8"
+      servers = ["1.1.1.1"]
     }
     ip_config {
       ipv4 {

--- a/proxmoxtf/resource/container_test.go
+++ b/proxmoxtf/resource/container_test.go
@@ -154,11 +154,13 @@ func TestContainerSchema(t *testing.T) {
 	test.AssertOptionalArguments(t, initializationDNSSchema, []string{
 		mkResourceVirtualEnvironmentContainerInitializationDNSDomain,
 		mkResourceVirtualEnvironmentContainerInitializationDNSServer,
+		mkResourceVirtualEnvironmentContainerInitializationDNSServers,
 	})
 
 	test.AssertValueTypes(t, initializationDNSSchema, map[string]schema.ValueType{
-		mkResourceVirtualEnvironmentContainerInitializationDNSDomain: schema.TypeString,
-		mkResourceVirtualEnvironmentContainerInitializationDNSServer: schema.TypeString,
+		mkResourceVirtualEnvironmentContainerInitializationDNSDomain:  schema.TypeString,
+		mkResourceVirtualEnvironmentContainerInitializationDNSServer:  schema.TypeString,
+		mkResourceVirtualEnvironmentContainerInitializationDNSServers: schema.TypeList,
 	})
 
 	initializationIPConfigSchema := test.AssertNestedSchemaExistence(

--- a/proxmoxtf/resource/vm_test.go
+++ b/proxmoxtf/resource/vm_test.go
@@ -300,11 +300,13 @@ func TestVMSchema(t *testing.T) {
 	test.AssertOptionalArguments(t, initializationDNSSchema, []string{
 		mkResourceVirtualEnvironmentVMInitializationDNSDomain,
 		mkResourceVirtualEnvironmentVMInitializationDNSServer,
+		mkResourceVirtualEnvironmentVMInitializationDNSServers,
 	})
 
 	test.AssertValueTypes(t, initializationDNSSchema, map[string]schema.ValueType{
-		mkResourceVirtualEnvironmentVMInitializationDNSDomain: schema.TypeString,
-		mkResourceVirtualEnvironmentVMInitializationDNSServer: schema.TypeString,
+		mkResourceVirtualEnvironmentVMInitializationDNSDomain:  schema.TypeString,
+		mkResourceVirtualEnvironmentVMInitializationDNSServer:  schema.TypeString,
+		mkResourceVirtualEnvironmentVMInitializationDNSServers: schema.TypeList,
 	})
 
 	initializationIPConfigSchema := test.AssertNestedSchemaExistence(


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
Added `servers` param, deprecate old `server` param. Apply AFAIK works as expected, tried some of combinations:
- old server and no servers
- both server and servers
- new servers without server
- old server and no servers -> apply -> then only servers

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/bpg/terraform-provider-proxmox/issues/816

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
