### PR TITLE
fix(vm): `cpu.architecture` showed as new attribute at re-apply after creation

### DIFF
--- a/proxmoxtf/resource/vm/validators.go
+++ b/proxmoxtf/resource/vm/validators.go
@@ -55,6 +55,7 @@ func BIOSValidator() schema.SchemaValidateDiagFunc {
 // CPUArchitectureValidator returns a schema validation function for a CPU architecture.
 func CPUArchitectureValidator() schema.SchemaValidateDiagFunc {
 	return validation.ToDiagFunc(validation.StringInSlice([]string{
+		"",
 		"aarch64",
 		"x86_64",
 	}, false))

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -58,7 +58,7 @@ const (
 	dvCloneNodeName       = ""
 	dvCloneFull           = true
 	dvCloneRetries        = 1
-	dvCPUArchitecture     = "x86_64"
+	dvCPUArchitecture     = ""
 	dvCPUCores            = 1
 	dvCPUHotplugged       = 0
 	dvCPULimit            = 0
@@ -1890,8 +1890,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		}
 
 		// Only the root account is allowed to change the CPU architecture, which makes this check necessary.
-		if client.API().IsRootTicket() ||
-			cpuArchitecture != dvCPUArchitecture {
+		if client.API().IsRootTicket() && cpuArchitecture != "" {
 			updateBody.CPUArchitecture = &cpuArchitecture
 		}
 
@@ -2574,8 +2573,7 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 	}
 
 	// Only the root account is allowed to change the CPU architecture, which makes this check necessary.
-	if client.API().IsRootTicket() ||
-		cpuArchitecture != dvCPUArchitecture {
+	if client.API().IsRootTicket() && cpuArchitecture != "" {
 		createBody.CPUArchitecture = &cpuArchitecture
 	}
 
@@ -4845,8 +4843,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 		cpuAffinity := cpuBlock[mkCPUAffinity].(string)
 
 		// Only the root account is allowed to change the CPU architecture, which makes this check necessary.
-		if client.API().IsRootTicket() ||
-			cpuArchitecture != dvCPUArchitecture {
+		if client.API().IsRootTicket() && cpuArchitecture != "" {
 			updateBody.CPUArchitecture = &cpuArchitecture
 		}
 


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

With this template
```hcl
resource "proxmox_virtual_environment_vm" "test_cdrom" {
  node_name = "pve"
  vm_id     = 999
  started   = false
  name      = "test-cpu-arch"

  cpu {
    cores = 2
    sockets = 1
  }
}
```

Before the fix:
```
❯ tofu apply -auto-approve

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.test_cdrom will be created
  + resource "proxmox_virtual_environment_vm" "test_cdrom" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "test-cpu-arch"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = 999

      + cpu {
          + architecture = "x86_64"
          + cores        = 2
          + hotplugged   = 0
          + limit        = 0
          + numa         = false
          + sockets      = 1
          + type         = "qemu64"
          + units        = 1024
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.test_cdrom: Creating...
proxmox_virtual_environment_vm.test_cdrom: Creation complete after 1s [id=999]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
❯ tofu apply -auto-approve
proxmox_virtual_environment_vm.test_cdrom: Refreshing state... [id=999]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.test_cdrom will be updated in-place
  ~ resource "proxmox_virtual_environment_vm" "test_cdrom" {
        id                      = "999"
        name                    = "test-cpu-arch"
        tags                    = []
        # (26 unchanged attributes hidden)

      ~ cpu {
          + architecture = "x86_64"
            # (8 unchanged attributes hidden)
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
proxmox_virtual_environment_vm.test_cdrom: Modifying... [id=999]
proxmox_virtual_environment_vm.test_cdrom: Modifications complete after 0s [id=999]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

After the fix:
```
❯ tofu apply -auto-approve

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.test_cdrom will be created
  + resource "proxmox_virtual_environment_vm" "test_cdrom" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "test-cpu-arch"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = 999

      + cpu {
          + cores      = 2
          + hotplugged = 0
          + limit      = 0
          + numa       = false
          + sockets    = 1
          + type       = "qemu64"
          + units      = 1024
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.test_cdrom: Creating...
proxmox_virtual_environment_vm.test_cdrom: Creation complete after 1s [id=999]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
❯ tofu apply -auto-approve
proxmox_virtual_environment_vm.test_cdrom: Refreshing state... [id=999]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates: https://github.com/bpg/terraform-provider-proxmox/issues/1494#issuecomment-2336493597

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
