### PR TITLE
fix(vm): incorrect detection of disk resize

### DIFF
--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5512,30 +5512,32 @@ func vmUpdateDiskLocationAndSize(
 				}
 			}
 
-			if *oldDisk.Size < *diskNewEntries[oldIface].Size {
-				if oldDisk.IsOwnedBy(vmID) {
-					diskResizeBodies = append(
-						diskResizeBodies,
-						&vms.ResizeDiskRequestBody{
-							Disk: oldIface,
-							Size: *diskNewEntries[oldIface].Size,
-						},
-					)
+			if *oldDisk.Size != *diskNewEntries[oldIface].Size {
+				if *oldDisk.Size < *diskNewEntries[oldIface].Size {
+					if oldDisk.IsOwnedBy(vmID) {
+						diskResizeBodies = append(
+							diskResizeBodies,
+							&vms.ResizeDiskRequestBody{
+								Disk: oldIface,
+								Size: *diskNewEntries[oldIface].Size,
+							},
+						)
+					} else {
+						return diag.Errorf(
+							"Cannot resize %s:%s in VM %d, it is not owned by this VM!",
+							*oldDisk.DatastoreID,
+							*oldDisk.PathInDatastore(),
+							vmID,
+						)
+					}
 				} else {
 					return diag.Errorf(
-						"Cannot resize %s:%s in VM %d, it is not owned by this VM!",
+						"Cannot shrink %s:%s in VM %d, it is not supported!",
 						*oldDisk.DatastoreID,
 						*oldDisk.PathInDatastore(),
 						vmID,
 					)
 				}
-			} else {
-				return diag.Errorf(
-					"Cannot shrink %s:%s in VM %d, it is not supported!",
-					*oldDisk.DatastoreID,
-					*oldDisk.PathInDatastore(),
-					vmID,
-				)
 			}
 		}
 


### PR DESCRIPTION
Regression after #1580, the provider incorrectly detects that disk has been resized when other disk attributes change.

Actually, the existing acceptance tests were failing, but that went unnoticed 😞 

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000 | Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
