### PR TITLE
fix(docs): fix wrong startup delay attributes

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -202,10 +202,10 @@ output "ubuntu_container_public_key" {
 - `startup` - (Optional) Defines startup and shutdown behavior of the container.
     - `order` - (Required) A non-negative number defining the general startup
         order.
-        - `up` - (Optional) A non-negative number defining the delay in seconds
-            before the next container is started.
-        - `down` - (Optional) A non-negative number defining the delay in
-            seconds before the next container is shut down.
+    - `up_delay` - (Optional) A non-negative number defining the delay in
+        seconds before the next container is started.
+    - `down_delay` - (Optional) A non-negative number defining the delay in
+        seconds before the next container is shut down.
 - `start_on_boot` - (Optional) Automatically start container when the host
   system boots (defaults to `true`).
 - `tags` - (Optional) A list of tags the container tags. This is only meta

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -465,10 +465,10 @@ output "ubuntu_vm_public_key" {
 - `startup` - (Optional) Defines startup and shutdown behavior of the VM.
     - `order` - (Required) A non-negative number defining the general startup
         order.
-    - `up` - (Optional) A non-negative number defining the delay in seconds
-        before the next VM is started.
-    - `down` - (Optional) A non-negative number defining the delay in seconds
-        before the next VM is shut down.
+    - `up_delay` - (Optional) A non-negative number defining the delay in
+        seconds before the next VM is started.
+    - `down_delay` - (Optional) A non-negative number defining the delay in
+        seconds before the next VM is shut down.
 - `tablet_device` - (Optional) Whether to enable the USB tablet device (defaults
     to `true`).
 - `tags` - (Optional) A list of tags of the VM. This is only meta information (


### PR DESCRIPTION
### Contributor's Note
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

### Proof of Work

Simple fix for the docs to match the updated define

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000 | Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!---
BEGIN_COMMIT_OVERRIDE
fix(docs): fix wrong startup delay attributes (#1088)
END_COMMIT_OVERRIDE
--->
