### PR TITLE
chore(vm): fix acceptance test for hardware mapping

### DIFF
--- a/fwprovider/tests/resource_hardware_mapping_test.go
+++ b/fwprovider/tests/resource_hardware_mapping_test.go
@@ -664,19 +664,6 @@ func TestAccResourceHardwareMappingUSBInvalidInput(t *testing.T) {
 				// Test the "Create" method implementation where all possible attributes are specified, but an error is expected
 				// when using an invalid device path.
 				{
-					ExpectError: regexp.MustCompile(
-						fmt.Sprintf(
-							// The error line is, for whatever reason, broken down into multiple lines in acceptance tests, so we need
-							// to capture newline characters.
-							// Note that the regular expression syntax used by Go does not capture newlines with the "." matcher,
-							// so we need to enable the "s" flag that enabled "."
-							// to match "\n".
-							// References:
-							//   1. https://pkg.go.dev/regexp/syntax
-							`(?s).*%s(?s).*`,
-							hwm.ErrResourceMessageInvalidPath(proxmoxtypes.TypeUSB),
-						),
-					),
 					Config: fmt.Sprintf(
 						`
 					resource "proxmox_virtual_environment_hardware_mapping_usb" "test" {
@@ -699,6 +686,7 @@ func TestAccResourceHardwareMappingUSBInvalidInput(t *testing.T) {
 						data.MapDeviceIDs[0],
 						te.nodeName,
 					),
+					ExpectError: regexp.MustCompile(`valid Linux device path for hardware mapping of type "usb"`),
 				},
 			},
 		},


### PR DESCRIPTION
Fix the [failing acceptance test](https://github.com/bpg/terraform-provider-proxmox/actions/runs/8743959587/job/23995760040#step:7:175) for the new hardware mapping functionality (#1213)

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000 | Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
