### PR TITLE
fix(vm): adding disks causes VM to be re-created

### DIFF
--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -67,4 +67,6 @@ jobs:
           PROXMOX_VE_ACC_NODE_NAME: ${{ matrix.node }}
           PROXMOX_VE_ACC_NODE_SSH_ADDRESS: ${{ secrets.PROXMOX_VE_HOST }}
           PROXMOX_VE_ACC_NODE_SSH_PORT: ${{ matrix.port }}
+          PROXMOX_VE_ACC_CLOUD_IMAGES_SERVER: ${{ secrets.PROXMOX_VE_ACC_CLOUD_IMAGES_SERVER }}
+          PROXMOX_VE_ACC_CONTAINER_IMAGES_SERVER: ${{ secrets.PROXMOX_VE_ACC_CONTAINER_IMAGES_SERVER }}
         run: make testacc

--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -57,7 +57,7 @@ resource "proxmox_virtual_environment_download_file" "ubuntu_container_template"
 	content_type = "vztmpl"
 	datastore_id = "local"
 	node_name = "{{.NodeName}}"
-	url = "http://download.proxmox.com/images/system/ubuntu-23.04-standard_23.04-1_amd64.tar.zst"
+	url = "{{.ContainerImagesServer}}/images/system/ubuntu-23.04-standard_23.04-1_amd64.tar.zst"
     overwrite_unmanaged = true
 }
 resource "proxmox_virtual_environment_container" "test_container" {

--- a/fwprovider/test/test_environment.go
+++ b/fwprovider/test/test_environment.go
@@ -78,12 +78,24 @@ provider "proxmox" {
 
 	const datastoreID = "local"
 
+	cloudImagesServer := utils.GetAnyStringEnv("PROXMOX_VE_ACC_CLOUD_IMAGES_SERVER")
+	if cloudImagesServer == "" {
+		cloudImagesServer = "https://cloud-images.ubuntu.com"
+	}
+
+	containerImagesServer := utils.GetAnyStringEnv("PROXMOX_VE_ACC_CONTAINER_IMAGES_SERVER")
+	if containerImagesServer == "" {
+		containerImagesServer = "http://download.proxmox.com"
+	}
+
 	return &Environment{
 		t: t,
 		templateVars: map[string]any{
-			"ProviderConfig": pc,
-			"NodeName":       nodeName,
-			"DatastoreID":    datastoreID,
+			"ProviderConfig":        pc,
+			"NodeName":              nodeName,
+			"DatastoreID":           datastoreID,
+			"CloudImagesServer":     cloudImagesServer,
+			"ContainerImagesServer": containerImagesServer,
 		},
 		providerConfig: pc,
 		NodeName:       nodeName,

--- a/proxmoxtf/resource/vm/disk/schema.go
+++ b/proxmoxtf/resource/vm/disk/schema.go
@@ -50,7 +50,6 @@ func Schema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Description: "The disk devices",
 			Optional:    true,
-			ForceNew:    true,
 			DefaultFunc: func() (interface{}, error) {
 				return []interface{}{
 					map[string]interface{}{
@@ -97,7 +96,6 @@ func Schema() map[string]*schema.Schema {
 						Type:             schema.TypeString,
 						Description:      "The file format",
 						Optional:         true,
-						ForceNew:         true,
 						Computed:         true,
 						ValidateDiagFunc: validators.FileFormat(),
 					},

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5057,7 +5057,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 		return diag.FromErr(err)
 	}
 
-	rr, err := disk.Update(d, planDisks, allDiskInfo, updateBody)
+	rr, err := disk.Update(ctx, client, nodeName, vmID, d, planDisks, allDiskInfo, updateBody)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -5473,7 +5473,7 @@ func vmUpdateDiskLocationAndSize(
 			for oldKey, oldDisk := range diskMap {
 				if _, present := diskNewEntries[prefix][oldKey]; !present {
 					return diag.Errorf(
-						"deletion of disks not supported. Please delete disk by hand. Old Interface was %s",
+						"deletion of disks not supported. Please delete disk by hand. Old interface was %q",
 						*oldDisk.Interface,
 					)
 				}


### PR DESCRIPTION
Another attempt to fix #103. 

May not work for all use cases though. Still need to be tested better for cloning, hotplug update, adding multiple disks, mixed disk updates, datastore migrations etc.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

First, apply this template:
```hcl
resource "proxmox_virtual_environment_vm" "test_disk" {
  node_name = "pve"
  name      = "test-disk"
  started   = false

  disk {
    file_format  = "raw"
    datastore_id = "local-lvm"
    interface    = "virtio0"
    size         = 8
  }
}
```
```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.test_disk will be created
  + resource "proxmox_virtual_environment_vm" "test_disk" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "test-disk"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "ignore"
          + file_format       = "raw"
          + interface         = "virtio0"
          + iothread          = false
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 8
          + ssd               = false
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.test_disk: Creating...
proxmox_virtual_environment_vm.test_disk: Creation complete after 1s [id=100]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Then add a new disk:
```hcl
resource "proxmox_virtual_environment_vm" "test_disk" {
  node_name = "pve"
  name      = "test-disk"
  started   = false

  disk {
    file_format  = "raw"
    datastore_id = "local-lvm"
    interface    = "virtio0"
    size         = 8
  }

  disk {
    file_format  = "raw"
    datastore_id = "local-lvm"
    interface    = "scsi0"
    size         = 10
  }
}
```
```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.test_disk will be updated in-place
  ~ resource "proxmox_virtual_environment_vm" "test_disk" {
        id                      = "100"
        name                    = "test-disk"
        tags                    = []
        # (26 unchanged attributes hidden)

      + disk {
          + aio          = "io_uring"
          + backup       = true
          + cache        = "none"
          + datastore_id = "local-lvm"
          + discard      = "ignore"
          + file_format  = "raw"
          + interface    = "scsi0"
          + iothread     = false
          + replicate    = true
          + size         = 10
          + ssd          = false
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
proxmox_virtual_environment_vm.test_disk: Modifying... [id=100]
proxmox_virtual_environment_vm.test_disk: Modifications complete after 0s [id=100]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

![Screenshot 2024-05-29 at 10 54 04 PM](https://github.com/bpg/terraform-provider-proxmox/assets/627562/188aec60-1148-4fee-9153-36f9e3667f4f)


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #103

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
