### PR TITLE
feat(vm): add support for cpu `affinity` attribute (#1148)

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -231,11 +231,12 @@ output "ubuntu_vm_public_key" {
         - `custom-<model>` - Custom CPU model. All `custom-<model>` values
             should be defined in `/etc/pve/virtual-guest/cpu-models.conf` file.
     - `units` - (Optional) The CPU units (defaults to `1024`).
+    - `affinity` - (Optional) The CPU cores that are used to run the VM’s vCPU.
 - `description` - (Optional) The description.
 - `disk` - (Optional) A disk (multiple blocks supported).
     - `aio` - (Optional) The disk AIO mode (defaults to `io_uring`).
         - `io_uring` - Use io_uring.
-        - `native` - Use native AIO. Should be used with to unbuffered, O_DIRECT, raw block storage only, 
+        - `native` - Use native AIO. Should be used with to unbuffered, O_DIRECT, raw block storage only,
             with the disk `cache` must be set to `none`. Raw block storage types include iSCSI, CEPH/RBD, and NVMe.
         - `threads` - Use thread-based AIO.
     - `backup` - (Optional) Whether the drive should be included when making backups (defaults to `true`).
@@ -422,7 +423,7 @@ output "ubuntu_vm_public_key" {
     - `queues` - (Optional) The number of queues for VirtIO (1..64).
     - `rate_limit` - (Optional) The rate limit in megabytes per second.
     - `vlan_id` - (Optional) The VLAN identifier.
-    - `trunks` - (Optional) String containing a `;` separated list of VLAN trunks 
+    - `trunks` - (Optional) String containing a `;` separated list of VLAN trunks
         ("10;20;30"). Note that the VLAN-aware feature need to be enabled on the PVE
         Linux Bridge to use trunks.
 - `node_name` - (Required) The name of the node to assign the virtual machine

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -231,7 +231,10 @@ output "ubuntu_vm_public_key" {
         - `custom-<model>` - Custom CPU model. All `custom-<model>` values
             should be defined in `/etc/pve/virtual-guest/cpu-models.conf` file.
     - `units` - (Optional) The CPU units (defaults to `1024`).
-    - `affinity` - (Optional) The CPU cores that are used to run the VM’s vCPU.
+    - `affinity` - (Optional) The CPU cores that are used to run the VM’s vCPU. The
+        value is a list of CPU IDs, separated by commas. The CPU IDs are zero-based.
+        For example, `0,1,2,3` (which also can be shortened to `0-3`) means that the VM’s vCPUs are run on the first four
+        CPU cores. Setting `affinity` is only allowed for `root@pam` authenticated user.
 - `description` - (Optional) The description.
 - `disk` - (Optional) A disk (multiple blocks supported).
     - `aio` - (Optional) The disk AIO mode (defaults to `io_uring`).

--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -14,6 +14,7 @@ resource "proxmox_virtual_environment_vm" "example_template" {
     cores = 2
     numa  = true
     limit = 64
+    # affinity = "0-1"
   }
 
   smbios {
@@ -75,7 +76,7 @@ resource "proxmox_virtual_environment_vm" "example_template" {
         address = "dhcp"
       }
       # ipv6 {
-      #    address = "dhcp" 
+      #    address = "dhcp"
       #}
     }
 

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -236,6 +236,7 @@ type CreateRequestBody struct {
 	CPULimit             *int                           `json:"cpulimit,omitempty"           url:"cpulimit,omitempty"`
 	CPUSockets           *int                           `json:"sockets,omitempty"            url:"sockets,omitempty"`
 	CPUUnits             *int                           `json:"cpuunits,omitempty"           url:"cpuunits,omitempty"`
+	CPUAffinity          *string                        `json:"affinity,omitempty"           url:"affinity,omitempty"`
 	DedicatedMemory      *int                           `json:"memory,omitempty"             url:"memory,omitempty"`
 	Delete               []string                       `json:"delete,omitempty"             url:"delete,omitempty,comma"`
 	DeletionProtection   *types.CustomBool              `json:"protection,omitempty"         url:"protection,omitempty,int"`
@@ -364,6 +365,7 @@ type GetResponseData struct {
 	CPULimit             *types.CustomInt                `json:"cpulimit,omitempty"`
 	CPUSockets           *int                            `json:"sockets,omitempty"`
 	CPUUnits             *int                            `json:"cpuunits,omitempty"`
+	CPUAffinity          *string                         `json:"affinity,omitempty"`
 	DedicatedMemory      *types.CustomInt64              `json:"memory,omitempty"`
 	DeletionProtection   *types.CustomBool               `json:"protection,omitempty"`
 	Description          *string                         `json:"description,omitempty"`

--- a/proxmoxtf/resource/vm/validators.go
+++ b/proxmoxtf/resource/vm/validators.go
@@ -144,6 +144,13 @@ func CPUTypeValidator() schema.SchemaValidateDiagFunc {
 	))
 }
 
+// CPUAffinityValidator returns a schema validation function for a CPU affinity.
+func CPUAffinityValidator() schema.SchemaValidateDiagFunc {
+	return validation.ToDiagFunc(
+		validation.StringMatch(regexp.MustCompile(`^\d+[\d-,]*$`), "must contain numbers but also number ranges"),
+	)
+}
+
 // QEMUAgentTypeValidator is a schema validation function for QEMU agent types.
 func QEMUAgentTypeValidator() schema.SchemaValidateDiagFunc {
 	return validation.ToDiagFunc(validation.StringInSlice([]string{"isa", "virtio"}, false))

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -64,6 +64,7 @@ const (
 	dvCPUSockets          = 1
 	dvCPUType             = "qemu64"
 	dvCPUUnits            = 1024
+	dvCPUAffinity         = ""
 	dvDescription         = ""
 
 	dvEFIDiskDatastoreID                = "local-lvm"
@@ -165,6 +166,7 @@ const (
 	mkCPUSockets          = "sockets"
 	mkCPUType             = "type"
 	mkCPUUnits            = "units"
+	mkCPUAffinity         = "affinity"
 	mkDescription         = "description"
 
 	mkEFIDisk                           = "efi_disk"
@@ -491,6 +493,7 @@ func VM() *schema.Resource {
 						mkCPUSockets:      dvCPUSockets,
 						mkCPUType:         dvCPUType,
 						mkCPUUnits:        dvCPUUnits,
+						mkCPUAffinity:     dvCPUAffinity,
 					},
 				}, nil
 			},
@@ -563,6 +566,13 @@ func VM() *schema.Resource {
 						ValidateDiagFunc: validation.ToDiagFunc(
 							validation.IntBetween(2, 262144),
 						),
+					},
+					mkCPUAffinity: {
+						Type:             schema.TypeString,
+						Description:      "The CPU affinity",
+						Optional:         true,
+						Default:          dvCPUAffinity,
+						ValidateDiagFunc: CPUAffinityValidator(),
 					},
 				},
 			},
@@ -1776,6 +1786,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		cpuSockets := cpuBlock[mkCPUSockets].(int)
 		cpuType := cpuBlock[mkCPUType].(string)
 		cpuUnits := cpuBlock[mkCPUUnits].(int)
+		cpuAffinity := cpuBlock[mkCPUAffinity].(string)
 
 		cpuFlagsConverted := make([]string, len(cpuFlags))
 
@@ -1797,6 +1808,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		updateBody.NUMAEnabled = &cpuNUMA
 		updateBody.CPUSockets = &cpuSockets
 		updateBody.CPUUnits = &cpuUnits
+		updateBody.CPUAffinity = &cpuAffinity
 
 		if cpuHotplugged > 0 {
 			updateBody.VirtualCPUCount = &cpuHotplugged
@@ -2183,6 +2195,7 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 	cpuNUMA := types.CustomBool(cpuBlock[mkCPUNUMA].(bool))
 	cpuType := cpuBlock[mkCPUType].(string)
 	cpuUnits := cpuBlock[mkCPUUnits].(int)
+	cpuAffinity := cpuBlock[mkCPUAffinity].(string)
 
 	description := d.Get(mkDescription).(string)
 
@@ -2415,6 +2428,7 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		},
 		CPUSockets:          &cpuSockets,
 		CPUUnits:            &cpuUnits,
+		CPUAffinity:         &cpuAffinity,
 		DedicatedMemory:     &memoryDedicated,
 		DeletionProtection:  &protection,
 		EFIDisk:             efiDisk,
@@ -3377,6 +3391,12 @@ func vmReadCustom(
 	} else {
 		// Default value of "cpuunits" is "1024" according to the API documentation.
 		cpu[mkCPUUnits] = 1024
+	}
+
+	if vmConfig.CPUAffinity != nil {
+		cpu[mkCPUAffinity] = *vmConfig.CPUAffinity
+	} else {
+		cpu[mkCPUAffinity] = ""
 	}
 
 	currentCPU := d.Get(mkCPU).([]interface{})
@@ -4643,6 +4663,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 		cpuSockets := cpuBlock[mkCPUSockets].(int)
 		cpuType := cpuBlock[mkCPUType].(string)
 		cpuUnits := cpuBlock[mkCPUUnits].(int)
+		cpuAffinity := cpuBlock[mkCPUAffinity].(string)
 
 		// Only the root account is allowed to change the CPU architecture, which makes this check necessary.
 		if api.API().IsRootTicket() ||
@@ -4653,6 +4674,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 		updateBody.CPUCores = &cpuCores
 		updateBody.CPUSockets = &cpuSockets
 		updateBody.CPUUnits = &cpuUnits
+		updateBody.CPUAffinity = &cpuAffinity
 		updateBody.NUMAEnabled = &cpuNUMA
 
 		if cpuHotplugged > 0 {

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -1808,7 +1808,10 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		updateBody.NUMAEnabled = &cpuNUMA
 		updateBody.CPUSockets = &cpuSockets
 		updateBody.CPUUnits = &cpuUnits
-		updateBody.CPUAffinity = &cpuAffinity
+
+		if cpuAffinity != "" {
+			updateBody.CPUAffinity = &cpuAffinity
+		}
 
 		if cpuHotplugged > 0 {
 			updateBody.VirtualCPUCount = &cpuHotplugged
@@ -2428,7 +2431,6 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		},
 		CPUSockets:          &cpuSockets,
 		CPUUnits:            &cpuUnits,
-		CPUAffinity:         &cpuAffinity,
 		DedicatedMemory:     &memoryDedicated,
 		DeletionProtection:  &protection,
 		EFIDisk:             efiDisk,
@@ -2477,6 +2479,10 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 
 	if cpuLimit > 0 {
 		createBody.CPULimit = &cpuLimit
+	}
+
+	if cpuAffinity != "" {
+		createBody.CPUAffinity = &cpuAffinity
 	}
 
 	if description != "" {
@@ -4676,6 +4682,12 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 		updateBody.CPUUnits = &cpuUnits
 		updateBody.CPUAffinity = &cpuAffinity
 		updateBody.NUMAEnabled = &cpuNUMA
+
+		if cpuAffinity != "" {
+			updateBody.CPUAffinity = &cpuAffinity
+		} else {
+			del = append(del, "affinity")
+		}
 
 		if cpuHotplugged > 0 {
 			updateBody.VirtualCPUCount = &cpuHotplugged


### PR DESCRIPTION
It helps to pin VMs to the special cpu.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

```terraform
  cpu {
    cores = 2
    affinity = "2,3"
  }
```
<img width="892" alt="Screenshot 2024-03-23 at 9 30 59 PM" src="https://github.com/bpg/terraform-provider-proxmox/assets/627562/5971e388-e3e4-417f-9a75-f05f5267f728">



<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1148 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
