### PR TITLE
fix(provider): "context deadline exceeded" error when retrieving the next available VM identifier

### DIFF
--- a/fwprovider/provider_test.go
+++ b/fwprovider/provider_test.go
@@ -98,7 +98,7 @@ func TestIDGenerator_Sequence(t *testing.T) {
 			defer wg.Done()
 
 			id, err := gen.NextID(ctx)
-			if err != nil {
+			if err == nil {
 				err = te.NodeClient().VM(0).CreateVM(ctx, &vms.CreateRequestBody{VMID: id})
 				ids[i] = id
 			}

--- a/proxmox/cluster/id_generator.go
+++ b/proxmox/cluster/id_generator.go
@@ -110,10 +110,10 @@ func (g IDGenerator) NextID(ctx context.Context) (int, error) {
 	},
 		retry.OnRetry(func(_ uint, err error) {
 			if strings.Contains(err.Error(), "already exists") && newID != nil {
-				newID = ptr.Ptr(*newID + 1)
-			} else {
-				errs = append(errs, err)
+				newID, err = g.client.GetNextID(ctx, nil)
 			}
+
+			errs = append(errs, err)
 		}),
 		retry.Context(ctx),
 		retry.UntilSucceeded(),


### PR DESCRIPTION
See more details in https://github.com/bpg/terraform-provider-proxmox/issues/1610#issuecomment-2489889683

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Updated the test to verify the use case identified in the issue.
Before the fix:
```
=== RUN   TestIDGenerator_Sequence
=== PAUSE TestIDGenerator_Sequence
=== CONT  TestIDGenerator_Sequence
    provider_test.go:78: 
        	Error Trace:	/Users/pasha/code/terraform-provider-proxmox/fwprovider/provider_test.go:78
        	            				/opt/homebrew/opt/go/libexec/src/runtime/asm_arm64.s:1223
        	Error:      	Received unexpected error:
        	            	unable to retrieve the next available VM identifier: context deadline exceeded
        	Test:       	TestIDGenerator_Sequence
    provider_test.go:78: 
        	Error Trace:	/Users/pasha/code/terraform-provider-proxmox/fwprovider/provider_test.go:78
        	            				/opt/homebrew/opt/go/libexec/src/runtime/asm_arm64.s:1223
        	Error:      	Received unexpected error:
        	            	unable to retrieve the next available VM identifier: error retrieving next VM ID: failed to perform HTTP GET request (path: cluster/nextid?vmid=128) - Reason: context deadline exceeded
        	            	context deadline exceeded
        	Test:       	TestIDGenerator_Sequence
    provider_test.go:78: 
        	Error Trace:	/Users/pasha/code/terraform-provider-proxmox/fwprovider/provider_test.go:78
        	            				/opt/homebrew/opt/go/libexec/src/runtime/asm_arm64.s:1223
        	Error:      	Received unexpected error:
        	            	unable to retrieve the next available VM identifier: context deadline exceeded
        	Test:       	TestIDGenerator_Sequence
    provider_test.go:78: 
        	Error Trace:	/Users/pasha/code/terraform-provider-proxmox/fwprovider/provider_test.go:78
        	            				/opt/homebrew/opt/go/libexec/src/runtime/asm_arm64.s:1223
        	Error:      	Received unexpected error:
        	            	unable to retrieve the next available VM identifier: error retrieving next VM ID: failed to perform HTTP GET request (path: cluster/nextid?vmid=128) - Reason: context deadline exceeded
        	            	context deadline exceeded
        	Test:       	TestIDGenerator_Sequence
    provider_test.go:78: 
        	Error Trace:	/Users/pasha/code/terraform-provider-proxmox/fwprovider/provider_test.go:78
        	            				/opt/homebrew/opt/go/libexec/src/runtime/asm_arm64.s:1223
        	Error:      	Received unexpected error:
        	            	unable to retrieve the next available VM identifier: error retrieving next VM ID: failed to perform HTTP GET request (path: cluster/nextid?vmid=128) - Reason: context deadline exceeded
        	            	context deadline exceeded
        	Test:       	TestIDGenerator_Sequence
    provider_test.go:78: 
        	Error Trace:	/Users/pasha/code/terraform-provider-proxmox/fwprovider/provider_test.go:78
        	            				/opt/homebrew/opt/go/libexec/src/runtime/asm_arm64.s:1223
        	Error:      	Received unexpected error:
        	            	unable to retrieve the next available VM identifier: error retrieving next VM ID: failed to perform HTTP GET request (path: cluster/nextid?vmid=128) - Reason: context deadline exceeded
        	            	context deadline exceeded
        	Test:       	TestIDGenerator_Sequence
--- FAIL: TestIDGenerator_Sequence (74.48s)

FAIL
```

After the fix:
```
=== RUN   TestIDGenerator_Sequence
=== PAUSE TestIDGenerator_Sequence
=== CONT  TestIDGenerator_Sequence
--- PASS: TestIDGenerator_Sequence (8.21s)
PASS
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1610

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced concurrency handling for VM operations, improving efficiency during cleanup and ID generation processes.
	- Improved error handling for ID retrieval, allowing for better management of ID conflicts.

- **Bug Fixes**
	- Refined error accumulation during ID retrieval to ensure all encountered errors are reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->