### PR TITLE
fix(firewall/rules): update firewall logic to handle unique rule ids, rules and terraform state with consistency

### DIFF
--- a/proxmox/firewall/rules.go
+++ b/proxmox/firewall/rules.go
@@ -58,7 +58,7 @@ func (c *Client) GetRulesID() string {
 	id := uuid.New().ID()
 	finalID := timestamp + int64(id)
 
-	return fmt.Sprintf("role-%d", finalID)
+	return fmt.Sprintf("rule-%d", finalID)
 }
 
 // CreateRule creates a firewall rule.

--- a/proxmox/firewall/rules.go
+++ b/proxmox/firewall/rules.go
@@ -10,12 +10,11 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"time"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
+	"github.com/google/uuid"
 )
 
 // Rule is an interface for the Proxmox firewall rule API.
@@ -54,7 +53,12 @@ func (c *Client) rulePath(pos int) string {
 
 // GetRulesID returns the ID of the rules object.
 func (c *Client) GetRulesID() string {
-	return "rule-" + strconv.Itoa(schema.HashString(c.rulesPath()))
+	// Creates unique id in every being called by using unix timestamp
+	timestamp := time.Now().UnixNano() / int64(time.Microsecond)
+	id := uuid.New().ID()
+	finalID := timestamp + int64(id)
+
+	return fmt.Sprintf("sg-%d", finalID)
 }
 
 // CreateRule creates a firewall rule.

--- a/proxmox/firewall/rules.go
+++ b/proxmox/firewall/rules.go
@@ -58,7 +58,7 @@ func (c *Client) GetRulesID() string {
 	id := uuid.New().ID()
 	finalID := timestamp + int64(id)
 
-	return fmt.Sprintf("sg-%d", finalID)
+	return fmt.Sprintf("role-%d", finalID)
 }
 
 // CreateRule creates a firewall rule.


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

This  PR is handling the below 2 issues:
```Issue 1```:  
Rule resources produce the same rule ID:
Example rules:
```
resource "proxmox_virtual_environment_cluster_firewall_security_group" "test" {
  name    = "test"
  comment = "Managed by Terraform"

  rule {
    type    = "in"
    action  = "REJECT"
    comment = "DENY HTTP 100.35"
    source  = "192.168.100.35"
    dport   = "80"
    proto   = "tcp"
    log     = "info"
  }

  rule {
    type    = "in"
    action  = "REJECT"
    comment = "DENY HTTPS 110.35"
    source  = "192.168.110.35"
    dport   = "443"
    proto   = "tcp"
    log     = "info"
  }

  rule {
    type    = "in"
    action  = "REJECT"
    comment = "DENY HTTPS 130.35"
    dest    = "192.168.130.35"
    dport   = "443"
    proto   = "tcp"
    log     = "info"
  }
}

resource "proxmox_virtual_environment_firewall_rules" "outbound" {
  node_name = "pve"
  container_id = "101"
  rule {
    type    = "out"
    action  = "REJECT"
    comment = "DENY TO HTTP 1.5"
    dest    = "192.168.1.5"
    sport   = "80"
    proto   = "tcp"
    log     = "info"
  }
  rule {
    type    = "out"
    action  = "REJECT"
    comment = "DENY TO HTTPS 1.5"
    dest    = "192.168.1.5"
    dport   = "443"
    proto   = "tcp"
    log     = "info"
  }
  lifecycle {
    ignore_changes = []
  }
}

resource "proxmox_virtual_environment_firewall_rules" "inbound" {
  node_name = "pve"
  container_id = "101"
  rule {
    type    = "in"
    action  = "ACCEPT"
    comment = "Allow HTTP"
    dest    = "0.0.0.0/0"
    dport   = "80"
    proto   = "tcp"
    log     = "info"
  }
  rule {
    type    = "in"
    action  = "ACCEPT"
    comment = "Allow HTTPS"
    dest    = "0.0.0.0/0"
    dport   = "443"
    proto   = "tcp"
    log     = "info"
  }
  rule {
    security_group = "test"
  }
  depends_on = [ 
      proxmox_virtual_environment_cluster_firewall_security_group.test 
      ]
  }
```  

Provider's Output:
```
Plan: 3 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_firewall_rules.outbound: Creating...
proxmox_virtual_environment_cluster_firewall_security_group.test: Creating...
proxmox_virtual_environment_firewall_rules.outbound: Creation complete after 0s [id=rule-2020289146] <-
proxmox_virtual_environment_cluster_firewall_security_group.test: Creation complete after 0s [id=test]
proxmox_virtual_environment_firewall_rules.inbound: Creating...
proxmox_virtual_environment_firewall_rules.inbound: Creation complete after 0s [id=rule-2020289146] <-
```  

```Issue 2```:
Rule checking/state logic is inconsistent, which produces the below issues:  

1.  Terraform plan yields continuously that change is detected and needs to be applied when no actual change happen.
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  ~ update in-place

Terraform will perform the following actions:

  # proxmox_virtual_environment_firewall_rules.inbound will be updated in-place
  ~ resource "proxmox_virtual_environment_firewall_rules" "inbound" {
        id           = "rule-2020289146"
        # (2 unchanged attributes hidden)

      ~ rule {
          - sport   = "80" -> null
            # (9 unchanged attributes hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # proxmox_virtual_environment_firewall_rules.outbound will be updated in-place
  ~ resource "proxmox_virtual_environment_firewall_rules" "outbound" {
        id           = "rule-2020289146"
        # (2 unchanged attributes hidden)

      ~ rule {
          ~ action  = "ACCEPT" -> "REJECT"
          ~ comment = "Allow HTTP" -> "DENY HTTP 1.5"
          ~ dest    = "0.0.0.0/0" -> "192.168.1.5"
          - dport   = "80" -> null
          ~ type    = "in" -> "out"
            # (5 unchanged attributes hidden)
        }
      ~ rule {
          ~ action  = "ACCEPT" -> "REJECT"
          ~ comment = "Allow HTTPS" -> "DENY HTTPS 1.5"
          ~ dest    = "0.0.0.0/0" -> "192.168.1.5"
          ~ type    = "in" -> "out"
            # (5 unchanged attributes hidden)
        }
    }

Plan: 0 to add, 2 to change, 0 to destroy.
proxmox_virtual_environment_firewall_rules.outbound: Modifying... [id=rule-2020289146]
proxmox_virtual_environment_firewall_rules.inbound: Modifying... [id=rule-2020289146]
proxmox_virtual_environment_firewall_rules.inbound: Modifications complete after 0s [id=rule-2020289146]
proxmox_virtual_environment_firewall_rules.outbound: Modifications complete after 1s [id=rule-2020289146]

Apply complete! Resources: 0 added, 2 changed, 0 destroyed.
...
proxmox_virtual_environment_cluster_firewall_security_group.test: Refreshing state... [id=test]
proxmox_virtual_environment_firewall_rules.outbound: Refreshing state... [id=rule-2020289146]
proxmox_virtual_environment_firewall_rules.inbound: Refreshing state... [id=rule-2020289146]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  ~ update in-place

Terraform will perform the following actions:

  # proxmox_virtual_environment_firewall_rules.inbound will be updated in-place
  ~ resource "proxmox_virtual_environment_firewall_rules" "inbound" {
        id           = "rule-2020289146"
...
proxmox_virtual_environment_firewall_rules.outbound: Refreshing state... [id=rule-2020289146]
proxmox_virtual_environment_cluster_firewall_security_group.test: Refreshing state... [id=test]
proxmox_virtual_environment_firewall_rules.inbound: Refreshing state... [id=rule-2020289146]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  ~ update in-place

Terraform will perform the following actions:

  # proxmox_virtual_environment_firewall_rules.inbound will be updated in-place
  ~ resource "proxmox_virtual_environment_firewall_rules" "inbound" {
        id           = "rule-2020289146"
        # (2 unchanged attributes hidden)

      ~ rule {
          - sport   = "80" -> null
            # (9 unchanged attributes hidden)
        }

        # (2 unchanged blocks hidden)
    }

  # proxmox_virtual_environment_firewall_rules.outbound will be updated in-place
  ~ resource "proxmox_virtual_environment_firewall_rules" "outbound" {
        id           = "rule-2020289146"
        # (2 unchanged attributes hidden)

      ~ rule {
          ~ action  = "ACCEPT" -> "REJECT"
          ~ comment = "Allow HTTP" -> "DENY HTTP 1.5"
          ~ dest    = "0.0.0.0/0" -> "192.168.1.5"
          - dport   = "80" -> null
          ~ type    = "in" -> "out"
            # (5 unchanged attributes hidden)
        }
      ~ rule {
          ~ action  = "ACCEPT" -> "REJECT"
          ~ comment = "Allow HTTPS" -> "DENY HTTPS 1.5"
          ~ dest    = "0.0.0.0/0" -> "192.168.1.5"
          ~ type    = "in" -> "out"
            # (5 unchanged attributes hidden)
        }
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```
2. Errors during rule delete/update operations : ```... no rule at position X ...``` 
```
proxmox_virtual_environment_firewall_rules.outbound: Refreshing state... [id=rule-2020289146]
proxmox_virtual_environment_cluster_firewall_security_group.test: Refreshing state... [id=test]
proxmox_virtual_environment_firewall_rules.inbound: Refreshing state... [id=rule-2020289146]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  - destroy

Terraform will perform the following actions:

  # proxmox_virtual_environment_cluster_firewall_security_group.test will be destroyed
  - resource "proxmox_virtual_environment_cluster_firewall_security_group" "test" {
      - comment = "Managed by Terraform" -> null
      - id      = "test" -> null
      - name    = "test" -> null

      - rule {
          - action  = "REJECT" -> null
          - comment = "DENY HTTP 100.35" -> null
          - dport   = "80" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 0 -> null
          - proto   = "tcp" -> null
          - source  = "192.168.100.35" -> null
          - type    = "in" -> null
        }
      - rule {
          - action  = "REJECT" -> null
          - comment = "DENY HTTPS 110.35" -> null
          - dport   = "443" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 1 -> null
          - proto   = "tcp" -> null
          - source  = "192.168.110.35" -> null
          - type    = "in" -> null
        }
      - rule {
          - action  = "REJECT" -> null
          - comment = "DENY HTTPS 130.35" -> null
          - dest    = "192.168.130.35" -> null
          - dport   = "443" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 2 -> null
          - proto   = "tcp" -> null
          - type    = "in" -> null
        }
    }

  # proxmox_virtual_environment_firewall_rules.inbound will be destroyed
  - resource "proxmox_virtual_environment_firewall_rules" "inbound" {
      - container_id = 101 -> null
      - id           = "rule-2020289146" -> null
      - node_name    = "pve" -> null

      - rule {
          - action  = "ACCEPT" -> null
          - comment = "Allow HTTP" -> null
          - dest    = "0.0.0.0/0" -> null
          - dport   = "80" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 0 -> null
          - proto   = "tcp" -> null
          - sport   = "80" -> null
          - type    = "in" -> null
        }
      - rule {
          - action  = "ACCEPT" -> null
          - comment = "Allow HTTPS" -> null
          - dest    = "0.0.0.0/0" -> null
          - dport   = "443" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 1 -> null
          - proto   = "tcp" -> null
          - type    = "in" -> null
        }
      - rule {
          - enabled        = true -> null
          - pos            = 2 -> null
          - security_group = "test" -> null
        }
    }

  # proxmox_virtual_environment_firewall_rules.outbound will be destroyed
  - resource "proxmox_virtual_environment_firewall_rules" "outbound" {
      - container_id = 101 -> null
      - id           = "rule-2020289146" -> null
      - node_name    = "pve" -> null

      - rule {
          - action  = "ACCEPT" -> null
          - comment = "Allow HTTP" -> null
          - dest    = "0.0.0.0/0" -> null
          - dport   = "80" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 0 -> null
          - proto   = "tcp" -> null
          - sport   = "80" -> null
          - type    = "in" -> null
        }
      - rule {
          - action  = "ACCEPT" -> null
          - comment = "Allow HTTPS" -> null
          - dest    = "0.0.0.0/0" -> null
          - dport   = "443" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 1 -> null
          - proto   = "tcp" -> null
          - type    = "in" -> null
        }
    }

Plan: 0 to add, 0 to change, 3 to destroy.
proxmox_virtual_environment_firewall_rules.outbound: Destroying... [id=rule-2020289146]
proxmox_virtual_environment_firewall_rules.inbound: Destroying... [id=rule-2020289146]
proxmox_virtual_environment_firewall_rules.outbound: Destruction complete after 0s
Error: error deleting firewall rule 2: received an HTTP 500 response - Reason: no rule at position 2

Error: error deleting firewall rule 1: received an HTTP 500 response - Reason: no rule at position 1 
```

This PR fixes the rule unique id creation and the state/rule consistency and as result no more errors during rule delete/update operations.

1. Unique id of rule resources:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  + create

Terraform will perform the following actions:

  # proxmox_virtual_environment_cluster_firewall_security_group.test will be created
  + resource "proxmox_virtual_environment_cluster_firewall_security_group" "test" {
      + comment = "Managed by Terraform"
      + id      = (known after apply)
      + name    = "test"

      + rule {
          + action  = "REJECT"
          + comment = "DENY HTTP 100.35"
          + dport   = "80"
          + enabled = true
          + log     = "info"
          + pos     = (known after apply)
          + proto   = "tcp"
          + source  = "192.168.100.35"
          + type    = "in"
        }
      + rule {
          + action  = "REJECT"
          + comment = "DENY HTTPS 110.35"
          + dport   = "443"
          + enabled = true
          + log     = "info"
          + pos     = (known after apply)
          + proto   = "tcp"
          + source  = "192.168.110.35"
          + type    = "in"
        }
      + rule {
          + action  = "REJECT"
          + comment = "DENY HTTPS 130.35"
          + dest    = "192.168.130.35"
          + dport   = "443"
          + enabled = true
          + log     = "info"
          + pos     = (known after apply)
          + proto   = "tcp"
          + type    = "in"
        }
    }

  # proxmox_virtual_environment_firewall_rules.inbound will be created
  + resource "proxmox_virtual_environment_firewall_rules" "inbound" {
      + container_id = 101
      + id           = (known after apply)
      + node_name    = "pve"

      + rule {
          + action  = "ACCEPT"
          + comment = "Allow HTTP"
          + dest    = "0.0.0.0/0"
          + dport   = "80"
          + enabled = true
          + log     = "info"
          + pos     = (known after apply)
          + proto   = "tcp"
          + type    = "in"
        }
      + rule {
          + action  = "ACCEPT"
          + comment = "Allow HTTPS"
          + dest    = "0.0.0.0/0"
          + dport   = "443"
          + enabled = true
          + log     = "info"
          + pos     = (known after apply)
          + proto   = "tcp"
          + type    = "in"
        }
      + rule {
          + enabled        = true
          + pos            = (known after apply)
          + security_group = "test"
        }
    }

  # proxmox_virtual_environment_firewall_rules.outbound will be created
  + resource "proxmox_virtual_environment_firewall_rules" "outbound" {
      + container_id = 101
      + id           = (known after apply)
      + node_name    = "pve"

      + rule {
          + action  = "REJECT"
          + comment = "DENY HTTP 1.5"
          + dest    = "192.168.1.5"
          + enabled = true
          + log     = "info"
          + pos     = (known after apply)
          + proto   = "tcp"
          + sport   = "80"
          + type    = "out"
        }
      + rule {
          + action  = "REJECT"
          + comment = "DENY HTTPS 1.5"
          + dest    = "192.168.1.5"
          + dport   = "443"
          + enabled = true
          + log     = "info"
          + pos     = (known after apply)
          + proto   = "tcp"
          + type    = "out"
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_firewall_rules.outbound: Creating...
proxmox_virtual_environment_cluster_firewall_security_group.test: Creating...
proxmox_virtual_environment_firewall_rules.outbound: Creation complete after 1s [id=role-1724524866788386] <-
proxmox_virtual_environment_cluster_firewall_security_group.test: Creation complete after 1s [id=test]
proxmox_virtual_environment_firewall_rules.inbound: Creating...
proxmox_virtual_environment_firewall_rules.inbound: Creation complete after 0s [id=role-1724523131556197] <-

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```
2. Terraform plan is now only creating diff when actual changes exist:
```
proxmox_virtual_environment_firewall_rules.outbound: Refreshing state... [id=role-1724524866788386]
proxmox_virtual_environment_cluster_firewall_security_group.test: Refreshing state... [id=test]
proxmox_virtual_environment_firewall_rules.inbound: Refreshing state... [id=role-1724523131556197]

No changes. Your infrastructure matches the configuration.
```
3. Terraform update/delete operations do not yield position errors any more:
```
proxmox_virtual_environment_cluster_firewall_security_group.test: Refreshing state... [id=test]
proxmox_virtual_environment_firewall_rules.outbound: Refreshing state... [id=role-1724524866788386]
proxmox_virtual_environment_firewall_rules.inbound: Refreshing state... [id=role-1724523131556197]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following
symbols:
  - destroy

Terraform will perform the following actions:

  # proxmox_virtual_environment_cluster_firewall_security_group.test will be destroyed
  - resource "proxmox_virtual_environment_cluster_firewall_security_group" "test" {
      - comment = "Managed by Terraform" -> null
      - id      = "test" -> null
      - name    = "test" -> null

      - rule {
          - action  = "REJECT" -> null
          - comment = "DENY HTTP 100.35" -> null
          - dport   = "80" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 0 -> null
          - proto   = "tcp" -> null
          - source  = "192.168.100.35" -> null
          - type    = "in" -> null
        }
      - rule {
          - action  = "REJECT" -> null
          - comment = "DENY HTTPS 110.35" -> null
          - dport   = "443" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 1 -> null
          - proto   = "tcp" -> null
          - source  = "192.168.110.35" -> null
          - type    = "in" -> null
        }
      - rule {
          - action  = "REJECT" -> null
          - comment = "DENY HTTPS 130.35" -> null
          - dest    = "192.168.130.35" -> null
          - dport   = "443" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 2 -> null
          - proto   = "tcp" -> null
          - type    = "in" -> null
        }
    }

  # proxmox_virtual_environment_firewall_rules.inbound will be destroyed
  - resource "proxmox_virtual_environment_firewall_rules" "inbound" {
      - container_id = 101 -> null
      - id           = "role-1724523131556197" -> null
      - node_name    = "pve" -> null

      - rule {
          - action  = "ACCEPT" -> null
          - comment = "Allow HTTP" -> null
          - dest    = "0.0.0.0/0" -> null
          - dport   = "80" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 0 -> null
          - proto   = "tcp" -> null
          - type    = "in" -> null
        }
      - rule {
          - action  = "ACCEPT" -> null
          - comment = "Allow HTTPS" -> null
          - dest    = "0.0.0.0/0" -> null
          - dport   = "443" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 1 -> null
          - proto   = "tcp" -> null
          - type    = "in" -> null
        }
      - rule {
          - enabled        = true -> null
          - pos            = 2 -> null
          - security_group = "test" -> null
        }
    }

  # proxmox_virtual_environment_firewall_rules.outbound will be destroyed
  - resource "proxmox_virtual_environment_firewall_rules" "outbound" {
      - container_id = 101 -> null
      - id           = "role-1724524866788386" -> null
      - node_name    = "pve" -> null

      - rule {
          - action  = "REJECT" -> null
          - comment = "DENY HTTP 1.5" -> null
          - dest    = "192.168.1.5" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 0 -> null
          - proto   = "tcp" -> null
          - sport   = "80" -> null
          - type    = "out" -> null
        }
      - rule {
          - action  = "REJECT" -> null
          - comment = "DENY HTTPS 1.5" -> null
          - dest    = "192.168.1.5" -> null
          - dport   = "443" -> null
          - enabled = true -> null
          - log     = "info" -> null
          - pos     = 1 -> null
          - proto   = "tcp" -> null
          - type    = "out" -> null
        }
    }

Plan: 0 to add, 0 to change, 3 to destroy.
proxmox_virtual_environment_firewall_rules.outbound: Destroying... [id=role-1724524866788386]
proxmox_virtual_environment_firewall_rules.inbound: Destroying... [id=role-1724523131556197]
proxmox_virtual_environment_firewall_rules.outbound: Destruction complete after 0s
proxmox_virtual_environment_firewall_rules.inbound: Destruction complete after 0s
proxmox_virtual_environment_cluster_firewall_security_group.test: Destroying... [id=test]
proxmox_virtual_environment_cluster_firewall_security_group.test: Destruction complete after 1s

Destroy complete! Resources: 3 destroyed.
```
FIXES #1504

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
