### PR TITLE
fix(provider): race condition in`~/.ssh` path existence check

### DIFF
--- a/proxmox/ssh/client.go
+++ b/proxmox/ssh/client.go
@@ -256,7 +256,7 @@ func (c *client) openNodeShell(ctx context.Context, node ProxmoxNode) (*ssh.Clie
 	sshPath := path.Join(homeDir, ".ssh")
 	if _, err = os.Stat(sshPath); os.IsNotExist(err) {
 		e := os.Mkdir(sshPath, 0o700)
-		if e != nil {
+		if e != nil && !os.IsExist(e) {
 			return nil, fmt.Errorf("failed to create %s: %w", sshPath, e)
 		}
 	}


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->

I am using the provider and repeatedly ran into an issue where the .ssh directory was already existent for some users, when the provider tried to add authorized_keys. This small change should fix this issue.

- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions. (imo N/A here)
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources. (imo N/A here)
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
The screenshot below shows the error that kept popping up for me.
![Screenshot from 2024-02-22 11-45-24](https://github.com/bpg/terraform-provider-proxmox/assets/10672940/655a2752-01e6-4f36-b1bd-5c6145bed920)

With the small fix in this PR if have not encountered the issue again.
An alternative way could be to use [os.mkdirall](https://pkg.go.dev/os#MkdirAll) but I figured this way introduces the least changes.


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->

<!---
BEGIN_COMMIT_OVERRIDE
fix(provider): race condition in`~/.ssh` path existence check (#1052)
END_COMMIT_OVERRIDE
--->