### PR TITLE
fix(lxc): panic when handling `network_interface.firewall` attribute

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,8 @@
         "iothread",
         "keyctl",
         "mbps",
+        "nameserver",
+        "nestif",
         "nolint",
         "NUMA",
         "proxmoxtf",

--- a/proxmoxtf/resource/container.go
+++ b/proxmoxtf/resource/container.go
@@ -1512,12 +1512,14 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m interf
 		rateLimit := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceRateLimit].(float64)
 		vlanID := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceVLANID].(int)
 		mtu := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceMTU].(int)
+		firewall := networkInterfaceMap[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall].(bool)
 
 		if bridge != "" {
 			networkInterfaceObject.Bridge = &bridge
 		}
 
 		networkInterfaceObject.Enabled = enabled
+		networkInterfaceObject.Name = name
 
 		if len(initializationIPConfigIPv4Address) > ni {
 			if initializationIPConfigIPv4Address[ni] != "" {
@@ -1537,11 +1539,13 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m interf
 			}
 		}
 
+		if firewall {
+			networkInterfaceObject.Firewall = types.CustomBool(firewall).Pointer()
+		}
+
 		if macAddress != "" {
 			networkInterfaceObject.MACAddress = &macAddress
 		}
-
-		networkInterfaceObject.Name = name
 
 		if rateLimit != 0 {
 			networkInterfaceObject.RateLimit = &rateLimit
@@ -1739,15 +1743,17 @@ func containerGetExistingNetworkInterface(
 
 		networkInterface := map[string]interface{}{}
 
+		networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceEnabled] = true
+		networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceName] = nv.Name
+
 		if nv.Bridge != nil {
 			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceBridge] = *nv.Bridge
 		} else {
 			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceBridge] = ""
 		}
 
-		networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceEnabled] = true
-		if nv.Firewall != nil {
-			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall] = *nv.Firewall
+		if nv.Firewall != nil && *nv.Firewall {
+			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall] = true
 		} else {
 			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall] = false
 		}
@@ -1757,8 +1763,6 @@ func containerGetExistingNetworkInterface(
 		} else {
 			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceMACAddress] = ""
 		}
-
-		networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceName] = nv.Name
 
 		if nv.RateLimit != nil {
 			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceRateLimit] = *nv.RateLimit
@@ -2287,16 +2291,17 @@ func containerRead(ctx context.Context, d *schema.ResourceData, m interface{}) d
 
 		networkInterface := map[string]interface{}{}
 
+		networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceEnabled] = true
+		networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceName] = nv.Name
+
 		if nv.Bridge != nil {
 			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceBridge] = *nv.Bridge
 		} else {
 			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceBridge] = ""
 		}
 
-		networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceEnabled] = true
-
-		if nv.Firewall != nil {
-			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall] = *nv.Firewall
+		if nv.Firewall != nil && *nv.Firewall {
+			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall] = true
 		} else {
 			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceFirewall] = false
 		}
@@ -2306,8 +2311,6 @@ func containerRead(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		} else {
 			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceMACAddress] = ""
 		}
-
-		networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceName] = nv.Name
 
 		if nv.RateLimit != nil {
 			networkInterface[mkResourceVirtualEnvironmentContainerNetworkInterfaceRateLimit] = *nv.RateLimit


### PR DESCRIPTION
Besides the panic from #1025, also fixes setting the `firewall` flag on container's network interface at creation.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Apply & re-apply of the following plan works now:
```terraform
resource "proxmox_virtual_environment_container" "test_container" {
  node_name = var.virtual_environment_node_name
  vm_id     = 9000

  disk {
    datastore_id = "local-lvm"
    size         = 8
  }

  started  = false
  template = true

  initialization {
    hostname = "test"

    ip_config {
      ipv4 {
        address = "dhcp"
      }
    }

    user_account {
      password = "password"
    }
  }

  network_interface {
    name     = "vmbr0"
    firewall = true
  }

  operating_system {
    template_file_id = proxmox_virtual_environment_download_file.ubuntu_container_template.id
    type             = "ubuntu"
  }
}

resource "proxmox_virtual_environment_download_file" "ubuntu_container_template" {
  content_type = "vztmpl"
  datastore_id = "local"
  node_name    = "pve"
  url          = "http://download.proxmox.com/images/system/ubuntu-20.04-standard_20.04-1_amd64.tar.gz"
}


resource "proxmox_virtual_environment_container" "clone_container" {
  node_name = var.virtual_environment_node_name
  vm_id     = 9001

  clone {
    datastore_id = "local-lvm"
    vm_id        = proxmox_virtual_environment_container.test_container.id
  }

}
```

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # proxmox_virtual_environment_container.clone_container will be created
  + resource "proxmox_virtual_environment_container" "clone_container" {
      + id            = (known after apply)
      + node_name     = "pve"
      + start_on_boot = true
      + started       = true
      + template      = false
      + unprivileged  = false
      + vm_id         = 9001

      + clone {
          + datastore_id = "local-lvm"
          + vm_id        = (known after apply)
        }
    }

  # proxmox_virtual_environment_container.test_container will be created
  + resource "proxmox_virtual_environment_container" "test_container" {
      + id            = (known after apply)
      + node_name     = "pve"
      + start_on_boot = true
      + template      = true
      + unprivileged  = false
      + vm_id         = 9000

      + disk {
          + datastore_id = "local-lvm"
          + size         = 8
        }

      + initialization {
          + hostname = "test"

          + ip_config {
              + ipv4 {
                  + address = "dhcp"
                }
            }

          + user_account {
              + password = (sensitive value)
            }
        }

      + network_interface {
          + bridge     = "vmbr0"
          + enabled    = true
          + firewall   = true
          + mtu        = 0
          + name       = "vmbr0"
          + rate_limit = 0
          + vlan_id    = 0
        }

      + operating_system {
          + template_file_id = (known after apply)
          + type             = "ubuntu"
        }
    }

  # proxmox_virtual_environment_download_file.ubuntu_container_template will be created
  + resource "proxmox_virtual_environment_download_file" "ubuntu_container_template" {
      + content_type   = "vztmpl"
      + datastore_id   = "local"
      + file_name      = (known after apply)
      + id             = (known after apply)
      + node_name      = "pve"
      + overwrite      = true
      + size           = (known after apply)
      + upload_timeout = 600
      + url            = "http://download.proxmox.com/images/system/ubuntu-20.04-standard_20.04-1_amd64.tar.gz"
      + verify         = true
    }

Plan: 3 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_download_file.ubuntu_container_template: Creating...
proxmox_virtual_environment_download_file.ubuntu_container_template: Creation complete after 5s [id=local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz]
proxmox_virtual_environment_container.test_container: Creating...
proxmox_virtual_environment_container.test_container: Still creating... [4m10s elapsed]
...
proxmox_virtual_environment_container.test_container: Creation complete after 4m15s [id=9000]
proxmox_virtual_environment_container.clone_container: Creating...
proxmox_virtual_environment_container.clone_container: Still creating... [10s elapsed]
proxmox_virtual_environment_container.clone_container: Creation complete after 16s [id=9001]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
❯ terraform apply -auto-approve
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - bpg/proxmox in /Users/pasha/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become
│ incompatible with published releases.
╵
proxmox_virtual_environment_download_file.ubuntu_container_template: Refreshing state... [id=local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz]
proxmox_virtual_environment_container.test_container: Refreshing state... [id=9000]
proxmox_virtual_environment_container.clone_container: Refreshing state... [id=9001]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1025

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
