### PR TITLE
fix(vm): `cdrom` is not attached when creating a VM from scratch

### DIFF
--- a/fwprovider/tests/resource_vm_test.go
+++ b/fwprovider/tests/resource_vm_test.go
@@ -639,6 +639,28 @@ func TestAccResourceVMDisks(t *testing.T) {
 				RefreshState: true,
 			},
 		}},
+
+		{"cdrom", []resource.TestStep{
+			{
+				Config: te.renderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name 	  = "test-cdrom"
+					cdrom {
+						enabled   = true
+					}
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					testResourceAttributes("proxmox_virtual_environment_vm.test_cdrom", map[string]string{
+						"cdrom.0.enabled": "true",
+					}),
+				),
+			},
+			{
+				RefreshState: true,
+			},
+		}},
 		{"efi disk", []resource.TestStep{
 			{
 				Config: te.renderConfig(`

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -17,12 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
 	"golang.org/x/exp/maps"
-
-	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/disk"
-	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/network"
-	"github.com/bpg/terraform-provider-proxmox/utils"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
@@ -34,12 +29,16 @@ import (
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/cluster"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/pools"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/validators"
+	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/disk"
+	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/network"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/structure"
+	"github.com/bpg/terraform-provider-proxmox/utils"
 )
 
 const (
@@ -2609,12 +2608,15 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 	ideDevice2Media := "cdrom"
 	ideDevices := vms.CustomStorageDevices{}
 
-	if cdromCloudInitEnabled {
+	if cdromCloudInitInterface != "" {
 		ideDevices[cdromCloudInitInterface] = &vms.CustomStorageDevice{
 			Enabled:    cdromCloudInitEnabled,
 			FileVolume: cdromCloudInitFileID,
 			Media:      &ideDevice2Media,
 		}
+	}
+
+	if cdromInterface != "" {
 		ideDevices[cdromInterface] = &vms.CustomStorageDevice{
 			Enabled:    cdromEnabled,
 			FileVolume: cdromFileID,


### PR DESCRIPTION
Regression after #1237

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
```hcl
resource "proxmox_virtual_environment_vm" "test_cdrom" {
  node_name = "pve"
  started   = false
  name      = "test-cdrom"
  cdrom {
    enabled = true
  }
}
```
```

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.test_cdrom will be created
  + resource "proxmox_virtual_environment_vm" "test_cdrom" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "test-cdrom"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + cdrom {
          + enabled   = true
          + interface = "ide3"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.test_cdrom: Creating...
proxmox_virtual_environment_vm.test_cdrom: Creation complete after 0s [id=101]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```
<img width="727" alt="Screenshot 2024-05-12 at 10 04 55 PM" src="https://github.com/bpg/terraform-provider-proxmox/assets/627562/fe6bf0c1-e31d-4f7d-95a1-18f3cc60b458">



<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1283

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
