### PR TITLE
fix(vm): panic if `numa` block is empty

### DIFF
--- a/utils/maps.go
+++ b/utils/maps.go
@@ -15,12 +15,7 @@ func OrderedListFromMap(inputMap map[string]interface{}) []interface{} {
 
 	sort.Strings(keyList)
 
-	orderedList := make([]interface{}, itemCount)
-	for i, k := range keyList {
-		orderedList[i] = inputMap[k]
-	}
-
-	return orderedList
+	return OrderedListFromMapByKeyValues(inputMap, keyList)
 }
 
 // MapResourceList generates a list of strings from a Terraform resource list (list of maps).
@@ -32,6 +27,10 @@ func MapResourceList(resourceList []interface{}, attrName string) map[string]int
 	m := make(map[string]interface{}, len(resourceList))
 
 	for _, resource := range resourceList {
+		if resource == nil {
+			continue
+		}
+
 		r := resource.(map[string]interface{})
 		key := r[attrName].(string)
 		m[key] = r

--- a/utils/maps_test.go
+++ b/utils/maps_test.go
@@ -5,12 +5,35 @@ import (
 	"testing"
 )
 
+func TestOrderedListFromMap(t *testing.T) {
+	t.Parallel()
+
+	inputMap := map[string]interface{}{
+		"value1": map[string]interface{}{"name": "resource1", "attr": "value1"},
+		"value3": map[string]interface{}{"name": "resource3", "attr": "value3"},
+		"value2": map[string]interface{}{"name": "resource2", "attr": "value2"},
+	}
+
+	expected := []interface{}{
+		map[string]interface{}{"name": "resource1", "attr": "value1"},
+		map[string]interface{}{"name": "resource2", "attr": "value2"},
+		map[string]interface{}{"name": "resource3", "attr": "value3"},
+	}
+
+	result := OrderedListFromMap(inputMap)
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("MapResourceList() = %v, want %v", result, expected)
+	}
+}
+
 func TestMapResourceList(t *testing.T) {
 	t.Parallel()
 
 	resourceList := []interface{}{
 		map[string]interface{}{"name": "resource1", "attr": "value1"},
 		map[string]interface{}{"name": "resource2", "attr": "value2"},
+		nil,
 		map[string]interface{}{"name": "resource3", "attr": "value3"},
 	}
 


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated templates in `/example` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Updated unit test before the fix:
```
go test -timeout 30s -run ^TestMapResourceList$ github.com/bpg/terraform-provider-proxmox/utils

--- FAIL: TestMapResourceList (0.00s)
panic: interface conversion: interface {} is nil, not map[string]interface {} [recovered]
	panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 21 [running]:
testing.tRunner.func1.2({0x100fee0c0, 0x140000af200})
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/testing/testing.go:1634 +0x33c
panic({0x100fee0c0?, 0x140000af200?})
	/opt/homebrew/Cellar/go/1.22.2/libexec/src/runtime/panic.go:770 +0x124
github.com/bpg/terraform-provider-proxmox/utils.MapResourceList(...)
	/Users/pasha/code/terraform-provider-proxmox/utils/maps.go:34
```

After the fix:

```
go test -timeout 30s -run ^TestMapResourceList$ github.com/bpg/terraform-provider-proxmox/utils

ok  	github.com/bpg/terraform-provider-proxmox/utils	0.132s
```


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1192

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
