### PR TITLE
fix(file): use `sudo` for snippets upload

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,11 @@
 {
     "git.alwaysSignOff": true,
     "cSpell.words": [
+        "capi",
         "CLRF",
         "iothread",
         "keyctl",
+        "nolint",
         "proxmoxtf",
         "qcow",
         "rootfs",
@@ -13,7 +15,8 @@
         "virtio",
         "VLANID",
         "vmbr",
-        "VMID"
+        "VMID",
+        "vztmpl"
     ],
     "go.lintTool": "golangci-lint",
     "go.lintFlags": [

--- a/docs/index.md
+++ b/docs/index.md
@@ -160,12 +160,12 @@ You can configure the `sudo` privilege for the user via the command line on the 
     sudo visudo
     ```
 
-  Add the following line to the end of the file:
+  Add the following lines to the end of the file:
 
     ```sh
     terraform ALL=(root) NOPASSWD: /sbin/pvesm
     terraform ALL=(root) NOPASSWD: /sbin/qm
-    terraform ALL=(root) NOPASSWD: /usr/bin/echo tfpve
+    terraform ALL=(root) NOPASSWD: /usr/bin/mv /tmp/tfpve/* /var/lib/vz/*
     ```
 
   Save the file and exit.
@@ -179,10 +179,10 @@ You can configure the `sudo` privilege for the user via the command line on the 
 - Test the SSH connection and password-less `sudo`:
   
     ```sh
-    ssh terraform@<target-node> sudo echo tfpve
+    ssh terraform@<target-node> sudo pvesm apiinfo 
     ```
 
-  You should be able to connect to the target node and see the output `tfpve` on the screen without being prompted for your password.
+  You should be able to connect to the target node and see the output containing `APIVER <number>` on the screen without being prompted for your password.
 
 ### Node IP address used for SSH connection
 

--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -601,7 +601,7 @@ func fileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 			),
 		})
 		if err != nil {
-			if matches, _ := regexp.Match(`cannot move .* Permission denied`, []byte(err.Error())); matches {
+			if matches, e := regexp.MatchString(`cannot move .* Permission denied`, err.Error()); e == nil && matches {
 				return diag.FromErr(newErrSSHUserNoPermission(capi.SSH().Username()))
 			}
 

--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -17,10 +17,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -538,7 +540,12 @@ func fileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 	switch *contentType {
 	case "iso", "vztmpl":
 		uploadTimeout := d.Get(mkResourceVirtualEnvironmentFileTimeoutUpload).(int)
+
 		_, err = capi.Node(nodeName).Storage(datastoreID).APIUpload(ctx, request, uploadTimeout, config.TempDir())
+		if err != nil {
+			diags = append(diags, diag.FromErr(err)...)
+			return diags
+		}
 	default:
 		// For all other content types, we need to upload the file to the node's
 		// datastore using SFTP.
@@ -565,14 +572,43 @@ func fileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 			}...)
 		}
 
-		remoteFileDir := *datastore.Path
+		// the temp directory is used to store the file on the node before moving it to the datastore
+		// will be created if it does not exist
+		tempFileDir := fmt.Sprintf("/tmp/tfpve/%s", uuid.NewString())
 
-		err = capi.SSH().NodeUpload(ctx, nodeName, remoteFileDir, request)
-	}
+		err = capi.SSH().NodeUpload(ctx, nodeName, tempFileDir, request)
+		if err != nil {
+			diags = append(diags, diag.FromErr(err)...)
+			return diags
+		}
 
-	if err != nil {
-		diags = append(diags, diag.FromErr(err)...)
-		return diags
+		// handle the case where the file is uploaded to a subdirectory of the datastore
+		srcDir := tempFileDir
+		dstDir := *datastore.Path
+
+		if request.ContentType != "" {
+			srcDir = tempFileDir + "/" + request.ContentType
+			dstDir = *datastore.Path + "/" + request.ContentType
+		}
+
+		_, err := capi.SSH().ExecuteNodeCommands(ctx, nodeName, []string{
+			// the `mv`` command should be scoped to the specific directories in sudoers!
+			fmt.Sprintf(`%s; try_sudo "mv %s/%s %s/%s" && rm -rf %s`,
+				trySudo,
+				srcDir, *fileName,
+				dstDir, *fileName,
+				tempFileDir,
+			),
+		})
+		if err != nil {
+			if matches, _ := regexp.Match(`cannot move .* Permission denied`, []byte(err.Error())); matches {
+				return diag.FromErr(newErrSSHUserNoPermission(capi.SSH().Username()))
+			}
+
+			diags = append(diags, diag.Errorf("error moving file: %s", err.Error())...)
+
+			return diags
+		}
 	}
 
 	volID, di := fileGetVolumeID(d)

--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -592,12 +592,13 @@ func fileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 		}
 
 		_, err := capi.SSH().ExecuteNodeCommands(ctx, nodeName, []string{
-			// the `mv`` command should be scoped to the specific directories in sudoers!
-			fmt.Sprintf(`%s; try_sudo "mv %s/%s %s/%s" && rm -rf %s`,
+			// the `mv` command should be scoped to the specific directories in sudoers!
+			fmt.Sprintf(`%s; try_sudo "mv %s/%s %s/%s" && rm %s/%s && rmdir -p %s`,
 				trySudo,
 				srcDir, *fileName,
 				dstDir, *fileName,
-				tempFileDir,
+				srcDir, *fileName,
+				srcDir,
 			),
 		})
 		if err != nil {

--- a/proxmoxtf/resource/sudo.go
+++ b/proxmoxtf/resource/sudo.go
@@ -1,0 +1,15 @@
+package resource
+
+import (
+	"fmt"
+)
+
+const (
+	trySudo = `try_sudo(){ if [ $(sudo -n pvesm apiinfo 2>&1 | grep "APIVER" | wc -l) -gt 0 ]; then sudo $1; else $1; fi }`
+)
+
+func newErrSSHUserNoPermission(username string) error {
+	return fmt.Errorf("the SSH user '%s' does not have required permissions. "+
+		"Make sure 'sudo' is installed and the user is configured in sudoers file. "+
+		"Refer to the documentation for more details.", username)
+}

--- a/proxmoxtf/resource/sudo.go
+++ b/proxmoxtf/resource/sudo.go
@@ -11,5 +11,5 @@ const (
 func newErrSSHUserNoPermission(username string) error {
 	return fmt.Errorf("the SSH user '%s' does not have required permissions. "+
 		"Make sure 'sudo' is installed and the user is configured in sudoers file. "+
-		"Refer to the documentation for more details.", username)
+		"Refer to the documentation for more details", username)
 }

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -2974,7 +2975,7 @@ func vmCreateCustomDisks(ctx context.Context, d *schema.ResourceData, m interfac
 		commands = append(
 			commands,
 			`set -e`,
-			`try_sudo(){ if [ $(sudo -n echo tfpve 2>&1 | grep "tfpve" | wc -l) -gt 0 ]; then sudo $1; else $1; fi }`,
+			trySudo,
 			fmt.Sprintf(`file_id="%s"`, fileID),
 			fmt.Sprintf(`file_format="%s"`, fileFormat),
 			fmt.Sprintf(`datastore_id_target="%s"`, datastoreID),
@@ -3007,9 +3008,8 @@ func vmCreateCustomDisks(ctx context.Context, d *schema.ResourceData, m interfac
 
 		out, err := api.SSH().ExecuteNodeCommands(ctx, nodeName, commands)
 		if err != nil {
-			if strings.Contains(err.Error(), "pvesm: not found") {
-				return diag.Errorf("The configured SSH user '%s' does not have the required permissions to import disks. "+
-					"Make sure `sudo` is installated and the user is a member of sudoers.", api.SSH().Username())
+			if matches, _ := regexp.Match(`pvesm: .* not found`, out); matches {
+				return diag.FromErr(newErrSSHUserNoPermission(api.SSH().Username()))
 			}
 
 			return diag.FromErr(err)

--- a/proxmoxtf/resource/vm.go
+++ b/proxmoxtf/resource/vm.go
@@ -3008,7 +3008,7 @@ func vmCreateCustomDisks(ctx context.Context, d *schema.ResourceData, m interfac
 
 		out, err := api.SSH().ExecuteNodeCommands(ctx, nodeName, commands)
 		if err != nil {
-			if matches, _ := regexp.Match(`pvesm: .* not found`, out); matches {
+			if matches, e := regexp.Match(`pvesm: .* not found`, out); e == nil && matches {
 				return diag.FromErr(newErrSSHUserNoPermission(api.SSH().Username()))
 			}
 


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

With sudoers like
```
terraform ALL=(root) NOPASSWD: /sbin/pvesm
terraform ALL=(root) NOPASSWD: /sbin/qm
terraform ALL=(root) NOPASSWD: /usr/bin/mv /tmp/tfpve/* /var/lib/vz/*
```
and permissions on the datastore folder
```
root@pve:~# ls -la /var/lib/vz/
total 28
drwxr-xr-x  7 root root 4096 Dec 17 18:05 .
drwxr-xr-x 38 root root 4096 Jan 26 20:06 ..
drwxr-xr-x  2 root root 4096 Nov  5 09:32 dump
drwxr-xr-x  3 root root 4096 Feb  3 23:33 images
drwxr-xr-x  2 root root 4096 Dec 17 18:05 private
drwxr-xr-x  2 root root 4096 Feb  5 00:20 snippets
drwxr-xr-x  4 root root 4096 Feb  5 00:13 template
```
applying of the [example template](https://github.com/bpg/terraform-provider-proxmox/blob/main/examples/guides/cloud-init/custom/main.tf) works without errors:
```
Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + vm_ipv4_address = (known after apply)
proxmox_virtual_environment_file.cloud_config: Creating...
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Creating...
proxmox_virtual_environment_file.cloud_config: Creation complete after 1s [id=local:snippets/cloud-config.yaml]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Still creating... [10s elapsed]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Still creating... [20s elapsed]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Creation complete after 26s [id=local:iso/jammy-server-cloudimg-amd64.img]
proxmox_virtual_environment_vm.ubuntu_vm: Creating...
proxmox_virtual_environment_vm.ubuntu_vm: Still creating... [10s elapsed]
proxmox_virtual_environment_vm.ubuntu_vm: Still creating... [20s elapsed]
proxmox_virtual_environment_vm.ubuntu_vm: Still creating... [30s elapsed]
proxmox_virtual_environment_vm.ubuntu_vm: Still creating... [40s elapsed]
proxmox_virtual_environment_vm.ubuntu_vm: Still creating... [50s elapsed]
proxmox_virtual_environment_vm.ubuntu_vm: Creation complete after 55s [id=100]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```

uploaded snippet:
```
root@pve:~# ls -la /var/lib/vz/snippets/
total 144
drwxr-xr-x 2 root      root      4096 Feb  5 01:05 .
drwxr-xr-x 7 root      root      4096 Dec 17 18:05 ..
-rw-r--r-- 1 terraform terraform 1147 Feb  5 01:05 cloud-config.yaml
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #986

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
