### PR TITLE
fix(pool): missing `pool_id` after import

### DIFF
--- a/proxmoxtf/resource/pool.go
+++ b/proxmoxtf/resource/pool.go
@@ -8,6 +8,7 @@ package resource
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -86,7 +87,15 @@ func Pool() *schema.Resource {
 		UpdateContext: poolUpdate,
 		DeleteContext: poolDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: func(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
+				d.SetId(d.Id())
+				err := d.Set(mkResourceVirtualEnvironmentPoolPoolID, d.Id())
+				if err != nil {
+					return nil, fmt.Errorf("failed setting state during import: %w", err)
+				}
+
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 	}
 }


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

With template:
```terraform
resource "proxmox_virtual_environment_pool" "import" {
  pool_id = "test"
}
```
```
❯ terraform import proxmox_virtual_environment_pool.import test
proxmox_virtual_environment_pool.import: Importing from ID "test"...
proxmox_virtual_environment_pool.import: Import prepared!
  Prepared proxmox_virtual_environment_pool for import
proxmox_virtual_environment_pool.import: Refreshing state... [id=test]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.

❯ terraform plan
proxmox_virtual_environment_pool.import: Refreshing state... [id=test]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #963

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
