### PR TITLE
fix: prevent authenticating multiple times in parallel

### DIFF
--- a/proxmox/api/ticket_auth.go
+++ b/proxmox/api/ticket_auth.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -24,6 +25,8 @@ type ticketAuthenticator struct {
 	conn        *Connection
 	authRequest string
 	authData    *AuthenticationResponseData
+
+	mu sync.Mutex
 }
 
 // NewTicketAuthenticator returns a new ticket authenticator.
@@ -46,6 +49,9 @@ func NewTicketAuthenticator(conn *Connection, creds *Credentials) (Authenticator
 }
 
 func (t *ticketAuthenticator) authenticate(ctx context.Context) (*AuthenticationResponseData, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	if t.authData != nil {
 		return t.authData, nil
 	}


### PR DESCRIPTION
Upstreaming some additions/fixes from my fork.

### Contributor's Note
I don't remember why this was an issue, as I added this almost a year ago, but it was breaking something.

### Community Note
- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
