### PR TITLE
fix(vm): regression: provider always tries to update `memory.*hugepages` even if it is not specified

### DIFF
--- a/fwprovider/tests/resource_vm_test.go
+++ b/fwprovider/tests/resource_vm_test.go
@@ -35,7 +35,9 @@ func TestAccResourceVM(t *testing.T) {
 					EOT
 				}`,
 			Check: resource.ComposeTestCheckFunc(
-				resource.TestCheckResourceAttr("proxmox_virtual_environment_vm.test_vm1", "description", "my\ndescription\nvalue"),
+				testResourceAttributes("proxmox_virtual_environment_vm.test_vm1", map[string]string{
+					"description": "my\ndescription\nvalue",
+				}),
 			),
 		}}},
 		{"single line description", []resource.TestStep{{
@@ -47,7 +49,9 @@ func TestAccResourceVM(t *testing.T) {
 					description = "my description value"
 				}`,
 			Check: resource.ComposeTestCheckFunc(
-				resource.TestCheckResourceAttr("proxmox_virtual_environment_vm.test_vm2", "description", "my description value"),
+				testResourceAttributes("proxmox_virtual_environment_vm.test_vm2", map[string]string{
+					"description": "my description value",
+				}),
 			),
 		}}},
 		{"no description", []resource.TestStep{{
@@ -59,7 +63,9 @@ func TestAccResourceVM(t *testing.T) {
 					description = ""
 				}`,
 			Check: resource.ComposeTestCheckFunc(
-				resource.TestCheckResourceAttr("proxmox_virtual_environment_vm.test_vm3", "description", ""),
+				testResourceAttributes("proxmox_virtual_environment_vm.test_vm3", map[string]string{
+					"description": "",
+				}),
 			),
 		}}},
 		{
@@ -72,7 +78,9 @@ func TestAccResourceVM(t *testing.T) {
 					protection = true
 				}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("proxmox_virtual_environment_vm.test_vm4", "protection", "true"),
+					testResourceAttributes("proxmox_virtual_environment_vm.test_vm4", map[string]string{
+						"protection": "true",
+					}),
 				),
 			}, {
 				Config: `
@@ -83,12 +91,14 @@ func TestAccResourceVM(t *testing.T) {
 					protection = false
 				}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("proxmox_virtual_environment_vm.test_vm4", "protection", "false"),
+					testResourceAttributes("proxmox_virtual_environment_vm.test_vm4", map[string]string{
+						"protection": "false",
+					}),
 				),
 			}},
 		},
 		{
-			"update CPU block", []resource.TestStep{{
+			"update cpu block", []resource.TestStep{{
 				Config: `
 				resource "proxmox_virtual_environment_vm" "test_vm5" {
 					node_name = "pve"
@@ -99,7 +109,9 @@ func TestAccResourceVM(t *testing.T) {
 					}
 				}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("proxmox_virtual_environment_vm.test_vm5", "cpu.0.cores", "2"),
+					testResourceAttributes("proxmox_virtual_environment_vm.test_vm5", map[string]string{
+						"cpu.0.sockets": "1",
+					}),
 				),
 			}, {
 				Config: `
@@ -112,7 +124,42 @@ func TestAccResourceVM(t *testing.T) {
 					}
 				}`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("proxmox_virtual_environment_vm.test_vm5", "cpu.0.cores", "1"),
+					testResourceAttributes("proxmox_virtual_environment_vm.test_vm5", map[string]string{
+						"cpu.0.sockets": "1",
+					}),
+				),
+			}},
+		},
+		{
+			"update memory block", []resource.TestStep{{
+				Config: `
+				resource "proxmox_virtual_environment_vm" "test_vm6" {
+					node_name = "pve"
+					started   = false
+					
+					memory {
+						dedicated = 2048
+					}
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					testResourceAttributes("proxmox_virtual_environment_vm.test_vm6", map[string]string{
+						"memory.0.dedicated": "2048",
+					}),
+				),
+			}, {
+				Config: `
+				resource "proxmox_virtual_environment_vm" "test_vm6" {
+					node_name = "pve"
+					started   = false
+					
+					memory {
+						dedicated = 1024
+					}
+				}`,
+				Check: resource.ComposeTestCheckFunc(
+					testResourceAttributes("proxmox_virtual_environment_vm.test_vm6", map[string]string{
+						"memory.0.dedicated": "1024",
+					}),
 				),
 			}},
 		},
@@ -496,6 +543,7 @@ func TestAccResourceVMDisks(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// fully cloned disk, does not have any attributes in state
 					resource.TestCheckNoResourceAttr("proxmox_virtual_environment_vm.test_disk3", "disk.0"),
+					testResourceAttributes("proxmox_virtual_environment_vm.test_disk3", map[string]string{}),
 				),
 			},
 			{

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5013,12 +5013,20 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 			}
 		}
 
-		if memoryHugepages != "" {
-			updateBody.Hugepages = &memoryHugepages
-			updateBody.KeepHugepages = &memoryKeepHugepages
-		} else {
-			del = append(del, "hugepages")
-			del = append(del, "keephugepages")
+		if d.HasChange(mkMemory + ".0." + mkMemoryHugepages) {
+			if memoryHugepages != "" {
+				updateBody.Hugepages = &memoryHugepages
+			} else {
+				del = append(del, "hugepages")
+			}
+		}
+
+		if d.HasChange(mkMemory + ".0." + mkMemoryKeepHugepages) {
+			if memoryHugepages != "" {
+				updateBody.KeepHugepages = &memoryKeepHugepages
+			} else {
+				del = append(del, "keephugepages")
+			}
 		}
 
 		rebootRequired = true

--- a/testacc
+++ b/testacc
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+TF_ACC=1 env $(cat testacc.env | xargs) go test -v  -timeout 120s -run "$1" github.com/bpg/terraform-provider-proxmox/fwprovider/tests $2


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

The new test fails before the fix:
```
=== NAME  TestAccResourceVM/update_memory_block
    resource_vm_test.go:174: Step 2/2 error: Error running apply: exit status 1
        
        Error: error updating VM: received an HTTP 500 response - Reason: only root can set 'hugepages' config
        
          with proxmox_virtual_environment_vm.test_vm6,
          on terraform_plugin_test.tf line 12, in resource "proxmox_virtual_environment_vm" "test_vm6":
          12:                           resource "proxmox_virtual_environment_vm" "test_vm6" {
        
--- FAIL: TestAccResourceVM (0.00s)
    --- FAIL: TestAccResourceVM/update_memory_block (4.72s)
```

After the fix:
```
--- PASS: TestAccResourceVM (0.00s)
--- PASS: TestAccResourceVM/update_memory_block (5.49s)
PASS
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1158
Relates #1180 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
