### PR TITLE
fix(provider): sequentially generated `vm_id`s may clash with exiting…

### DIFF
--- a/fwprovider/provider_test.go
+++ b/fwprovider/provider_test.go
@@ -1,0 +1,114 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package fwprovider_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bpg/terraform-provider-proxmox/fwprovider/test"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/cluster"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
+	"github.com/bpg/terraform-provider-proxmox/utils"
+)
+
+func TestIDGenerator_Sequence(t *testing.T) {
+	t.Parallel()
+
+	const numIDs = 10
+
+	if utils.GetAnyStringEnv("TF_ACC") == "" {
+		t.Skip("Acceptance tests are disabled")
+	}
+
+	te := test.InitEnvironment(t)
+
+	ctx := context.Background()
+
+	gen := cluster.NewIDGenerator(te.ClusterClient(), cluster.IDGeneratorConfig{RandomIDs: false})
+	firstID, err := gen.NextID(ctx)
+	require.NoError(t, err)
+
+	busyID := firstID + 5
+
+	_, err = te.ClusterClient().GetNextID(ctx, ptr.Ptr(busyID))
+	require.NoError(t, err, "the VM ID %d should be available", busyID)
+
+	err = te.NodeClient().VM(0).CreateVM(ctx, &vms.CreateRequestBody{VMID: busyID})
+	require.NoError(t, err, "failed to create VM %d", busyID)
+
+	t.Cleanup(func() {
+		err = te.NodeClient().VM(busyID).DeleteVM(ctx)
+		require.NoError(t, err, "failed to delete VM %d", busyID)
+	})
+
+	ids := make([]int, numIDs)
+
+	t.Cleanup(func() {
+		for _, id := range ids {
+			if id > 100 {
+				_ = te.NodeClient().VM(id).DeleteVM(ctx) //nolint:errcheck
+			}
+		}
+	})
+
+	prevID := firstID
+
+	for i := range numIDs {
+		id, err := gen.NextID(ctx)
+		require.NoError(t, err)
+		err = te.NodeClient().VM(0).CreateVM(ctx, &vms.CreateRequestBody{VMID: id})
+		ids[i] = id
+
+		require.NoError(t, err)
+		require.Greater(t, id, prevID, "the generated ID should be greater than the previous one")
+
+		prevID = id
+	}
+}
+
+func TestIDGenerator_Random(t *testing.T) {
+	t.Parallel()
+
+	const (
+		numIDs       = 7
+		randomIDStat = 1000
+		randomIDEnd  = 1010
+	)
+
+	if utils.GetAnyStringEnv("TF_ACC") == "" {
+		t.Skip("Acceptance tests are disabled")
+	}
+
+	te := test.InitEnvironment(t)
+
+	ctx := context.Background()
+
+	gen := cluster.NewIDGenerator(te.ClusterClient(), cluster.IDGeneratorConfig{RandomIDs: true, RandomIDStat: randomIDStat, RandomIDEnd: randomIDEnd})
+
+	ids := make([]int, numIDs)
+
+	t.Cleanup(func() {
+		for _, id := range ids {
+			if id > 100 {
+				_ = te.NodeClient().VM(id).DeleteVM(ctx) //nolint:errcheck
+			}
+		}
+	})
+
+	for i := range numIDs {
+		id, err := gen.NextID(ctx)
+		require.NoError(t, err)
+		err = te.NodeClient().VM(0).CreateVM(ctx, &vms.CreateRequestBody{VMID: id})
+		ids[i] = id
+
+		require.NoError(t, err)
+	}
+}

--- a/fwprovider/test/test_environment.go
+++ b/fwprovider/test/test_environment.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/bpg/terraform-provider-proxmox/fwprovider"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/access"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/cluster"
 	sdkV2provider "github.com/bpg/terraform-provider-proxmox/proxmoxtf/provider"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
@@ -180,6 +181,11 @@ func (e *Environment) NodeClient() *nodes.Client {
 // NodeStorageClient returns a new storage client for the test environment.
 func (e *Environment) NodeStorageClient() *storage.Client {
 	return &storage.Client{Client: e.NodeClient(), StorageName: e.DatastoreID}
+}
+
+// ClusterClient returns a new cluster client for the test environment.
+func (e *Environment) ClusterClient() *cluster.Client {
+	return &cluster.Client{Client: e.Client()}
 }
 
 // testAccMuxProviders returns a map of mux servers for the acceptance tests.


### PR DESCRIPTION
… VM / Container IDs

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Added a new acceptance test specifically for the described use case.

Before the fix:
```
=== RUN   TestIDGenerator_Sequence
=== PAUSE TestIDGenerator_Sequence
=== CONT  TestIDGenerator_Sequence
    provider_test.go:64: 
        	Error Trace:	/Users/pasha/code/terraform-provider-proxmox/fwprovider/provider_test.go:64
        	Error:      	Received unexpected error:
        	            	unable to retrieve the next available VM identifier: All attempts fail:
        	            	#1: error retrieving next VM ID: received an HTTP 400 response - Reason: Parameter verification failed. (vmid: VM 105 already exists)
        	            	#2: error retrieving next VM ID: received an HTTP 400 response - Reason: Parameter verification failed. (vmid: VM 105 already exists)
        	            	#3: error retrieving next VM ID: received an HTTP 400 response - Reason: Parameter verification failed. (vmid: VM 105 already exists)
        	            	#4: error retrieving next VM ID: received an HTTP 400 response - Reason: Parameter verification failed. (vmid: VM 105 already exists)
        	            	#5: error retrieving next VM ID: received an HTTP 400 response - Reason: Parameter verification failed. (vmid: VM 105 already exists)
        	            	#6: error retrieving next VM ID: received an HTTP 400 response - Reason: Parameter verification failed. (vmid: VM 105 already exists)
        	            	#7: error retrieving next VM ID: received an HTTP 400 response - Reason: Parameter verification failed. (vmid: VM 105 already exists)
        	            	#8: error retrieving next VM ID: received an HTTP 400 response - Reason: Parameter verification failed. (vmid: VM 105 already exists)
        	            	#9: error retrieving next VM ID: received an HTTP 400 response - Reason: Parameter verification failed. (vmid: VM 105 already exists)
        	            	#10: error retrieving next VM ID: received an HTTP 400 response - Reason: Parameter verification failed. (vmid: VM 105 already exists)
        	Test:       	TestIDGenerator_Sequence
--- FAIL: TestIDGenerator_Sequence (58.11s)

FAIL
```

After the fix:
```
=== RUN   TestIDGenerator_Sequence
=== PAUSE TestIDGenerator_Sequence
=== CONT  TestIDGenerator_Sequence
--- PASS: TestIDGenerator_Sequence (13.11s)
PASS
```

Plus a test for the random generator to make sure it skips already used IDs. 

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1567

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
