### PR TITLE
fix(vm): error 'resizing of efidisks is not supported' when clonning a VM with re-defined `efi_disk`

### DIFF
--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -155,6 +155,12 @@ resource "proxmox_virtual_environment_vm" "example" {
     serial = "my-custom-serial"
   }
 
+  efi_disk {
+    datastore_id = local.datastore_id
+    file_format  = "raw"
+    type         = "4m"
+  }
+
   initialization {
     datastore_id = local.datastore_id
     // if unspecified:

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -2233,7 +2233,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 			continue
 		}
 
-		if &efiType != currentDiskInfo.Type {
+		if efiType != *currentDiskInfo.Type {
 			return diag.Errorf(
 				"resizing of efidisks is not supported.",
 			)


### PR DESCRIPTION
Hello,

There seems to be an issue with how EFI disks types are compared. I stumbled upon it while cloning a template which was created using packer. The type was the same for both packer and terraform, but it was failing with the following log:

```
Error: resizing of efidisks is not supported.
```

After switching to comparing the values, it creates the VM as intended. I did not test it with `make example`, but tried it on my local test cluster: I'll try to run the example when I have the chance.

Kind regards,
Joris

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Updated example template fails without fix:
```
proxmox_virtual_environment_firewall_options.container_options: Creating...
proxmox_virtual_environment_firewall_ipset.container_ipset: Creating...
proxmox_virtual_environment_firewall_rules.container_rules: Creating...
proxmox_virtual_environment_firewall_alias.container_alias: Creation complete after 0s [id=container-alias]
proxmox_virtual_environment_firewall_options.container_options: Creation complete after 0s [id=options-2501178773]
proxmox_virtual_environment_firewall_ipset.container_ipset: Creation complete after 0s [id=container-ipset]
proxmox_virtual_environment_firewall_rules.container_rules: Creation complete after 1s [id=rule-250004132]
proxmox_virtual_environment_vm.trunks-example: Still creating... [40s elapsed]
proxmox_virtual_environment_vm.trunks-example: Creation complete after 48s [id=102]
╷
│ Error: resizing of efidisks is not supported.
│ 
│   with proxmox_virtual_environment_vm.example,
│   on resource_virtual_environment_vm.tf line 115, in resource "proxmox_virtual_environment_vm" "example":
│  115: resource "proxmox_virtual_environment_vm" "example" {
│ 
╵
make: *** [example-apply] Error 1
```

Then passes with the fix.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #759

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->