### PR TITLE
fix(access): user token `expiration_date` handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ See [CONTRIBUTORS.md](CONTRIBUTORS.md) for a list of contributors to this projec
 - [Radosław Szamszur](https://github.com/rszamszur)
 - [Ben Bouillet](https://github.com/benbouillet)
 
-Thanks again for your support, it is much appreciated! 🙏
+Thanks again for your continuous support, it is much appreciated! 🙏
 
 
 ## Acknowledgements

--- a/fwprovider/tests/resource_user_test.go
+++ b/fwprovider/tests/resource_user_test.go
@@ -119,27 +119,25 @@ func TestAccResourceUserToken(t *testing.T) {
 			[]resource.TestStep{
 				{
 					Config: te.renderConfig(`resource "proxmox_virtual_environment_user_token" "user_token" {
-					comment  			= "Managed by Terraform"
-					expiration_date 	= "2034-01-01T22:00:00Z"
-					token_name 			= "{{.TokenName}}"
-					user_id  			= "{{.UserID}}"
-				}`),
+						comment  			= "Managed by Terraform"
+						token_name 			= "{{.TokenName}}"
+						user_id  			= "{{.UserID}}"
+					}`),
 					Check: testResourceAttributes("proxmox_virtual_environment_user_token.user_token", map[string]string{
-						"comment":         "Managed by Terraform",
-						"expiration_date": "2034-01-01T22:00:00Z",
-						"id":              fmt.Sprintf("%s!%s", userID, tokenName),
-						"user_id":         userID,
-						"value":           fmt.Sprintf("%s!%s=.*", userID, tokenName),
+						"comment": "Managed by Terraform",
+						"id":      fmt.Sprintf("%s!%s", userID, tokenName),
+						"user_id": userID,
+						"value":   fmt.Sprintf("%s!%s=.*", userID, tokenName),
 					}),
 				},
 				{
 					Config: te.renderConfig(`resource "proxmox_virtual_environment_user_token" "user_token" {
-					comment  			  = "Managed by Terraform 2"
-					expiration_date 	  = "2033-01-01T01:01:01Z"
-					privileges_separation = false
-					token_name 			  = "{{.TokenName}}"
-					user_id  			  = "{{.UserID}}"
-				}`),
+						comment  			  = "Managed by Terraform 2"
+						expiration_date 	  = "2033-01-01T01:01:01Z"
+						privileges_separation = false
+						token_name 			  = "{{.TokenName}}"
+						user_id  			  = "{{.UserID}}"
+					}`),
 					Check: resource.ComposeTestCheckFunc(
 						testResourceAttributes("proxmox_virtual_environment_user_token.user_token", map[string]string{
 							"comment":               "Managed by Terraform 2",
@@ -149,6 +147,26 @@ func TestAccResourceUserToken(t *testing.T) {
 							"user_id":               userID,
 						}),
 						testNoResourceAttributesSet("proxmox_virtual_environment_user_token.user_token", []string{
+							"value",
+						}),
+					),
+				},
+				{
+					Config: te.renderConfig(`resource "proxmox_virtual_environment_user_token" "user_token" {
+						comment  			  = "Managed by Terraform 2"
+						privileges_separation = false
+						token_name 			  = "{{.TokenName}}"
+						user_id  			  = "{{.UserID}}"
+					}`),
+					Check: resource.ComposeTestCheckFunc(
+						testResourceAttributes("proxmox_virtual_environment_user_token.user_token", map[string]string{
+							"comment":               "Managed by Terraform 2",
+							"privileges_separation": "false",
+							"token_name":            tokenName,
+							"user_id":               userID,
+						}),
+						testNoResourceAttributesSet("proxmox_virtual_environment_user_token.user_token", []string{
+							"expiration_date",
 							"value",
 						}),
 					),


### PR DESCRIPTION
…:00Z" if undefined

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1292

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
