### PR TITLE
fix(vm): regression: `mac_addresses` list is missing some interfaces

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "mode": "test",
             "program": "${workspaceFolder}/fwprovider/tests",
             "envFile": "${workspaceFolder}/testacc.env",
-            "args": ["-debug", "-test.v", "-test.timeout", "30s"]
+            "args": ["-debug", "-test.v", "-test.timeout", "120s"]
             
         },
         {

--- a/fwprovider/tests/resource_vm_test.go
+++ b/fwprovider/tests/resource_vm_test.go
@@ -80,6 +80,93 @@ func TestAccResourceVM(t *testing.T) {
 	}
 }
 
+func TestAccResourceVMNetwork(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		step resource.TestStep
+	}{
+		{"network interfaces mac", resource.TestStep{
+			Config: `
+				resource "proxmox_virtual_environment_file" "cloud_config" {
+					content_type = "snippets"
+					datastore_id = "local"
+					node_name    = "pve"
+					source_raw {
+						data = <<EOF
+#cloud-config
+runcmd:
+  - apt update
+  - apt install -y qemu-guest-agent
+  - systemctl enable qemu-guest-agent
+  - systemctl start qemu-guest-agent
+EOF
+						file_name = "cloud-config.yaml"
+					}
+				}
+				
+				resource "proxmox_virtual_environment_vm" "test_vm_network1" {
+					node_name = "pve"
+					started   = true
+					agent {
+						enabled = true
+					}
+					cpu {
+						cores = 2
+					}
+					memory {
+						dedicated = 2048
+					}
+					disk {
+						datastore_id = "local-lvm"
+						file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
+						interface    = "virtio0"
+						iothread     = true
+						discard      = "on"
+						size         = 20
+					}
+					initialization {
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+						user_data_file_id = proxmox_virtual_environment_file.cloud_config.id
+					}
+					network_device {
+						bridge = "vmbr0"
+					}
+				}
+
+				resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
+					content_type = "iso"
+					datastore_id = "local"
+					node_name    = "pve"
+					url = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+				}`,
+			Check: resource.ComposeTestCheckFunc(
+				resource.TestCheckResourceAttr("proxmox_virtual_environment_vm.test_vm_network1", "ipv4_addresses.#", "2"),
+				resource.TestCheckResourceAttr("proxmox_virtual_environment_vm.test_vm_network1", "mac_addresses.#", "2"),
+			),
+		}},
+	}
+
+	accProviders := testAccMuxProviders(context.Background(), t)
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			resource.Test(t, resource.TestCase{
+				ProtoV6ProviderFactories: accProviders,
+				Steps:                    []resource.TestStep{tt.step},
+			})
+		})
+	}
+}
+
 func TestAccResourceVMDisks(t *testing.T) {
 	t.Parallel()
 

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -518,7 +518,7 @@ func Container() *schema.Resource {
 										ForceNew:    true,
 										Sensitive:   true,
 										Default:     dvInitializationUserAccountPassword,
-										DiffSuppressFunc: func(k, oldVal, newVal string, d *schema.ResourceData) bool {
+										DiffSuppressFunc: func(k, oldVal, _ string, _ *schema.ResourceData) bool {
 											return len(oldVal) > 0 &&
 												strings.ReplaceAll(oldVal, "*", "") == ""
 										},
@@ -604,7 +604,7 @@ func Container() *schema.Resource {
 							// 	// PVE strips leading slashes from the path, so we have to do the same
 							// 	return strings.TrimPrefix(i.(string), "/")
 							// },
-							DiffSuppressFunc: func(k, oldVal, newVal string, d *schema.ResourceData) bool {
+							DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
 								return "/"+oldVal == newVal
 							},
 						},
@@ -691,7 +691,7 @@ func Container() *schema.Resource {
 							Description: "The MAC address",
 							Optional:    true,
 							Default:     dvNetworkInterfaceMACAddress,
-							DiffSuppressFunc: func(k, oldVal, newVal string, d *schema.ResourceData) bool {
+							DiffSuppressFunc: func(_, _, newVal string, _ *schema.ResourceData) bool {
 								return newVal == ""
 							},
 							ValidateDiagFunc: validator.MACAddress(),

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5169,6 +5169,9 @@ func vmReadNetworkValues(
 					networkInterfaceNames[ri] = rv.Name
 				}
 			}
+
+			err = d.Set(mkMACAddresses, macAddresses)
+			diags = append(diags, diag.FromErr(err)...)
 		}
 	}
 


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Using the [cloud-init example](https://github.com/bpg/terraform-provider-proxmox/blob/main/examples/guides/cloud-init/custom/main.tf) with addition of these outputs:
```terrafrom
output "vm_all_ipv4_address" {
  value = proxmox_virtual_environment_vm.ubuntu_vm.ipv4_addresses
}

output "vm_all_mac_addresses" {
  value = proxmox_virtual_environment_vm.ubuntu_vm.mac_addresses
}
```

Results before the fix:
```
Outputs:

vm_all_ipv4_address = tolist([
  tolist([
    "127.0.0.1",
  ]),
  tolist([
    "192.168.XXX.XXX",
  ]),
])
vm_all_mac_addresses = tolist([
  "BC:24:11:17:49:4F",
])
```
after the fix:
```
Outputs:

vm_all_ipv4_address = tolist([
  tolist([
    "127.0.0.1",
  ]),
  tolist([
    "192.168.XXX.XXX",
  ]),
])
vm_all_mac_addresses = tolist([
  "00:00:00:00:00:00",
  "BC:24:11:6B:F9:89",
])
```


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1048

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
