### PR TITLE
fix(lxc): panic on empty `initialization.ip_config` block

### DIFF
--- a/proxmoxtf/resource/container.go
+++ b/proxmoxtf/resource/container.go
@@ -1341,6 +1341,10 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m interf
 		initializationIPConfig := initializationBlock[mkResourceVirtualEnvironmentContainerInitializationIPConfig].([]interface{})
 
 		for _, c := range initializationIPConfig {
+			if c == nil {
+				continue
+			}
+
 			configBlock := c.(map[string]interface{})
 			ipv4 := configBlock[mkResourceVirtualEnvironmentContainerInitializationIPConfigIPv4].([]interface{})
 
@@ -2641,6 +2645,10 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m interface{})
 		initializationIPConfig := initializationBlock[mkResourceVirtualEnvironmentContainerInitializationIPConfig].([]interface{})
 
 		for _, c := range initializationIPConfig {
+			if c == nil {
+				continue
+			}
+
 			configBlock := c.(map[string]interface{})
 			ipv4 := configBlock[mkResourceVirtualEnvironmentContainerInitializationIPConfigIPv4].([]interface{})
 


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Apply & reapply a template with

```terraform
  initialization {
    ip_config {}
  }
```
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # proxmox_virtual_environment_container.test_container will be updated in-place
  ~ resource "proxmox_virtual_environment_container" "test_container" {
        id            = "102"
        tags          = []
        # (7 unchanged attributes hidden)

      ~ initialization {
            # (1 unchanged attribute hidden)

          + ip_config {
            }

            # (1 unchanged block hidden)
        }

        # (5 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
proxmox_virtual_environment_container.test_container: Modifying... [id=102]
proxmox_virtual_environment_container.test_container: Modifications complete after 0s [id=102]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #936

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
