### PR TITLE
feat(vm): add support for `disk.serial` attribute 

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -276,6 +276,7 @@ output "ubuntu_vm_public_key" {
     - `iothread` - (Optional) Whether to use iothreads for this disk (defaults
         to `false`).
     - `replicate` - (Optional) Whether the drive should be considered for replication jobs (defaults to `true`).
+    - `serial` - (Optional) The serial number of the disk, up to 20 bytes long.
     - `size` - (Optional) The disk size in gigabytes (defaults to `8`).
     - `speed` - (Optional) The speed limits.
         - `iops_read` - (Optional) The maximum read I/O in operations per second.

--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -53,6 +53,7 @@ resource "proxmox_virtual_environment_vm" "example_template" {
     interface    = "scsi0"
     discard      = "on"
     cache        = "writeback"
+    serial	     = "dead_beef"
     ssd          = true
   }
 

--- a/fwprovider/test/resource_vm_disks_test.go
+++ b/fwprovider/test/resource_vm_disks_test.go
@@ -69,6 +69,7 @@ func TestAccResourceVMDisks(t *testing.T) {
 						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "virtio0"
+						serial	     = "dead_beef"
 						size         = 8
 						replicate    = false
 						aio          = "native"
@@ -93,6 +94,7 @@ func TestAccResourceVMDisks(t *testing.T) {
 						"disk.0.iothread":                     "false",
 						"disk.0.path_in_datastore":            `vm-\d+-disk-\d+`,
 						"disk.0.replicate":                    "false",
+						"disk.0.serial":                       "deadbeef",
 						"disk.0.size":                         "8",
 						"disk.0.ssd":                          "false",
 						"disk.0.speed.0.iops_read":            "100",
@@ -122,6 +124,7 @@ func TestAccResourceVMDisks(t *testing.T) {
 						interface    = "virtio0"
 						iothread     = true
 						discard      = "on"
+						serial       = "dead_beef"
 						size         = 20
 					}
 				}`),
@@ -134,6 +137,7 @@ func TestAccResourceVMDisks(t *testing.T) {
 					"disk.0.interface":         "virtio0",
 					"disk.0.iothread":          "true",
 					"disk.0.path_in_datastore": `vm-\d+-disk-\d+`,
+					"disk.0.serial":            "dead_beef",
 					"disk.0.size":              "20",
 					"disk.0.ssd":               "false",
 				}),

--- a/fwprovider/test/resource_vm_disks_test.go
+++ b/fwprovider/test/resource_vm_disks_test.go
@@ -69,7 +69,7 @@ func TestAccResourceVMDisks(t *testing.T) {
 						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "virtio0"
-						serial	     = "dead_beef"
+						serial	     = "-dead_beef-"
 						size         = 8
 						replicate    = false
 						aio          = "native"
@@ -94,7 +94,7 @@ func TestAccResourceVMDisks(t *testing.T) {
 						"disk.0.iothread":                     "false",
 						"disk.0.path_in_datastore":            `vm-\d+-disk-\d+`,
 						"disk.0.replicate":                    "false",
-						"disk.0.serial":                       "deadbeef",
+						"disk.0.serial":                       "-dead_beef-",
 						"disk.0.size":                         "8",
 						"disk.0.ssd":                          "false",
 						"disk.0.speed.0.iops_read":            "100",

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -38,6 +38,7 @@ type CustomStorageDevice struct {
 	MaxWriteSpeedMbps       *int              `json:"mbps_wr,omitempty"     url:"mbps_wr,omitempty"`
 	Media                   *string           `json:"media,omitempty"       url:"media,omitempty"`
 	Replicate               *types.CustomBool `json:"replicate,omitempty"   url:"replicate,omitempty,int"`
+	Serial                  *string           `json:"serial,omitempty"      url:"serial,omitempty"`
 	Size                    *types.DiskSize   `json:"size,omitempty"        url:"size,omitempty"`
 	SSD                     *types.CustomBool `json:"ssd,omitempty"         url:"ssd,omitempty,int"`
 	DatastoreID             *string           `json:"-"                     url:"-"`
@@ -158,6 +159,10 @@ func (d *CustomStorageDevice) EncodeOptions() string {
 		} else {
 			values = append(values, "iothread=0")
 		}
+	}
+
+	if d.Serial != nil && *d.Serial != "" {
+		values = append(values, fmt.Sprintf("serial=%s", *d.Serial))
 	}
 
 	if d.SSD != nil {
@@ -345,6 +350,9 @@ func (d *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 			case "replicate":
 				bv := types.CustomBool(v[1] == "1")
 				d.Replicate = &bv
+
+			case "serial":
+				d.Serial = &v[1]
 
 			case "size":
 				d.Size = new(types.DiskSize)

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -258,6 +258,7 @@ func GetDiskDeviceObjects(
 		fileID, _ := block[mkDiskFileID].(string)
 		ioThread := types.CustomBool(block[mkDiskIOThread].(bool))
 		replicate := types.CustomBool(block[mkDiskReplicate].(bool))
+		serial := block[mkDiskSerial].(string)
 		size, _ := block[mkDiskSize].(int)
 		ssd := types.CustomBool(block[mkDiskSSD].(bool))
 
@@ -301,6 +302,7 @@ func GetDiskDeviceObjects(
 		diskDevice.Format = &fileFormat
 		diskDevice.Interface = &diskInterface
 		diskDevice.Replicate = &replicate
+		diskDevice.Serial = &serial
 		diskDevice.Size = types.DiskSizeFromGigabytes(int64(size))
 
 		if !strings.HasPrefix(diskInterface, "virtio") {
@@ -535,6 +537,12 @@ func Read(
 			disk[mkDiskReplicate] = true
 		}
 
+		if dd.Serial != nil {
+			disk[mkDiskSerial] = *dd.Serial
+		} else {
+			disk[mkDiskSerial] = ""
+		}
+
 		if dd.SSD != nil {
 			disk[mkDiskSSD] = *dd.SSD
 		} else {
@@ -700,6 +708,7 @@ func Update(
 				tmp.MaxReadSpeedMbps = disk.MaxReadSpeedMbps
 				tmp.MaxWriteSpeedMbps = disk.MaxWriteSpeedMbps
 				tmp.Replicate = disk.Replicate
+				tmp.Serial = disk.Serial
 				tmp.SSD = disk.SSD
 
 				switch prefix {

--- a/proxmoxtf/resource/vm/disk/schema.go
+++ b/proxmoxtf/resource/vm/disk/schema.go
@@ -1,3 +1,9 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 package disk
 
 import (
@@ -34,6 +40,7 @@ const (
 	mkDiskIOThread            = "iothread"
 	mkDiskPathInDatastore     = "path_in_datastore"
 	mkDiskReplicate           = "replicate"
+	mkDiskSerial              = "serial"
 	mkDiskSize                = "size"
 	mkDiskSpeed               = "speed"
 	mkDiskSpeedRead           = "read"
@@ -63,6 +70,7 @@ func Schema() map[string]*schema.Schema {
 						mkDiskIOThread:        false,
 						mkDiskPathInDatastore: nil,
 						mkDiskReplicate:       true,
+						mkDiskSerial:          "",
 						mkDiskSize:            dvDiskSize,
 						mkDiskSSD:             false,
 					},
@@ -125,6 +133,13 @@ func Schema() map[string]*schema.Schema {
 						ForceNew:         true,
 						Default:          "",
 						ValidateDiagFunc: validators.FileID(),
+					},
+					mkDiskSerial: {
+						Type:             schema.TypeString,
+						Description:      "The drive’s reported serial number",
+						Optional:         true,
+						Default:          "",
+						ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(0, 20)),
 					},
 					mkDiskSize: {
 						Type:             schema.TypeInt,


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

```hcl
resource "proxmox_virtual_environment_vm" "test_disk" {
  node_name = "pve"
  started   = false
  name 	    = "test-disk"

  disk {
    file_format  = "raw"
    datastore_id = "local-lvm"
    interface    = "virtio0"
    serial	 = "dead_beef"
    size         = 8
    replicate    = false
    aio          = "native"
  }
}
```

```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.test_disk will be created
  + resource "proxmox_virtual_environment_vm" "test_disk" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "test-disk"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + disk {
          + aio               = "native"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "ignore"
          + file_format       = "raw"
          + interface         = "virtio0"
          + iothread          = false
          + path_in_datastore = (known after apply)
          + replicate         = false
          + serial            = "dead_beef"
          + size              = 8
          + ssd               = false
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.test_disk: Creating...
proxmox_virtual_environment_vm.test_disk: Creation complete after 2s [id=100]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

<img width="1123" alt="Screenshot 2024-06-10 at 9 33 55 PM" src="https://github.com/bpg/terraform-provider-proxmox/assets/627562/90fad2ec-c610-423f-ad3f-8e88fc4daa38">




<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1290

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
