### PR TITLE
fix(lxc): improve configurable timeouts for containers operations

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -215,6 +215,7 @@ output "ubuntu_container_public_key" {
   meta-argument to ignore changes to this attribute.
 - `template` - (Optional) Whether to create a template (defaults to `false`).
 - `timeout_create` - (Optional) Timeout for creating a container in seconds (defaults to 1800).
+- `timeout_start` - (Optional) Timeout for starting a container in seconds (defaults to 300).
 - `unprivileged` - (Optional) Whether the container runs as unprivileged on
   the host (defaults to `false`).
 - `vm_id` - (Optional) The container identifier


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.

>Because of the environment type I work on, it is not possible for me to use the `make example` test command. But I tested directly with a real resource as you will see bellow.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Basically, this PR add a very simple fix about a previous one. The changes are about:
- Fix timeouts on CT creation
- Add configurable timeout for CT start

**Before**

```bash
proxmox_virtual_environment_container.homarr: Creating...
proxmox_virtual_environment_container.homarr: Still creating... [10s elapsed]
proxmox_virtual_environment_container.homarr: Still creating... [20s elapsed]
proxmox_virtual_environment_container.homarr: Still creating... [30s elapsed]
proxmox_virtual_environment_container.homarr: Still creating... [40s elapsed]
proxmox_virtual_environment_container.homarr: Still creating... [50s elapsed]
proxmox_virtual_environment_container.homarr: Still creating... [1m0s elapsed]
╷
│ Error: error waiting for container created: timeout while waiting for task "UPID:pve0:000A1770:10432569:66007457:vzcreate:102:root@pam:" to complete
│ 
│   with proxmox_virtual_environment_container.homarr,
│   on _ct_homarr.tf line 7, in resource "proxmox_virtual_environment_container" "homarr":
│    7: resource "proxmox_virtual_environment_container" "homarr" {
│ 
╵
```

**After**

```bash
proxmox_virtual_environment_container.homarr: Creating...
proxmox_virtual_environment_container.homarr: Still creating... [10s elapsed]
proxmox_virtual_environment_container.homarr: Still creating... [20s elapsed]
proxmox_virtual_environment_container.homarr: Still creating... [30s elapsed]
proxmox_virtual_environment_container.homarr: Still creating... [40s elapsed]
proxmox_virtual_environment_container.homarr: Still creating... [50s elapsed]
proxmox_virtual_environment_container.homarr: Still creating... [1m0s elapsed]
proxmox_virtual_environment_container.homarr: Still creating... [1m10s elapsed]
proxmox_virtual_environment_container.homarr: Still creating... [1m20s elapsed]
proxmox_virtual_environment_container.homarr: Still creating... [1m30s elapsed]
proxmox_virtual_environment_container.homarr: Creation complete after 1m34s [id=103]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

cluster_info = {
  "cpu_count" = tolist([
    4,
    48,
    56,
  ])
  "cpu_utilization" = tolist([
    0.01,
    0,
    0,
  ])
  "id" = "nodes"
  "memory_available" = tolist([
    16549924864,
    202750861312,
    135052587008,
  ])
  "memory_used" = tolist([
    1799516160,
    28236533760,
    2103070720,
  ])
  "names" = tolist([
    "pve0",
    "pve1",
    "pve2",
  ])
  "online" = tolist([
    true,
    true,
    true,
  ])
  "ssl_fingerprints" = tolist([***])
  "support_levels" = tolist([
    "",
    "",
    "",
  ])
  "uptime" = tolist([
    2728548,
    2670762,
    2680233,
  ])
}
```


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1160 | Relates #1146, #1107

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!---
BEGIN_COMMIT_OVERRIDE
fix(lxc): improve configurable timeouts for containers operations (#1161)
END_COMMIT_OVERRIDE
--->