### PR TITLE
fix(docs): Fix the generation path for "guides"

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -28,7 +28,7 @@ import (
 
 // Temporary: while migrating to the TF framework, we need to copy the generated docs to the right place
 // for the resources / data sources that have been migrated.
-//go:generate cp -R ../build/docs-gen/guides/ ../docs/guides/
+//go:generate cp -R ../build/docs-gen/guides/ ../docs
 //go:generate cp ../build/docs-gen/data-sources/virtual_environment_version.md ../docs/data-sources/
 //go:generate cp ../build/docs-gen/data-sources/virtual_environment_hagroup.md ../docs/data-sources/
 //go:generate cp ../build/docs-gen/data-sources/virtual_environment_hagroups.md ../docs/data-sources/


### PR DESCRIPTION
### Contributor's Note
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

### Summary

Fixes the path where the "guides" are generated within the `docs` directory. Before they were placed in `docs/guides/guides` which is a unnecessarily nested folder with the same name.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

