### PR TITLE
fix(lxc): use default rootfs size (4Gb) prevents creation of mount points

### DIFF
--- a/example/resource_virtual_environment_container.tf
+++ b/example/resource_virtual_environment_container.tf
@@ -5,7 +5,7 @@ resource "proxmox_virtual_environment_container" "example_template" {
 
   disk {
     datastore_id = element(data.proxmox_virtual_environment_datastores.example.datastore_ids, index(data.proxmox_virtual_environment_datastores.example.datastore_ids, "local-lvm"))
-    size         = 10
+    size         = 4
   }
 
   mount_point {

--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -67,7 +67,13 @@ resource "proxmox_virtual_environment_container" "test_container" {
 
   disk {
     datastore_id = "local-lvm"
-    size         = 8
+    size         = 4
+  }
+
+  mount_point {
+    volume = "local-lvm"
+    size   = "4G"
+    path   = "mnt/local"
   }
 
   description = <<-EOT

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -1384,17 +1384,6 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m interf
 
 	diskDatastoreID := diskBlock[mkDiskDatastoreID].(string)
 
-	var rootFS *containers.CustomRootFS
-
-	diskSize := diskBlock[mkDiskSize].(int)
-	if diskSize != dvDiskSize && diskDatastoreID != "" {
-		// This is a special case where the rootfs size is set to a non-default value at creation time.
-		// see https://pve.proxmox.com/pve-docs/chapter-pct.html#_storage_backed_mount_points
-		rootFS = &containers.CustomRootFS{
-			Volume: fmt.Sprintf("%s:%d", diskDatastoreID, diskSize),
-		}
-	}
-
 	features, err := containerGetFeatures(container, d)
 	if err != nil {
 		return diag.FromErr(err)
@@ -1592,6 +1581,17 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m interf
 		}
 
 		mountPointArray = append(mountPointArray, mountPointObject)
+	}
+
+	var rootFS *containers.CustomRootFS
+
+	diskSize := diskBlock[mkDiskSize].(int)
+	if diskDatastoreID != "" && (diskSize != dvDiskSize || len(mountPointArray) > 0) {
+		// This is a special case where the rootfs size is set to a non-default value at creation time.
+		// see https://pve.proxmox.com/pve-docs/chapter-pct.html#_storage_backed_mount_points
+		rootFS = &containers.CustomRootFS{
+			Volume: fmt.Sprintf("%s:%d", diskDatastoreID, diskSize),
+		}
 	}
 
 	networkInterface := d.Get(mkNetworkInterface).([]interface{})


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1393

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
