### PR TITLE
fix(vm): handle more than 4 `hostpci` devices

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -312,7 +312,7 @@ output "ubuntu_vm_public_key" {
         (defaults to `v2.0`).
 - `hostpci` - (Optional) A host PCI device mapping (multiple blocks supported).
     - `device` - (Required) The PCI device name for Proxmox, in form
-        of `hostpciX` where `X` is a sequential number from 0 to 3.
+        of `hostpciX` where `X` is a sequential number from 0 to 15.
     - `id` - (Optional) The PCI device ID. This parameter is not compatible
         with `api_token` and requires the root `username` and `password`
         configured in the proxmox provider. Use either this or `mapping`.

--- a/fwprovider/vm/cdrom/resource.go
+++ b/fwprovider/vm/cdrom/resource.go
@@ -22,7 +22,7 @@ type Value = types.Map
 // NewValue returns a new Value with the given CD-ROM settings from the PVE API.
 func NewValue(ctx context.Context, config *vms.GetResponseData, diags *diag.Diagnostics) Value {
 	// find storage devices with media=cdrom
-	cdroms := config.CustomStorageDevices.Filter(func(device *vms.CustomStorageDevice) bool {
+	cdroms := config.StorageDevices.Filter(func(device *vms.CustomStorageDevice) bool {
 		return device.Media != nil && *device.Media == "cdrom"
 	})
 

--- a/proxmox/nodes/vms/custom_pci_device.go
+++ b/proxmox/nodes/vms/custom_pci_device.go
@@ -27,50 +27,50 @@ type CustomPCIDevice struct {
 }
 
 // CustomPCIDevices handles QEMU host PCI device mapping parameters.
-type CustomPCIDevices []CustomPCIDevice
+type CustomPCIDevices map[string]*CustomPCIDevice
 
 // EncodeValues converts a CustomPCIDevice struct to a URL value.
-func (r *CustomPCIDevice) EncodeValues(key string, v *url.Values) error {
+func (d *CustomPCIDevice) EncodeValues(key string, v *url.Values) error {
 	var values []string
 
-	if r.DeviceIDs == nil && r.Mapping == nil {
+	if d.DeviceIDs == nil && d.Mapping == nil {
 		return fmt.Errorf("either device ID or resource mapping must be set")
 	}
 
-	if r.DeviceIDs != nil {
-		values = append(values, fmt.Sprintf("host=%s", strings.Join(*r.DeviceIDs, ";")))
+	if d.DeviceIDs != nil {
+		values = append(values, fmt.Sprintf("host=%s", strings.Join(*d.DeviceIDs, ";")))
 	}
 
-	if r.Mapping != nil {
-		values = append(values, fmt.Sprintf("mapping=%s", *r.Mapping))
+	if d.Mapping != nil {
+		values = append(values, fmt.Sprintf("mapping=%s", *d.Mapping))
 	}
 
-	if r.MDev != nil {
-		values = append(values, fmt.Sprintf("mdev=%s", *r.MDev))
+	if d.MDev != nil {
+		values = append(values, fmt.Sprintf("mdev=%s", *d.MDev))
 	}
 
-	if r.PCIExpress != nil {
-		if *r.PCIExpress {
+	if d.PCIExpress != nil {
+		if *d.PCIExpress {
 			values = append(values, "pcie=1")
 		} else {
 			values = append(values, "pcie=0")
 		}
 	}
 
-	if r.ROMBAR != nil {
-		if *r.ROMBAR {
+	if d.ROMBAR != nil {
+		if *d.ROMBAR {
 			values = append(values, "rombar=1")
 		} else {
 			values = append(values, "rombar=0")
 		}
 	}
 
-	if r.ROMFile != nil {
-		values = append(values, fmt.Sprintf("romfile=%s", *r.ROMFile))
+	if d.ROMFile != nil {
+		values = append(values, fmt.Sprintf("romfile=%s", *d.ROMFile))
 	}
 
-	if r.XVGA != nil {
-		if *r.XVGA {
+	if d.XVGA != nil {
+		if *d.XVGA {
 			values = append(values, "x-vga=1")
 		} else {
 			values = append(values, "x-vga=0")
@@ -83,10 +83,10 @@ func (r *CustomPCIDevice) EncodeValues(key string, v *url.Values) error {
 }
 
 // EncodeValues converts a CustomPCIDevices array to multiple URL values.
-func (r CustomPCIDevices) EncodeValues(key string, v *url.Values) error {
-	for i, d := range r {
-		if err := d.EncodeValues(fmt.Sprintf("%s%d", key, i), v); err != nil {
-			return fmt.Errorf("failed to encode PCI device %d: %w", i, err)
+func (r CustomPCIDevices) EncodeValues(_ string, v *url.Values) error {
+	for s, d := range r {
+		if err := d.EncodeValues(s, v); err != nil {
+			return fmt.Errorf("failed to encode PCI device %s: %w", s, err)
 		}
 	}
 
@@ -94,7 +94,7 @@ func (r CustomPCIDevices) EncodeValues(key string, v *url.Values) error {
 }
 
 // UnmarshalJSON converts a CustomPCIDevice string to an object.
-func (r *CustomPCIDevice) UnmarshalJSON(b []byte) error {
+func (d *CustomPCIDevice) UnmarshalJSON(b []byte) error {
 	var s string
 
 	if err := json.Unmarshal(b, &s); err != nil {
@@ -107,27 +107,27 @@ func (r *CustomPCIDevice) UnmarshalJSON(b []byte) error {
 		v := strings.Split(strings.TrimSpace(p), "=")
 		if len(v) == 1 {
 			dIDs := strings.Split(v[0], ";")
-			r.DeviceIDs = &dIDs
+			d.DeviceIDs = &dIDs
 		} else if len(v) == 2 {
 			switch v[0] {
 			case "host":
 				dIDs := strings.Split(v[1], ";")
-				r.DeviceIDs = &dIDs
+				d.DeviceIDs = &dIDs
 			case "mapping":
-				r.Mapping = &v[1]
+				d.Mapping = &v[1]
 			case "mdev":
-				r.MDev = &v[1]
+				d.MDev = &v[1]
 			case "pcie":
 				bv := types.CustomBool(v[1] == "1")
-				r.PCIExpress = &bv
+				d.PCIExpress = &bv
 			case "rombar":
 				bv := types.CustomBool(v[1] == "1")
-				r.ROMBAR = &bv
+				d.ROMBAR = &bv
 			case "romfile":
-				r.ROMFile = &v[1]
+				d.ROMFile = &v[1]
 			case "x-vga":
 				bv := types.CustomBool(v[1] == "1")
-				r.XVGA = &bv
+				d.XVGA = &bv
 			}
 		}
 	}

--- a/proxmox/nodes/vms/vms_types_test.go
+++ b/proxmox/nodes/vms/vms_types_test.go
@@ -25,7 +25,10 @@ func TestUnmarshalGetResponseData(t *testing.T) {
 		"ide2": "%[1]s",
 		"ide3": "%[1]s",
 		"virtio13": "%[1]s",
-		"scsi22": "%[1]s"
+		"scsi22": "%[1]s",
+		"hostpci0": "0000:81:00.2",
+		"hostpci1": "host=81:00.4,pcie=0,rombar=1,x-vga=0",
+		"hostpci12": "mapping=mappeddevice,pcie=0,rombar=1,x-vga=0"
 	}`, "local-lvm:vm-100-disk-0,aio=io_uring,backup=1,cache=none,discard=ignore,replicate=1,size=8G,ssd=1")
 
 	var data GetResponseData
@@ -34,20 +37,26 @@ func TestUnmarshalGetResponseData(t *testing.T) {
 
 	assert.Equal(t, "test", *data.BackupFile)
 
-	assert.NotNil(t, data.CustomStorageDevices)
-	assert.Len(t, data.CustomStorageDevices, 6)
-	assert.NotNil(t, data.CustomStorageDevices["ide0"])
-	assertDevice(t, data.CustomStorageDevices["ide0"])
-	assert.NotNil(t, data.CustomStorageDevices["ide1"])
-	assertDevice(t, data.CustomStorageDevices["ide1"])
-	assert.NotNil(t, data.CustomStorageDevices["ide2"])
-	assertDevice(t, data.CustomStorageDevices["ide2"])
-	assert.NotNil(t, data.CustomStorageDevices["ide3"])
-	assertDevice(t, data.CustomStorageDevices["ide3"])
-	assert.NotNil(t, data.CustomStorageDevices["virtio13"])
-	assertDevice(t, data.CustomStorageDevices["virtio13"])
-	assert.NotNil(t, data.CustomStorageDevices["scsi22"])
-	assertDevice(t, data.CustomStorageDevices["scsi22"])
+	assert.NotNil(t, data.StorageDevices)
+	assert.Len(t, data.StorageDevices, 6)
+	assert.NotNil(t, data.StorageDevices["ide0"])
+	assertDevice(t, data.StorageDevices["ide0"])
+	assert.NotNil(t, data.StorageDevices["ide1"])
+	assertDevice(t, data.StorageDevices["ide1"])
+	assert.NotNil(t, data.StorageDevices["ide2"])
+	assertDevice(t, data.StorageDevices["ide2"])
+	assert.NotNil(t, data.StorageDevices["ide3"])
+	assertDevice(t, data.StorageDevices["ide3"])
+	assert.NotNil(t, data.StorageDevices["virtio13"])
+	assertDevice(t, data.StorageDevices["virtio13"])
+	assert.NotNil(t, data.StorageDevices["scsi22"])
+	assertDevice(t, data.StorageDevices["scsi22"])
+
+	assert.NotNil(t, data.PCIDevices)
+	assert.Len(t, data.PCIDevices, 3)
+	assert.NotNil(t, data.PCIDevices["hostpci0"])
+	assert.NotNil(t, data.PCIDevices["hostpci1"])
+	assert.NotNil(t, data.PCIDevices["hostpci12"])
 }
 
 func assertDevice(t *testing.T, dev *CustomStorageDevice) {

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -30,7 +30,7 @@ import (
 // GetInfo returns the disk information for a VM.
 // Deprecated: use vms.MapCustomStorageDevices from proxmox/nodes/vms instead.
 func GetInfo(resp *vms.GetResponseData, d *schema.ResourceData) vms.CustomStorageDevices {
-	storageDevices := resp.CustomStorageDevices
+	storageDevices := resp.StorageDevices
 
 	currentDisk := d.Get(MkDisk)
 


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Using template:
```hcl
resource "proxmox_virtual_environment_vm" "test_vm" {
  node_name = "pve"
  vm_id     = 999
  name      = "test-hostpci"

  started = false

  hostpci {
    device = "hostpci0"
    id     = "0000:01:00.0"
    pcie   = true
  }
  hostpci {
    device = "hostpci2"
    id     = "0000:01:00.0"
    pcie   = true
  }
  hostpci {
    device = "hostpci4"
    id     = "0000:01:00.0"
    pcie   = true
  }
  hostpci {
    device = "hostpci6"
    id     = "0000:01:00.0"
    pcie   = true
  }
  hostpci {
    device = "hostpci8"
    id     = "0000:01:00.0"
    pcie   = true
  }
}
```

Before the fix:
```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.test_vm will be created
  + resource "proxmox_virtual_environment_vm" "test_vm" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "test-hostpci"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = 999

      + hostpci {
          + device = "hostpci0"
          + id     = "0000:01:00.0"
          + pcie   = true
        }
      + hostpci {
          + device = "hostpci2"
          + id     = "0000:01:00.0"
          + pcie   = true
        }
      + hostpci {
          + device = "hostpci4"
          + id     = "0000:01:00.0"
          + pcie   = true
        }
      + hostpci {
          + device = "hostpci6"
          + id     = "0000:01:00.0"
          + pcie   = true
        }
      + hostpci {
          + device = "hostpci8"
          + id     = "0000:01:00.0"
          + pcie   = true
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.test_vm: Creating...
proxmox_virtual_environment_vm.test_vm: Creation complete after 1s [id=999]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
❯ tofu apply -auto-approve
proxmox_virtual_environment_vm.test_vm: Refreshing state... [id=999]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.test_vm will be updated in-place
  ~ resource "proxmox_virtual_environment_vm" "test_vm" {
        id                      = "999"
        name                    = "test-hostpci"
        tags                    = []
        # (26 unchanged attributes hidden)

      ~ hostpci {
          ~ device = "hostpci1" -> "hostpci2"
            id     = "0000:01:00.0"
            # (3 unchanged attributes hidden)
        }
      ~ hostpci {
          ~ device = "hostpci2" -> "hostpci4"
            id     = "0000:01:00.0"
            # (3 unchanged attributes hidden)
        }
      ~ hostpci {
          ~ device = "hostpci3" -> "hostpci6"
            id     = "0000:01:00.0"
            # (3 unchanged attributes hidden)
        }
      + hostpci {
          + device = "hostpci8"
          + id     = "0000:01:00.0"
          + pcie   = true
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
proxmox_virtual_environment_vm.test_vm: Modifying... [id=999]
proxmox_virtual_environment_vm.test_vm: Modifications complete after 1s [id=999]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

After the fix:
```
❯ tofu apply -auto-approve
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.test_vm will be created
  + resource "proxmox_virtual_environment_vm" "test_vm" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "test-hostpci"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = 999

      + hostpci {
          + device = "hostpci0"
          + id     = "0000:01:00.0"
          + pcie   = true
        }
      + hostpci {
          + device = "hostpci2"
          + id     = "0000:01:00.0"
          + pcie   = true
        }
      + hostpci {
          + device = "hostpci4"
          + id     = "0000:01:00.0"
          + pcie   = true
        }
      + hostpci {
          + device = "hostpci6"
          + id     = "0000:01:00.0"
          + pcie   = true
        }
      + hostpci {
          + device = "hostpci8"
          + id     = "0000:01:00.0"
          + pcie   = true
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.test_vm: Creating...
proxmox_virtual_environment_vm.test_vm: Creation complete after 1s [id=999]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
❯ tofu apply -auto-approve
proxmox_virtual_environment_vm.test_vm: Refreshing state... [id=999]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1541

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
