### PR TITLE
feat(file): add support to set the file mode

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -233,7 +233,7 @@ output "ubuntu_container_public_key" {
     - `keyctl` - (Optional) Whether the container supports `keyctl()` system
       call (defaults to `false`)
     - `mount` - (Optional) List of allowed mount types (`cifs` or `nfs`)
-- `hook_script_file_id` - (Optional) The identifier for a file containing a hook script (needs to be executable).
+- `hook_script_file_id` - (Optional) The identifier for a file containing a hook script (needs to be executable, e.g. by using the `proxmox_virtual_environment_file.file_mode` attribute).
 
 ## Attribute Reference
 

--- a/docs/resources/virtual_environment_file.md
+++ b/docs/resources/virtual_environment_file.md
@@ -80,6 +80,27 @@ resource "proxmox_virtual_environment_file" "cloud_config" {
 }
 ```
 
+The `file_mode` attribute can be used to make a script file executable, e.g. when referencing the file in the `hook_script_file_id` attribute of [a container](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_container#hook_script_file_id) or [a VM](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_vm#hook_script_file_id) resource which is a requirement enforced by the Proxmox VE API.
+
+```hcl
+resource "proxmox_virtual_environment_file" "hook_script" {
+  content_type = "snippets"
+  datastore_id = "local"
+  node_name    = "pve"
+  # Hook scripts must be executable, otherwise the Proxmox VE API will reject the configuration for the VM/CT.
+  file_mode    = "0700"
+
+  source_raw {
+    data      = <<-EOF
+      #!/usr/bin/env bash
+
+      echo "Running hook script"
+      EOF
+    file_name = "prepare-hook.sh"
+  }
+}
+```
+
 ### Container Template (`vztmpl`)
 
 -> Consider using `proxmox_virtual_environment_download_file` resource instead. Using this resource for container images is less efficient (requires to transfer uploaded image to node) though still supported.

--- a/docs/resources/virtual_environment_file.md
+++ b/docs/resources/virtual_environment_file.md
@@ -105,6 +105,7 @@ resource "proxmox_virtual_environment_file" "ubuntu_container_template" {
     - `snippets` (allowed extensions: any)
     - `vztmpl` (allowed extensions: `.tar.gz`, `.tar.xz`, `tar.zst`)
 - `datastore_id` - (Required) The datastore id.
+- `file_mode` - The file mode in octal format, e.g. `0700` or `600`. Note that the prefixes `0o` and `0x` is not supported! Setting this attribute is also only allowed for `root@pam` authenticated user.
 - `node_name` - (Required) The node name.
 - `overwrite` - (Optional) Whether to overwrite an existing file (defaults to
     `true`).

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -545,7 +545,7 @@ output "ubuntu_vm_public_key" {
         - `vmware` - VMware Compatible.
     - `clipboard` - (Optional) Enable VNC clipboard by setting to `vnc`. See the [Proxmox documentation](https://pve.proxmox.com/pve-docs/pve-admin-guide.html#qm_virtual_machines_settings) section 10.2.8 for more information.
 - `vm_id` - (Optional) The VM identifier.
-- `hook_script_file_id` - (Optional) The identifier for a file containing a hook script (needs to be executable).
+- `hook_script_file_id` - (Optional) The identifier for a file containing a hook script (needs to be executable, e.g. by using the `proxmox_virtual_environment_file.file_mode` attribute). 
 
 ## Attribute Reference
 

--- a/example/resource_virtual_environment_file.tf
+++ b/example/resource_virtual_environment_file.tf
@@ -63,24 +63,3 @@ local-hostname: myhost.internal
     file_name = "meta-config.yaml"
   }
 }
-
-#===============================================================================
-# Snippets
-#===============================================================================
-
-resource "proxmox_virtual_environment_file" "hook_script" {
-  content_type = "snippets"
-  datastore_id = element(data.proxmox_virtual_environment_datastores.example.datastore_ids, index(data.proxmox_virtual_environment_datastores.example.datastore_ids, "local"))
-  node_name    = data.proxmox_virtual_environment_datastores.example.node_name
-  # Hook scripts must be executable, otherwise the Proxmox VE API will reject the configuration for the VM/CT.
-  file_mode = "0700"
-
-  source_raw {
-    data = <<-EOF
-      #!/usr/bin/env bash
-
-      echo "Running hook script"
-      EOF
-    file_name = "prepare-hook.sh"
-  }
-}

--- a/example/resource_virtual_environment_file.tf
+++ b/example/resource_virtual_environment_file.tf
@@ -63,3 +63,24 @@ local-hostname: myhost.internal
     file_name = "meta-config.yaml"
   }
 }
+
+#===============================================================================
+# Snippets
+#===============================================================================
+
+resource "proxmox_virtual_environment_file" "hook_script" {
+  content_type = "snippets"
+  datastore_id = element(data.proxmox_virtual_environment_datastores.example.datastore_ids, index(data.proxmox_virtual_environment_datastores.example.datastore_ids, "local"))
+  node_name    = data.proxmox_virtual_environment_datastores.example.node_name
+  # Hook scripts must be executable, otherwise the Proxmox VE API will reject the configuration for the VM/CT.
+  file_mode = "0700"
+
+  source_raw {
+    data = <<-EOF
+      #!/usr/bin/env bash
+
+      echo "Running hook script"
+      EOF
+    file_name = "prepare-hook.sh"
+  }
+}

--- a/proxmox/api/client_types.go
+++ b/proxmox/api/client_types.go
@@ -29,4 +29,9 @@ type FileUploadRequest struct {
 	ContentType string
 	FileName    string
 	File        *os.File
+	// Will be handled as unsigned 32-bit integer since the underlying type of os.FileMode is the same, but must be parsed
+	// as string due to the conversion of the octal format.
+	// References:
+	//   1. https://en.wikipedia.org/wiki/Chmod#Special_modes
+	Mode string
 }

--- a/proxmox/ssh/client.go
+++ b/proxmox/ssh/client.go
@@ -16,6 +16,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -269,8 +270,31 @@ func (c *client) NodeUpload(
 			remoteFilePath, bytesUploaded, fileSize)
 	}
 
+	remoteStat, err := remoteFile.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to read file info of uploaded file %s: %w", remoteFilePath, err)
+	}
+
+	remoteFileMode := remoteStat.Mode()
+
+	if d.Mode != "" {
+		parsedFileMode, parseErr := strconv.ParseUint(d.Mode, 8, 12)
+		if parseErr != nil {
+			return fmt.Errorf("failed to parse file mode %q: %w", d.Mode, err)
+		}
+
+		targetFileMode := os.FileMode(uint32(parsedFileMode))
+		if err = sftpClient.Chmod(remoteFilePath, targetFileMode); err != nil {
+			return fmt.Errorf("failed to change file mode of remote file from %#o (%s) to %#o (%s): %w",
+				remoteFileMode.Perm(), remoteFileMode, targetFileMode.Perm(), targetFileMode, err)
+		}
+
+		remoteFileMode = targetFileMode
+	}
+
 	tflog.Debug(ctx, "uploaded file to datastore", map[string]interface{}{
 		"remote_file_path": remoteFilePath,
+		"remote_file_mode": fmt.Sprintf("%#o (%s)", remoteFileMode, remoteFileMode),
 		"size":             bytesUploaded,
 	})
 
@@ -330,6 +354,17 @@ func (c *client) NodeStreamUpload(
 	err = c.checkUploadedFile(ctx, sshClient, remoteFilePath, fileSize)
 	if err != nil {
 		return err
+	}
+
+	if d.Mode != "" {
+		parsedFileMode, parseErr := strconv.ParseUint(d.Mode, 8, 12)
+		if parseErr != nil {
+			return fmt.Errorf("failed to parse file mode %q: %w", d.Mode, err)
+		}
+
+		if err = c.changeModeUploadedFile(ctx, sshClient, remoteFilePath, os.FileMode(uint32(parsedFileMode))); err != nil {
+			return err
+		}
 	}
 
 	tflog.Debug(ctx, "uploaded file to datastore", map[string]interface{}{
@@ -406,6 +441,49 @@ func (c *client) checkUploadedFile(
 		return fmt.Errorf("failed to upload file %s: uploaded %d bytes, expected %d bytes",
 			remoteFilePath, bytesUploaded, fileSize)
 	}
+
+	return nil
+}
+
+func (c *client) changeModeUploadedFile(
+	ctx context.Context,
+	sshClient *ssh.Client,
+	remoteFilePath string,
+	fileMode os.FileMode,
+) error {
+	sftpClient, err := sftp.NewClient(sshClient)
+	if err != nil {
+		return fmt.Errorf("failed to create SFTP client: %w", err)
+	}
+
+	defer func(sftpClient *sftp.Client) {
+		e := sftpClient.Close()
+		if e != nil {
+			tflog.Warn(ctx, "failed to close SFTP client", map[string]interface{}{
+				"error": e,
+			})
+		}
+	}(sftpClient)
+
+	remoteFile, err := sftpClient.Open(remoteFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to open remote file %s: %w", remoteFilePath, err)
+	}
+
+	remoteStat, err := remoteFile.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to read remote file %s: %w", remoteFilePath, err)
+	}
+
+	if err = sftpClient.Chmod(remoteFilePath, fileMode); err != nil {
+		return fmt.Errorf("failed to change file mode of remote file from %#o (%s) to %#o (%s): %w",
+			remoteStat.Mode().Perm(), remoteStat.Mode(), fileMode.Perm(), fileMode, err)
+	}
+
+	tflog.Debug(ctx, "changed mode of uploaded file", map[string]interface{}{
+		"before": fmt.Sprintf("%#o (%s)", remoteStat.Mode().Perm(), remoteStat.Mode()),
+		"after":  fmt.Sprintf("%#o (%s)", fileMode.Perm(), fileMode),
+	})
 
 	return nil
 }

--- a/proxmox/ssh/client.go
+++ b/proxmox/ssh/client.go
@@ -270,31 +270,8 @@ func (c *client) NodeUpload(
 			remoteFilePath, bytesUploaded, fileSize)
 	}
 
-	remoteStat, err := remoteFile.Stat()
-	if err != nil {
-		return fmt.Errorf("failed to read file info of uploaded file %s: %w", remoteFilePath, err)
-	}
-
-	remoteFileMode := remoteStat.Mode()
-
-	if d.Mode != "" {
-		parsedFileMode, parseErr := strconv.ParseUint(d.Mode, 8, 12)
-		if parseErr != nil {
-			return fmt.Errorf("failed to parse file mode %q: %w", d.Mode, err)
-		}
-
-		targetFileMode := os.FileMode(uint32(parsedFileMode))
-		if err = sftpClient.Chmod(remoteFilePath, targetFileMode); err != nil {
-			return fmt.Errorf("failed to change file mode of remote file from %#o (%s) to %#o (%s): %w",
-				remoteFileMode.Perm(), remoteFileMode, targetFileMode.Perm(), targetFileMode, err)
-		}
-
-		remoteFileMode = targetFileMode
-	}
-
 	tflog.Debug(ctx, "uploaded file to datastore", map[string]interface{}{
 		"remote_file_path": remoteFilePath,
-		"remote_file_mode": fmt.Sprintf("%#o (%s)", remoteFileMode, remoteFileMode),
 		"size":             bytesUploaded,
 	})
 

--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -99,7 +99,8 @@ func File() *schema.Resource {
 			mkResourceVirtualEnvironmentFileFileMode: {
 				Type: schema.TypeString,
 				Description: `The file mode in octal format, e.g. "0700" or "600".` +
-					`Note that the prefixes "0o" and "0x" are not supported!`,
+					`Note that the prefixes "0o" and "0x" are not supported!` +
+					`Setting this attribute is also only allowed for "root@pam" authenticated user.`,
 				Optional:         true,
 				ValidateDiagFunc: validators.FileMode(),
 				ForceNew:         true,

--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -99,11 +99,10 @@ func File() *schema.Resource {
 			mkResourceVirtualEnvironmentFileFileMode: {
 				Type: schema.TypeString,
 				Description: `The file mode in octal format, e.g. "0700" or "600".` +
-					`Note that the prefix "0o" or "0x" is not supported!`,
+					`Note that the prefixes "0o" and "0x" are not supported!`,
 				Optional:         true,
 				ValidateDiagFunc: validators.FileMode(),
-				// Allow to update only the file mode even when the content has not changed.
-				ForceNew: true,
+				ForceNew:         true,
 			},
 			mkResourceVirtualEnvironmentFileFileSize: {
 				Type:        schema.TypeInt,

--- a/proxmoxtf/resource/file_test.go
+++ b/proxmoxtf/resource/file_test.go
@@ -39,6 +39,7 @@ func TestFileSchema(t *testing.T) {
 	test.AssertOptionalArguments(t, s, []string{
 		mkResourceVirtualEnvironmentFileContentType,
 		mkResourceVirtualEnvironmentFileSourceFile,
+		mkResourceVirtualEnvironmentFileFileMode,
 		mkResourceVirtualEnvironmentFileSourceRaw,
 		mkResourceVirtualEnvironmentFileTimeoutUpload,
 	})
@@ -55,6 +56,7 @@ func TestFileSchema(t *testing.T) {
 		mkResourceVirtualEnvironmentFileDatastoreID:          schema.TypeString,
 		mkResourceVirtualEnvironmentFileFileModificationDate: schema.TypeString,
 		mkResourceVirtualEnvironmentFileFileName:             schema.TypeString,
+		mkResourceVirtualEnvironmentFileFileMode:             schema.TypeString,
 		mkResourceVirtualEnvironmentFileFileSize:             schema.TypeInt,
 		mkResourceVirtualEnvironmentFileFileTag:              schema.TypeString,
 		mkResourceVirtualEnvironmentFileNodeName:             schema.TypeString,

--- a/proxmoxtf/resource/validators/file_test.go
+++ b/proxmoxtf/resource/validators/file_test.go
@@ -41,3 +41,39 @@ func TestFileID(t *testing.T) {
 		})
 	}
 }
+
+func TestFileMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		valid bool
+	}{
+		{"valid", "0700", true},
+		{"invalid", "invalid", false},
+		// Even though Go supports octal prefixes, we should not allow them in the string value to reduce the complexity.
+		{"invalid", "0o700", false},
+		{"invalid", "0x700", false},
+		// Maximum value for uint32, incremented by one.
+		{"too large", "4294967296", false},
+		{"too small", "0", false},
+		{"negative", "-1", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := FileMode()
+			res := f(tt.value, nil)
+
+			if tt.valid {
+				require.Empty(t, res, "validate: '%s'", tt.value)
+			} else {
+				require.NotEmpty(t, res, "validate: '%s'", tt.value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Contributor's Note

- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.
  - [x] Tested against own Proxmox VE clusters.

### Summary
#733 implemented basic support for hook scripts, but [the authors "did not manage to find time to work on"][1] also including support to set the file mode. This small but important feature makes the use of the [`proxmox_virtual_environment_container.hook_script_file_id`][2] and [`virtual_environment_vm.hook_script_file_id`][3] attributes basically useless when not combined with the manual step of making the uploaded file executable (manually running `chmod +x /path/to/script` or using other methods, based on the storage backend). Using the `hook_script_file_id` on its own also causes all planned and applied changes in the same execution to not be saved in the state because the Proxmox VE API responses with a HTTP `500` error since the uploaded and assigned file is not executable.

This pull request implements the missing feature to set the file mode by adding a new `file_mode` attribute of type `string` where an octal-formatted value can be passed, e.g. `0700` or only `600`. Note that the octal prefixes `0o` and `0x` are not supported to reduce the complexity, even though [the used `os.FileMode` type][4] supports it.
Changing the file mode also causes the file to be replaced, which is true for almost any attribute in the `proxmox_virtual_environment_file` resource, to ensure that the file mode can also be changed after the initial creation.

<details>
<summary>Off-Topic</summary>
@bpg Sorry for the silence in my last PR for the APT repository support!
Life kicked in again and I had not time to resolve the review changes. I'll fix these in a new PR 😄
</details>

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #570
Relates #733

[1]: https://github.com/bpg/terraform-provider-proxmox/pull/733#issuecomment-2096716738
[2]: https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_container#hook_script_file_id
[3]: https://registry.terraform.io/providers/bpg/proxmox/latest/docs/resources/virtual_environment_vm#hook_script_file_id
[4]: https://pkg.go.dev/os#FileMode
