### PR TITLE
chore(docs): add 'stop_on_destroy' configuration to cloud image examples

### DIFF
--- a/docs/guides/cloud-image.md
+++ b/docs/guides/cloud-image.md
@@ -19,6 +19,9 @@ resource "proxmox_virtual_environment_vm" "centos_vm" {
   name      = "test-centos"
   node_name = "pve"
 
+  # should be true if qemu agent is not installed / enabled on the VM
+  stop_on_destroy = true
+
   initialization {
     user_account {
       # do not use this in production, configure your own ssh key instead!
@@ -52,6 +55,9 @@ Ubuntu cloud images are available at [cloud-images.ubuntu.com](https://cloud-ima
 resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
   name      = "test-ubuntu"
   node_name = "pve"
+
+  # should be true if qemu agent is not installed / enabled on the VM
+  stop_on_destroy = true
 
   initialization {
     user_account {
@@ -89,6 +95,9 @@ If you already have a cloud image on Proxmox, you can use it to create a VM:
 resource "proxmox_virtual_environment_vm" "debian_vm" {
   name      = "test-debian"
   node_name = "pve"
+
+  # should be true if qemu agent is not installed / enabled on the VM
+  stop_on_destroy = true
 
   initialization {
     user_account {

--- a/examples/guides/cloud-image/centos-qcow2/main.tf
+++ b/examples/guides/cloud-image/centos-qcow2/main.tf
@@ -2,6 +2,9 @@ resource "proxmox_virtual_environment_vm" "centos_vm" {
   name      = "test-centos"
   node_name = "pve"
 
+  # should be true if qemu agent is not installed / enabled on the VM
+  stop_on_destroy = true
+
   initialization {
     user_account {
       # do not use this in production, configure your own ssh key instead!

--- a/examples/guides/cloud-image/debian-from-storage/main.tf
+++ b/examples/guides/cloud-image/debian-from-storage/main.tf
@@ -2,6 +2,9 @@ resource "proxmox_virtual_environment_vm" "debian_vm" {
   name      = "test-debian"
   node_name = "pve"
 
+  # should be true if qemu agent is not installed / enabled on the VM
+  stop_on_destroy = true
+
   initialization {
     user_account {
       # do not use this in production, configure your own ssh key instead!

--- a/examples/guides/cloud-image/ubuntu-img/main.tf
+++ b/examples/guides/cloud-image/ubuntu-img/main.tf
@@ -2,6 +2,9 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
   name      = "test-ubuntu"
   node_name = "pve"
 
+  # should be true if qemu agent is not installed / enabled on the VM
+  stop_on_destroy = true
+
   initialization {
     user_account {
       # do not use this in production, configure your own ssh key instead!


### PR DESCRIPTION
Added the 'stop_on_destroy' parameter to the Proxmox VM configurations in the cloud image documentation and example files for CentOS, Ubuntu, and Debian. This parameter should be set to true if the QEMU agent is not installed or enabled on the VM, enhancing clarity for users configuring their virtual machines.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1620

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated cloud image configuration guides for CentOS, Ubuntu, and Debian VMs
  - Added new `stop_on_destroy` configuration option for VM resources

- **New Features**
  - Introduced a new parameter to control VM behavior during destruction
  - Enables more precise VM management when QEMU agent is not installed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->