### PR TITLE
fix(docs): Mention alternate valid use of Volid's for containers

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -41,6 +41,8 @@ resource "proxmox_virtual_environment_container" "ubuntu_container" {
 
   operating_system {
     template_file_id = proxmox_virtual_environment_file.latest_ubuntu_22_jammy_lxc_img.id
+    # Or you can use a volume ID, as obtained from a "pvesm list <storage>"
+    # template_file_id = "local:vztmpl/debian-12-standard_12.2-1_amd64.tar.zst"
     type             = "ubuntu"
   }
 
@@ -187,6 +189,8 @@ output "ubuntu_container_public_key" {
 - `node_name` - (Required) The name of the node to assign the container to.
 - `operating_system` - (Required) The Operating System configuration.
     - `template_file_id` - (Required) The identifier for an OS template file.
+       This can be a `Volid` from the output of `pvesm list <storage>`, amongst
+       other choices.
     - `type` - (Optional) The type (defaults to `unmanaged`).
         - `alpine` - Alpine.
         - `archlinux` - Arch Linux.

--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -189,8 +189,8 @@ output "ubuntu_container_public_key" {
 - `node_name` - (Required) The name of the node to assign the container to.
 - `operating_system` - (Required) The Operating System configuration.
     - `template_file_id` - (Required) The identifier for an OS template file.
-       This can be a `Volid` from the output of `pvesm list <storage>`, amongst
-       other choices.
+       The ID format is `<datastore_id>:<content_type>/<file_name>`, for example `local:iso/jammy-server-cloudimg-amd64.tar.gz`. Can be also taken from
+       `proxmox_virtual_environment_download_file` resource, or from the output of `pvesm list <storage>`.
     - `type` - (Optional) The type (defaults to `unmanaged`).
         - `alpine` - Alpine.
         - `archlinux` - Arch Linux.

--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -42,7 +42,7 @@ resource "proxmox_virtual_environment_container" "ubuntu_container" {
   operating_system {
     template_file_id = proxmox_virtual_environment_file.latest_ubuntu_22_jammy_lxc_img.id
     # Or you can use a volume ID, as obtained from a "pvesm list <storage>"
-    # template_file_id = "local:vztmpl/debian-12-standard_12.2-1_amd64.tar.zst"
+    # template_file_id = "local:vztmpl/jammy-server-cloudimg-amd64.tar.gz"
     type             = "ubuntu"
   }
 


### PR DESCRIPTION
Volid's can be used with `template_file_id`.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
Just a small doco tweak.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->


<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
