### PR TITLE
fix(storage): ignore `os.ErrClosed` from deferred `fileReader.Close()` in storage.APIUpload

### DIFF
--- a/proxmox/nodes/storage/upload.go
+++ b/proxmox/nodes/storage/upload.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -112,6 +113,11 @@ func (c *Client) APIUpload(
 	defer func(fileReader *os.File) {
 		e := fileReader.Close()
 		if e != nil {
+			if errors.Is(e, os.ErrClosed) {
+				// We can ignore the error in the case that the file was already closed.
+				return
+			}
+
 			tflog.Error(ctx, "failed to close file reader", map[string]interface{}{
 				"error": e,
 			})


### PR DESCRIPTION
Good Day!

This PR contains a change to `proxmox/nodes/storage/upload.go`, in the deferred call to `fileReader.Close()`. This adds a branch to check if the error returned from the Close call is an `os.ErrClosed`, and if so ignores the error.

This resolves an issue I am having while using the downstream [pulumi-proxmoxve](https://github.com/muhlba91/pulumi-proxmoxve) provider which is based on this terraform provider. In my use case, I am using NixOS, and am trying to create an LXC container based on a vztmpl which is generated locally on my workstation and being uploaded to Proxmox via the pulumi equivalent to the `proxmox_virtual_environment_file` resource.

The error I am having is that whenever the `nixos-system-x86_64-linux.tar.xz` file (size of approximately 114Mb) is uploaded to the proxmox node, the underlying provider plugin throws an error `storage/upload.go:115: provider: failed to close file reader: provider=proxmox@v6.11.1 error="close /tmp/nix-shell.0BVrDm/multipart4267575038: file already closed"`. The file upload does complete successfully, and the file resource is left in a consistent state for subsequent applys (i.e. the `id` property of the resource does get set correctly), and I am able to successfully create an LXC container based on the file resource.

Rerunning the file create/update in my pulumi project with this change resolves the "file already closed" error for my use case.

I am not sure why this error is occurring in the first place, I don't see any extra call to `fileReader.Close()` anywhere else in the terraform provider, it is not clear to me why the fileReader would already be closed. I tested the file resource using a smaller snippet file, and it did not have this issue, so I suspect the issue may have something to do with the size of the upload. However since the upload is ultimately successful with this change, I believe it is safe to catch and ignore the `os.ErrClosed` in this deferred call.

Please let me know if you have any questions or concerns, would be happy to provide additional info 

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Using a pulumi resource definition analogous to this:

```ts
const osTemplate = new proxmox.storage.File("nixos-lxc-template", {
  nodeName: "pve",
  datastoreId: "local",
  contentType: "vztmpl",
  sourceFile: {
    path: "/path/to/nixos-system-x86_64-linux.tar.xz",
    changed: true,
  },
})
```

With the public [pulumi-proxmoxve@v6.11.1 release](https://github.com/muhlba91/pulumi-proxmoxve/releases/tag/v6.11.1), and running `pulumi up` I consistently get a "file already closed" error after the provider replaces the file resource:

![image](https://github.com/user-attachments/assets/d47f9ade-0ecf-4a47-ae72-121d9410a79f)

However changing the pulumi-proxmoxve provider to use this fixed version of the terraform provider, and using the same resource definition, I can consistently replace the file without getting the error:

![image](https://github.com/user-attachments/assets/49b4e123-5c02-4987-b8d1-25b75a947d48)

I was also able to run `make example` and all resources were successfully create/destroyed with this change.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!---
BEGIN_COMMIT_OVERRIDE
fix(storage): ignore `os.ErrClosed` from deferred `fileReader.Close()` in storage.APIUpload (#1468)
END_COMMIT_OVERRIDE
--->