### PR TITLE
fix(firewall): remove strict validation for `rule.iface` attribute

### DIFF
--- a/fwprovider/tests/resource_firewall_test.go
+++ b/fwprovider/tests/resource_firewall_test.go
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccResourceClusterFirewall(t *testing.T) {
+	te := initTestEnvironment(t)
+
+	tests := []struct {
+		name  string
+		steps []resource.TestStep
+	}{
+		{"rules1", []resource.TestStep{{
+			Config: te.renderConfig(`
+			resource "proxmox_virtual_environment_firewall_rules" "rules1" {
+				rule {
+					type   = "in"
+					action = "ACCEPT"
+					iface  = "vmbr0"
+					dport = "8006"
+					proto = "tcp"
+					comment = "PVE Admin Interface"
+				}
+			}`),
+			Check: resource.ComposeTestCheckFunc(
+				testResourceAttributes("proxmox_virtual_environment_firewall_rules.rules1", map[string]string{
+					"rule.0.type":    "in",
+					"rule.0.action":  "ACCEPT",
+					"rule.0.iface":   "vmbr0",
+					"rule.0.dport":   "8006",
+					"rule.0.proto":   "tcp",
+					"rule.0.comment": "PVE Admin Interface",
+				}),
+				testNoResourceAttributesSet("proxmox_virtual_environment_firewall_rules.rules1", []string{
+					"node_name",
+				}),
+			),
+		}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: te.accProviders,
+				Steps:                    tt.steps,
+			})
+		})
+	}
+}

--- a/proxmoxtf/resource/firewall/rules.go
+++ b/proxmoxtf/resource/firewall/rules.go
@@ -115,9 +115,8 @@ func Rules() *schema.Resource {
 			Type: schema.TypeString,
 			Description: "Network interface name. You have to use network configuration key names for VMs" +
 				" and containers ('net\\d+'). Host related rules can use arbitrary strings.",
-			Optional:         true,
-			Default:          dvRuleIface,
-			ValidateDiagFunc: validators.FirewallIFace(),
+			Optional: true,
+			Default:  dvRuleIface,
 		},
 		mkRuleLog: {
 			Type: schema.TypeString,


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
A cluster-level rule like
```terraform
resource "proxmox_virtual_environment_firewall_rules" "rules1" {
  rule {
    type   = "in"
    action = "ACCEPT"
    iface  = "vmbr0"
    dport = "8006"
    proto = "tcp"
    comment = "PVE Admin Interface"
  }
}
```
now can be created without errors. New acceptance test passes:
```
--- PASS: TestAccResourceClusterFirewall (0.00s)
    --- PASS: TestAccResourceClusterFirewall/rules1 (1.17s)
PASS
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/tests      1.432s
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1176

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
