### PR TITLE
fix(lxc): panic on empty `initialization.ip_config.ipv4|6` block

### DIFF
--- a/proxmoxtf/resource/container.go
+++ b/proxmoxtf/resource/container.go
@@ -1353,7 +1353,7 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m interf
 			configBlock := c.(map[string]interface{})
 			ipv4 := configBlock[mkResourceVirtualEnvironmentContainerInitializationIPConfigIPv4].([]interface{})
 
-			if len(ipv4) > 0 {
+			if len(ipv4) > 0 && ipv4[0] != nil {
 				ipv4Block := ipv4[0].(map[string]interface{})
 
 				initializationIPConfigIPv4Address = append(
@@ -1372,7 +1372,7 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m interf
 
 			ipv6 := configBlock[mkResourceVirtualEnvironmentContainerInitializationIPConfigIPv6].([]interface{})
 
-			if len(ipv6) > 0 {
+			if len(ipv6) > 0 && ipv6[0] != nil {
 				ipv6Block := ipv6[0].(map[string]interface{})
 
 				initializationIPConfigIPv6Address = append(
@@ -2660,7 +2660,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m interface{})
 			configBlock := c.(map[string]interface{})
 			ipv4 := configBlock[mkResourceVirtualEnvironmentContainerInitializationIPConfigIPv4].([]interface{})
 
-			if len(ipv4) > 0 {
+			if len(ipv4) > 0 && ipv4[0] != nil {
 				ipv4Block := ipv4[0].(map[string]interface{})
 
 				initializationIPConfigIPv4Address = append(
@@ -2679,7 +2679,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m interface{})
 
 			ipv6 := configBlock[mkResourceVirtualEnvironmentContainerInitializationIPConfigIPv6].([]interface{})
 
-			if len(ipv6) > 0 {
+			if len(ipv6) > 0 && ipv6[0] != nil {
 				ipv6Block := ipv6[0].(map[string]interface{})
 
 				initializationIPConfigIPv6Address = append(


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Apply & re-apply of this template works without panic now:
```terraform
resource "proxmox_virtual_environment_container" "test_container" {
  node_name = var.virtual_environment_node_name

  disk {
    datastore_id = "local-lvm"
    size         = 8
  }

  started  = true

  initialization {
    hostname = "test"

    ip_config {
      ipv4 {}
      ipv6 {}
    }

    user_account {
      password = "password"
    }
  }

  network_interface {
    name     = "vmbr0"
    firewall = true
  }

  operating_system {
    template_file_id = proxmox_virtual_environment_download_file.ubuntu_container_template.id
    type             = "ubuntu"
  }
}

resource "proxmox_virtual_environment_download_file" "ubuntu_container_template" {
  content_type = "vztmpl"
  datastore_id = "local"
  node_name    = "pve"
  url          = "http://download.proxmox.com/images/system/ubuntu-20.04-standard_20.04-1_amd64.tar.gz"
}
```
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # proxmox_virtual_environment_container.test_container will be created
  + resource "proxmox_virtual_environment_container" "test_container" {
      + id            = (known after apply)
      + node_name     = "pve"
      + start_on_boot = true
      + started       = true
      + template      = false
      + unprivileged  = false
      + vm_id         = -1

      + disk {
          + datastore_id = "local-lvm"
          + size         = 8
        }

      + initialization {
          + hostname = "test"

          + ip_config {
              + ipv4 {}
              + ipv6 {}
            }

          + user_account {
              + password = (sensitive value)
            }
        }

      + network_interface {
          + bridge     = "vmbr0"
          + enabled    = true
          + firewall   = true
          + mtu        = 0
          + name       = "vmbr0"
          + rate_limit = 0
          + vlan_id    = 0
        }

      + operating_system {
          + template_file_id = (known after apply)
          + type             = "ubuntu"
        }
    }

  # proxmox_virtual_environment_download_file.ubuntu_container_template will be created
  + resource "proxmox_virtual_environment_download_file" "ubuntu_container_template" {
      + content_type   = "vztmpl"
      + datastore_id   = "local"
      + file_name      = (known after apply)
      + id             = (known after apply)
      + node_name      = "pve"
      + overwrite      = true
      + size           = (known after apply)
      + upload_timeout = 600
      + url            = "http://download.proxmox.com/images/system/ubuntu-20.04-standard_20.04-1_amd64.tar.gz"
      + verify         = true
    }

Plan: 2 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_download_file.ubuntu_container_template: Creating...
proxmox_virtual_environment_download_file.ubuntu_container_template: Creation complete after 5s [id=local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz]
proxmox_virtual_environment_container.test_container: Creating...
proxmox_virtual_environment_container.test_container: Still creating... [10s elapsed]
proxmox_virtual_environment_container.test_container: Creation complete after 11s [id=103]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
❯ terraform apply -auto-approve
proxmox_virtual_environment_download_file.ubuntu_container_template: Refreshing state... [id=local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz]
proxmox_virtual_environment_container.test_container: Refreshing state... [id=103]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  ~ update in-place

Terraform will perform the following actions:

  # proxmox_virtual_environment_container.test_container will be updated in-place
  ~ resource "proxmox_virtual_environment_container" "test_container" {
        id            = "103"
        tags          = []
        # (6 unchanged attributes hidden)

      ~ initialization {
            # (1 unchanged attribute hidden)

          + ip_config {
              + ipv4 {}
              + ipv6 {}
            }

            # (1 unchanged block hidden)
        }

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
proxmox_virtual_environment_container.test_container: Modifying... [id=103]
proxmox_virtual_environment_container.test_container: Modifications complete after 0s [id=103]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1036

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
