### PR TITLE
fix(vm): check task warning status against exit code

### DIFF
--- a/proxmox/nodes/tasks/tasks.go
+++ b/proxmox/nodes/tasks/tasks.go
@@ -160,7 +160,7 @@ func (c *Client) WaitForTask(ctx context.Context, upid string, opts ...TaskWaitO
 
 	if status.ExitCode != "OK" {
 		if options.ignoreWarnings &&
-			strings.HasPrefix(status.Status, "WARNINGS: ") && !strings.Contains(status.Status, "ERROR") {
+			strings.HasPrefix(status.ExitCode, "WARNINGS: ") && !strings.Contains(status.ExitCode, "ERROR") {
 			return nil
 		}
 


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

Follow up for #1317 . After testing it, I noticed that the provider still failed. I logged down the values, it appears that warnings is set to the ExitCode parameter instead.

 `status.Status=stopped`
 `status.ExitCode=WARNINGS: 1`

### Proof of Work
After this patch, when VM has warning status, state is retained in provider and VM is successfully started.
![Screenshot from 2024-05-27 18-37-18](https://github.com/bpg/terraform-provider-proxmox/assets/1191779/81490bea-dc81-45cc-9300-31970101683b)



<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1314

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
