### PR TITLE
feat(lxc): add configurable timeout for container creation

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -214,6 +214,7 @@ output "ubuntu_container_public_key" {
   difference on the resource. You may use the `ignore_changes` lifecycle
   meta-argument to ignore changes to this attribute.
 - `template` - (Optional) Whether to create a template (defaults to `false`).
+- `timeout_create` - (Optional) Timeout for creating a container in seconds (defaults to 1800).
 - `unprivileged` - (Optional) Whether the container runs as unprivileged on
   the host (defaults to `false`).
 - `vm_id` - (Optional) The container identifier

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -75,6 +75,7 @@ const (
 	dvStartupDownDelay                  = -1
 	dvStartOnBoot                       = true
 	dvTemplate                          = false
+	dvTimeoutCreate                     = 1800
 	dvUnprivileged                      = false
 	dvVMID                              = -1
 
@@ -154,6 +155,7 @@ const (
 	mkStartOnBoot                       = "start_on_boot"
 	mkTags                              = "tags"
 	mkTemplate                          = "template"
+	mkTimeoutCreate                     = "timeout_create"
 	mkUnprivileged                      = "unprivileged"
 	mkVMID                              = "vm_id"
 )
@@ -833,6 +835,12 @@ func Container() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Default:     dvTemplate,
+			},
+			mkTimeoutCreate: {
+				Type:        schema.TypeInt,
+				Description: "Create container timeout",
+				Optional:    true,
+				Default:     dvTimeoutCreate,
 			},
 			mkUnprivileged: {
 				Type:        schema.TypeBool,
@@ -1721,8 +1729,10 @@ func containerCreateStart(ctx context.Context, d *schema.ResourceData, m interfa
 
 	containerAPI := api.Node(nodeName).Container(vmID)
 
+	createTimeout := d.Get(mkTimeoutCreate).(int)
+
 	// Start the container and wait for it to reach a running state before continuing.
-	err = containerAPI.StartContainer(ctx, 60)
+	err = containerAPI.StartContainer(ctx, createTimeout)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
I might have pretty fast disks, so wasn't able to reproduce the exact issue from #1107.
But the argument form template is getting passed down to the container create call.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1107

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
