### PR TITLE
fix(vm): missing disks when importing VM to a TF state

### DIFF
--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -4268,7 +4268,7 @@ func vmReadCustom(
 		diskMap[di] = disk
 	}
 
-	if len(currentDiskList) > 0 {
+	if len(clone) == 0 || len(currentDiskList) > 0 {
 		orderedDiskList := orderedListFromMap(diskMap)
 		err := d.Set(mkResourceVirtualEnvironmentVMDisk, orderedDiskList)
 		diags = append(diags, diag.FromErr(err)...)
@@ -5119,6 +5119,10 @@ func vmReadCustom(
 	diags = append(
 		diags,
 		vmReadNetworkValues(ctx, d, m, vmID, vmConfig)...)
+
+	d.SetId(strconv.Itoa(vmID))
+	d.Set(mkResourceVirtualEnvironmentVMVMID, vmID)
+	d.Set(mkResourceVirtualEnvironmentVMNodeName, nodeName)
 
 	return diags
 }

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -5120,9 +5120,12 @@ func vmReadCustom(
 		diags,
 		vmReadNetworkValues(ctx, d, m, vmID, vmConfig)...)
 
+	// during import these core attributes might not be set, so set them explicitly here
 	d.SetId(strconv.Itoa(vmID))
-	d.Set(mkResourceVirtualEnvironmentVMVMID, vmID)
-	d.Set(mkResourceVirtualEnvironmentVMNodeName, nodeName)
+	e := d.Set(mkResourceVirtualEnvironmentVMVMID, vmID)
+	diags = append(diags, diag.FromErr(e)...)
+	e = d.Set(mkResourceVirtualEnvironmentVMNodeName, nodeName)
+	diags = append(diags, diag.FromErr(e)...)
 
 	return diags
 }


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Having this VM in PVE:
<img width="786" alt="Screenshot 2024-01-10 at 10 25 58 PM" src="https://github.com/bpg/terraform-provider-proxmox/assets/627562/17d90819-2f6f-4936-9fc8-4ae28362a109">


Import:
```
❯ terraform import proxmox_virtual_environment_vm.test pve/1000
proxmox_virtual_environment_vm.test: Importing from ID "pve/1000"...
proxmox_virtual_environment_vm.test: Import prepared!
  Prepared proxmox_virtual_environment_vm for import
proxmox_virtual_environment_vm.test: Refreshing state... [id=1000]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```

Check the state:
```
❯ terraform state show proxmox_virtual_environment_vm.test
# proxmox_virtual_environment_vm.test:
resource "proxmox_virtual_environment_vm" "test" {
    acpi                    = true
    bios                    = "seabios"
    id                      = "1000"
    ipv4_addresses          = [
        [
            "127.0.0.1",
        ],
        [
            "192.168.3.247",
        ],
    ]
    ipv6_addresses          = [
        [
            "::1",
        ],
        [
            "fe80::be24:11ff:fec2:8b6d",
        ],
    ]
    keyboard_layout         = "en-us"
    mac_addresses           = [
        "00:00:00:00:00:00",
        "BC:24:11:C2:8B:6D",
    ]
    name                    = "test"
    network_interface_names = [
        "lo",
        "eth0",
    ]
    node_name               = "pve"
    scsi_hardware           = "virtio-scsi-pci"
    started                 = true
    tablet_device           = true
    tags                    = []
    template                = false
    vm_id                   = 1000

    agent {
        enabled = true
        timeout = "15m"
        trim    = false
        type    = "virtio"
    }

    cpu {
        cores      = 2
        flags      = []
        hotplugged = 0
        limit      = 0
        numa       = false
        sockets    = 1
        type       = "qemu64"
        units      = 1024
    }

    disk {
        cache             = "none"
        datastore_id      = "local-lvm"
        discard           = "on"
        file_format       = "raw"
        interface         = "virtio0"
        iothread          = true
        path_in_datastore = "vm-1000-disk-0"
        size              = 20
        ssd               = false
    }

    initialization {
        datastore_id      = "local-lvm"
        interface         = "ide2"
        user_data_file_id = "local:snippets/cloud-config.yaml"

        ip_config {
            ipv4 {
                address = "dhcp"
            }
        }
    }

    memory {
        dedicated = 2048
        floating  = 0
        shared    = 0
    }

    network_device {
        bridge      = "vmbr0"
        enabled     = true
        firewall    = false
        mac_address = "BC:24:11:C2:8B:6D"
        model       = "virtio"
        mtu         = 0
        queues      = 0
        rate_limit  = 0
        vlan_id     = 0
    }

    operating_system {
        type = "l26"
    }
}
```


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #782

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
