### PR TITLE
fix(lxc): add new storage-backed mount point to existing container

### DIFF
--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -111,10 +111,6 @@ func TestAccResourceContainer(t *testing.T) {
 		}}},
 		{"update mount points", []resource.TestStep{
 			{
-				SkipFunc: func() (bool, error) {
-					// mount point deletion: https://github.com/bpg/terraform-provider-proxmox/issues/1392
-					return true, nil
-				},
 				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_container" "test_container" {
 				    node_name = "{{.NodeName}}"
@@ -128,11 +124,6 @@ func TestAccResourceContainer(t *testing.T) {
 						volume = "local-lvm"
 						size   = "4G"
 						path   = "mnt/local1"
-				    }
-					mount_point {
-						volume = "local"
-						size   = "8G"
-						path   = "mnt/local2"
 				    }
 				    initialization {
 				  		hostname = "test"
@@ -151,14 +142,10 @@ func TestAccResourceContainer(t *testing.T) {
 				    }
 				}`),
 				Check: ResourceAttributes("proxmox_virtual_environment_container.test_container", map[string]string{
-					"mount_point.#": "2",
+					"mount_point.#": "1",
 				}),
 			},
 			{
-				SkipFunc: func() (bool, error) {
-					// mount point deletion: https://github.com/bpg/terraform-provider-proxmox/issues/1392
-					return true, nil
-				},
 				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_container" "test_container" {
 				    node_name = "{{.NodeName}}"
@@ -171,6 +158,12 @@ func TestAccResourceContainer(t *testing.T) {
 						volume = "local-lvm"
 						size   = "4G"
 						path   = "mnt/local1"
+				    }
+					// add a new mount point
+				    mount_point {
+						volume = "local-lvm"
+						size   = "4G"
+						path   = "mnt/local2"
 				    }
 				    initialization {
 				  		hostname = "test"


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Update existing acceptance test to check this use case.

The fast fails before the fix:
```
=== RUN   TestAccResourceContainer/update_mount_points
=== PAUSE TestAccResourceContainer/update_mount_points
=== CONT  TestAccResourceContainer/update_mount_points
    resource_container_test.go:253: Step 2/2 error: Error running apply: exit status 1

        Error: error updating container: received an HTTP 500 response - Reason: unable to parse volume ID 'local-lvm'

          with proxmox_virtual_environment_container.test_container,
          on terraform_plugin_test.tf line 22, in resource "proxmox_virtual_environment_container" "test_container":
          22: 				resource "proxmox_virtual_environment_container" "test_container" {

--- FAIL: TestAccResourceContainer/update_mount_points (8.92s)
```
producing these PUT request params:
<img width="899" alt="Screenshot 2024-09-23 at 9 36 34 PM" src="https://github.com/user-attachments/assets/ad2c47ca-cc86-491c-9ee6-a95bf04599e2">


Passes after the fix:
```
=== RUN   TestAccResourceContainer/update_mount_points
=== PAUSE TestAccResourceContainer/update_mount_points
=== CONT  TestAccResourceContainer/update_mount_points
--- PASS: TestAccResourceContainer/update_mount_points (8.66s)
--- PASS: TestAccResourceContainer (1.26s)
PASS
```
<img width="891" alt="Screenshot 2024-09-23 at 9 37 31 PM" src="https://github.com/user-attachments/assets/581ef282-2035-49fb-be3c-0f40da6d4c30">


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1493

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
