### PR TITLE
fix(vm): do not reboot at disk resize

### DIFF
--- a/proxmox/helpers/ptr/ptr.go
+++ b/proxmox/helpers/ptr/ptr.go
@@ -19,3 +19,16 @@ func Or[T any](p *T, or T) T {
 
 	return or
 }
+
+// Eq compares two pointers and returns true if they are equal.
+func Eq[T comparable](a, b *T) bool {
+	if a == nil && b == nil {
+		return true
+	}
+
+	if a == nil || b == nil {
+		return false
+	}
+
+	return *a == *b
+}

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/ssh"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
@@ -602,7 +603,7 @@ func Update(
 				continue
 			}
 
-			if tmp.AIO != disk.AIO {
+			if !ptr.Eq(tmp.AIO, disk.AIO) {
 				rebootRequired = true
 				tmp.AIO = disk.AIO
 			}

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5523,12 +5523,19 @@ func vmUpdateDiskLocationAndSize(
 					)
 				} else {
 					return diag.Errorf(
-						"Cannot resize %s:%s in VM %d configuration, it is not owned by this VM!",
+						"Cannot resize %s:%s in VM %d, it is not owned by this VM!",
 						*oldDisk.DatastoreID,
 						*oldDisk.PathInDatastore(),
 						vmID,
 					)
 				}
+			} else {
+				return diag.Errorf(
+					"Cannot shrink %s:%s in VM %d, it is not supported!",
+					*oldDisk.DatastoreID,
+					*oldDisk.PathInDatastore(),
+					vmID,
+				)
 			}
 		}
 


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

After the fix, the disk can be increased without restart:
```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.ubuntu_vm will be updated in-place
  ~ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
        id                      = "24044"
        name                    = "test-ubuntu"
        tags                    = []
        # (26 unchanged attributes hidden)

      ~ disk {
          ~ size              = 42 -> 45
            # (12 unchanged attributes hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
proxmox_virtual_environment_vm.ubuntu_vm: Modifying... [id=24044]
proxmox_virtual_environment_vm.ubuntu_vm: Modifications complete after 1s [id=24044]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
No restart in the task log:
<img width="724" alt="Screenshot 2024-10-07 at 8 37 12 PM" src="https://github.com/user-attachments/assets/c39c10fd-8905-4b53-a24b-ed8ce4059b40">


Also, disk shrinking is properly reported as unsupported:
```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.ubuntu_vm will be updated in-place
  ~ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
        id                      = "24044"
        name                    = "test-ubuntu"
        tags                    = []
        # (26 unchanged attributes hidden)

      ~ disk {
          ~ size              = 42 -> 41
            # (12 unchanged attributes hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
proxmox_virtual_environment_vm.ubuntu_vm: Modifying... [id=24044]
╷
│ Error: Cannot shrink local-lvm:vm-24044-disk-0 in VM 24044, it is not supported!
│
│   with proxmox_virtual_environment_vm.ubuntu_vm,
│   on main.tf line 5, in resource "proxmox_virtual_environment_vm" "ubuntu_vm":
│    5: resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
│
╵
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1211
Closes #1560

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
