### PR TITLE
feat(vm): add support for `disconnected` attribute in network interface

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -408,20 +408,17 @@ output "ubuntu_vm_public_key" {
     it (defaults to `false`).
 - `name` - (Optional) The virtual machine name.
 - `network_device` - (Optional) A network device (multiple blocks supported).
-    - `bridge` - (Optional) The name of the network bridge (defaults
-        to `vmbr0`).
-    - `enabled` - (Optional) Whether to enable the network device (defaults
-        to `true`).
-    - `firewall` - (Optional) Whether this interface's firewall rules should be
-        used (defaults to `false`).
+    - `bridge` - (Optional) The name of the network bridge (defaults to `vmbr0`).
+    - `disconnected` - (Optional) Whether to disconnect the network device from the network (defaults to `false`).
+    - `enabled` - (Optional) Whether to enable the network device (defaults to `true`).
+    - `firewall` - (Optional) Whether this interface's firewall rules should be used (defaults to `false`).
     - `mac_address` - (Optional) The MAC address.
     - `model` - (Optional) The network device model (defaults to `virtio`).
         - `e1000` - Intel E1000.
         - `rtl8139` - Realtek RTL8139.
         - `virtio` - VirtIO (paravirtualized).
         - `vmxnet3` - VMware vmxnet3.
-    - `mtu` - (Optional) Force MTU, for VirtIO only. Set to 1 to use the bridge
-        MTU. Cannot be larger than the bridge MTU.
+    - `mtu` - (Optional) Force MTU, for VirtIO only. Set to 1 to use the bridge MTU. Cannot be larger than the bridge MTU.
     - `queues` - (Optional) The number of queues for VirtIO (1..64).
     - `rate_limit` - (Optional) The rate limit in megabytes per second.
     - `vlan_id` - (Optional) The VLAN identifier.

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -89,16 +89,16 @@ type CustomEFIDisk struct {
 
 // CustomNetworkDevice handles QEMU network device parameters.
 type CustomNetworkDevice struct {
-	Model      string            `json:"model"               url:"model"`
-	Bridge     *string           `json:"bridge,omitempty"    url:"bridge,omitempty"`
 	Enabled    bool              `json:"-"                   url:"-"`
+	Bridge     *string           `json:"bridge,omitempty"    url:"bridge,omitempty"`
 	Firewall   *types.CustomBool `json:"firewall,omitempty"  url:"firewall,omitempty,int"`
 	LinkDown   *types.CustomBool `json:"link_down,omitempty" url:"link_down,omitempty,int"`
 	MACAddress *string           `json:"macaddr,omitempty"   url:"macaddr,omitempty"`
+	MTU        *int              `json:"mtu,omitempty"       url:"mtu,omitempty"`
+	Model      string            `json:"model"               url:"model"`
 	Queues     *int              `json:"queues,omitempty"    url:"queues,omitempty"`
 	RateLimit  *float64          `json:"rate,omitempty"      url:"rate,omitempty"`
 	Tag        *int              `json:"tag,omitempty"       url:"tag,omitempty"`
-	MTU        *int              `json:"mtu,omitempty"       url:"mtu,omitempty"`
 	Trunks     []int             `json:"trunks,omitempty"    url:"trunks,omitempty"`
 }
 

--- a/proxmoxtf/resource/vm/network/network.go
+++ b/proxmoxtf/resource/vm/network/network.go
@@ -23,15 +23,16 @@ func GetNetworkDeviceObjects(d *schema.ResourceData) (vms.CustomNetworkDevices, 
 		block := networkDeviceEntry.(map[string]interface{})
 
 		bridge := block[mkNetworkDeviceBridge].(string)
+		disconnected := types.CustomBool(block[mkNetworkDeviceDisconnected].(bool))
 		enabled := block[mkNetworkDeviceEnabled].(bool)
 		firewall := types.CustomBool(block[mkNetworkDeviceFirewall].(bool))
 		macAddress := block[mkNetworkDeviceMACAddress].(string)
 		model := block[mkNetworkDeviceModel].(string)
+		mtu := block[mkNetworkDeviceMTU].(int)
 		queues := block[mkNetworkDeviceQueues].(int)
 		rateLimit := block[mkNetworkDeviceRateLimit].(float64)
-		vlanID := block[mkNetworkDeviceVLANID].(int)
 		trunks := block[mkNetworkDeviceTrunks].(string)
-		mtu := block[mkNetworkDeviceMTU].(int)
+		vlanID := block[mkNetworkDeviceVLANID].(int)
 
 		device := vms.CustomNetworkDevice{
 			Enabled:  enabled,
@@ -41,6 +42,10 @@ func GetNetworkDeviceObjects(d *schema.ResourceData) (vms.CustomNetworkDevices, 
 
 		if bridge != "" {
 			device.Bridge = &bridge
+		}
+
+		if disconnected {
+			device.LinkDown = &disconnected
 		}
 
 		if macAddress != "" {
@@ -144,6 +149,12 @@ func ReadNetworkDeviceObjects(d *schema.ResourceData, vmConfig *vms.GetResponseD
 			}
 
 			networkDevice[mkNetworkDeviceEnabled] = nd.Enabled
+
+			if nd.LinkDown != nil {
+				networkDevice[mkNetworkDeviceDisconnected] = *nd.LinkDown
+			} else {
+				networkDevice[mkNetworkDeviceDisconnected] = false
+			}
 
 			if nd.Firewall != nil {
 				networkDevice[mkNetworkDeviceFirewall] = *nd.Firewall

--- a/proxmoxtf/resource/vm/network/schema.go
+++ b/proxmoxtf/resource/vm/network/schema.go
@@ -17,30 +17,31 @@ const (
 	dvNetworkDeviceBridge    = "vmbr0"
 	dvNetworkDeviceEnabled   = true
 	dvNetworkDeviceFirewall  = false
+	dvNetworkDeviceMTU       = 0
 	dvNetworkDeviceModel     = "virtio"
 	dvNetworkDeviceQueues    = 0
 	dvNetworkDeviceRateLimit = 0
-	dvNetworkDeviceVLANID    = 0
 	dvNetworkDeviceTrunks    = ""
-	dvNetworkDeviceMTU       = 0
+	dvNetworkDeviceVLANID    = 0
 
 	mkIPv4Addresses = "ipv4_addresses"
 	mkIPv6Addresses = "ipv6_addresses"
 	mkMACAddresses  = "mac_addresses"
 
 	// MkNetworkDevice is the name of the network device.
-	MkNetworkDevice           = "network_device"
-	mkNetworkDeviceBridge     = "bridge"
-	mkNetworkDeviceEnabled    = "enabled"
-	mkNetworkDeviceFirewall   = "firewall"
-	mkNetworkDeviceMACAddress = "mac_address"
-	mkNetworkDeviceModel      = "model"
-	mkNetworkDeviceQueues     = "queues"
-	mkNetworkDeviceRateLimit  = "rate_limit"
-	mkNetworkDeviceVLANID     = "vlan_id"
-	mkNetworkDeviceTrunks     = "trunks"
-	mkNetworkDeviceMTU        = "mtu"
-	mkNetworkInterfaceNames   = "network_interface_names"
+	MkNetworkDevice             = "network_device"
+	mkNetworkDeviceBridge       = "bridge"
+	mkNetworkDeviceDisconnected = "disconnected"
+	mkNetworkDeviceEnabled      = "enabled"
+	mkNetworkDeviceFirewall     = "firewall"
+	mkNetworkDeviceMACAddress   = "mac_address"
+	mkNetworkDeviceMTU          = "mtu"
+	mkNetworkDeviceModel        = "model"
+	mkNetworkDeviceQueues       = "queues"
+	mkNetworkDeviceRateLimit    = "rate_limit"
+	mkNetworkDeviceTrunks       = "trunks"
+	mkNetworkDeviceVLANID       = "vlan_id"
+	mkNetworkInterfaceNames     = "network_interface_names"
 )
 
 // Schema returns the schema for the network resource.
@@ -85,6 +86,11 @@ func Schema() map[string]*schema.Schema {
 						Description: "The bridge",
 						Optional:    true,
 						Default:     dvNetworkDeviceBridge,
+					},
+					mkNetworkDeviceDisconnected: {
+						Type:        schema.TypeBool,
+						Description: "Whether the network device should be disconnected from the network",
+						Optional:    true,
 					},
 					mkNetworkDeviceEnabled: {
 						Type:        schema.TypeBool,


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

A VM template with
```terraform
network_device {
  bridge = "vmbr0"
  disconnected = true
}
```
produced:
<img width="649" alt="Screenshot 2024-03-15 at 9 32 25 PM" src="https://github.com/bpg/terraform-provider-proxmox/assets/627562/d92a7b48-b914-4bab-adaa-6ffbd5bc0c82">


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1093

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
