### PR TITLE
fix: use `raw` file format for `efi_disk` by default

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -293,7 +293,7 @@ output "ubuntu_vm_public_key" {
     to `ovmf`)
     - `datastore_id` (Optional) The identifier for the datastore to create
         the disk in (defaults to `local-lvm`).
-    - `file_format` (Optional) The file format.
+    - `file_format` (Optional) The file format (defaults to `raw`).
     - `type` (Optional) Size and type of the OVMF EFI disk. `4m` is newer and
         recommended, and required for Secure Boot. For backwards compatibility
         use `2m`. Ignored for VMs with cpu.architecture=`aarch64` (defaults

--- a/fwprovider/tests/resource_vm_test.go
+++ b/fwprovider/tests/resource_vm_test.go
@@ -609,6 +609,30 @@ func TestAccResourceVMDisks(t *testing.T) {
 				RefreshState: true,
 			},
 		}},
+		{"efi disk", []resource.TestStep{
+			{
+				Config: te.renderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_efi_disk" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name 	  = "test-efi-disk"
+
+					efi_disk {
+						datastore_id = "local-lvm"
+						type = "4m"
+					}
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					testResourceAttributes("proxmox_virtual_environment_vm.test_efi_disk", map[string]string{
+						"efi_disk.0.datastore_id": "local-lvm",
+						"efi_disk.0.type":         "4m",
+					}),
+				),
+			},
+			{
+				RefreshState: true,
+			},
+		}},
 		{"ide disks", []resource.TestStep{
 			{
 				Config: te.renderConfig(`

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -72,7 +72,7 @@ const (
 	dvDescription         = ""
 
 	dvEFIDiskDatastoreID                = "local-lvm"
-	dvEFIDiskFileFormat                 = "qcow2"
+	dvEFIDiskFileFormat                 = "raw"
 	dvEFIDiskType                       = "2m"
 	dvEFIDiskPreEnrolledKeys            = false
 	dvTPMStateDatastoreID               = "local-lvm"


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

This template can be applied without errors:
```hcl
resource "proxmox_virtual_environment_vm" "test_efi_disk" {
	node_name = "pve"
	started   = false
	name 	  = "test-efi-disk"

	efi_disk {
		datastore_id = "local-lvm"
		type = "4m"
	}
}
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1246

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
