### PR TITLE
Fix race condition issue for ~/.ssh directory

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -866,6 +866,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "Dr-Shadow",
+      "name": "Dr-Shadow",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5308086?v=4",
+      "profile": "https://github.com/Dr-Shadow",
+      "contributions": [
+        "bug"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -124,6 +124,7 @@
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ecanuto"><img src="https://avatars.githubusercontent.com/u/55260?v=4?s=100" width="100px;" alt="Everaldo Canuto"/><br /><sub><b>Everaldo Canuto</b></sub></a><br /><a href="https://github.com/bpg/terraform-provider-proxmox/commits?author=ecanuto" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Dr-Shadow"><img src="https://avatars.githubusercontent.com/u/5308086?v=4?s=100" width="100px;" alt="Dr-Shadow"/><br /><sub><b>Dr-Shadow</b></sub></a><br /><a href="https://github.com/bpg/terraform-provider-proxmox/issues?q=author%3ADr-Shadow" title="Bug reports">🐛</a></td>
     </tr>
   </tbody>
   <tfoot>

--- a/proxmox/ssh/client.go
+++ b/proxmox/ssh/client.go
@@ -256,7 +256,7 @@ func (c *client) openNodeShell(ctx context.Context, node ProxmoxNode) (*ssh.Clie
 	sshPath := path.Join(homeDir, ".ssh")
 	if _, err = os.Stat(sshPath); os.IsNotExist(err) {
 		e := os.Mkdir(sshPath, 0o700)
-		if e != nil {
+		if e != nil && !os.IsExist(e) {
 			return nil, fmt.Errorf("failed to create %s: %w", sshPath, e)
 		}
 	}


### PR DESCRIPTION
### Contributor's Note

I am using the provider and repeatedly ran into an issue where the `.ssh` directory was already existent for some users, when the provider tried to add `authorized_keys`. This small change should fix this issue.

- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions. (N/A)
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources. (N/A)
- [ x] I have ran `make example` to verify that the change works as expected.


### Proof of Work
![Screenshot from 2024-02-22 11-45-24](https://github.com/bpg/terraform-provider-proxmox/assets/10672940/e999a460-001c-4a62-b29b-198892e5bd10)

This error did not occur anymore after I tested my suggested fix here.
An alternative way could be to use [os.mkdirall](https://pkg.go.dev/os#MkdirAll) but I figured this way introduces the least changes.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000 | Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
