### PR TITLE
fix(vm): do not delete a VM during retry on `create`

### DIFF
--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -6,12 +6,6 @@
 
 //go:build acceptance || all
 
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
- */
-
 package test
 
 import (
@@ -161,7 +155,7 @@ func TestAccResourceVM(t *testing.T) {
 						architecture = "x86_64"
 					}
 				}`, WithAPIToken()),
-				ExpectError: regexp.MustCompile(`the CPU architecture can only be set by the root account`),
+				ExpectError: regexp.MustCompile(`can only be set by the root account`),
 			},
 				{
 					Config: te.RenderConfig(`


### PR DESCRIPTION
### Contributor's Note

Another attempt to make VM `create` more reliable. The create operation in PVE is not idempotent, but it may fail with a transient error, like `got no worker upid - start worker failed`. 

Remove `delete` from the retry flow, and retry only specific errors. Therefore, next time when we see error like "unable to create VM 100 - VM 100 already exists on node 'pve'", it would actually mean an attempt of "re-writing" an existing VM, not a fluke caused by retry.


Another attempt to make the VM `create` operation more reliable. In PVE, the `create` process isn’t idempotent and can sometimes fail with transient errors, such as `got no worker upid - start worker failed`.

This change removes `delete` from the retry flow and enables retries only for specific errors. As a result, if we encounter an error like "unable to create VM 100 - VM 100 already exists on node 'pve'," it would indicate an actual attempt to "re-write" an existing VM rather than a fluke caused by a retry.

<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

I was able to reliable reproduce this error in acceptance tests after scaling down my test node:
```
    --- FAIL: TestAccResourceVM/single_line_description (13.18s)
        resource_vm_test.go:326: Step 1/1 error: Error running apply: exit status 1
            
            Error: error creating VM: All attempts fail:
            #1: received an HTTP 500 response - Reason: got no worker upid - start worker failed
            #2: received an HTTP 500 response - Reason: unable to create VM 121 - VM 121 already exists on node 'pve'
            #3: received an HTTP 500 response - Reason: unable to create VM 121 - VM 121 already exists on node 'pve'
            
              with proxmox_virtual_environment_vm.test_vm2,
              on terraform_plugin_test.tf line 25, in resource "proxmox_virtual_environment_vm" "test_vm2":
              25:                               resource "proxmox_virtual_environment_vm" "test_vm2" {
```

Not reproducible after the fix. All acceptance tests pass.


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
