### PR TITLE
fix(provider): handle IPv6 in ssh client

### DIFF
--- a/proxmox/ssh/client.go
+++ b/proxmox/ssh/client.go
@@ -473,7 +473,14 @@ func (c *client) openNodeShell(ctx context.Context, node ProxmoxNode) (*ssh.Clie
 		return nil, fmt.Errorf("failed to determine the home directory: %w", err)
 	}
 
-	sshHost := fmt.Sprintf("%s:%d", node.Address, node.Port)
+	var sshHost string
+	if strings.Contains(node.Address, ":") {
+		// IPv6
+		sshHost = fmt.Sprintf("[%s]:%d", node.Address, node.Port)
+	} else {
+		// IPv4
+		sshHost = fmt.Sprintf("%s:%d", node.Address, node.Port)
+	}
 
 	sshPath := path.Join(homeDir, ".ssh")
 	if _, err = os.Stat(sshPath); os.IsNotExist(err) {


### PR DESCRIPTION
~I have **not** tested this but~ it's pretty simple and I think it should work fine.

Should fix this error:
```
Error: creating custom disk: unable to authenticate user "root" over SSH to "fdaa:a:a:a:2::3:22". Please verify that ssh-agent is correctly loaded with an authorized key via 'ssh-add -L' (NOTE: configurations in ~/.ssh/config are not considered
infrastructure  by the provider): failed to dial fdaa:a:a:a:2::3:22: dial tcp: address fdaa:a:a:a:2::3:22: too many colons in address
```