### PR TITLE
fix(vm): `vga` block defaults handling during create / clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,6 @@ id_rsa.pub
 # Binary
 terraform-provider-proxmox*
 
-# .vscode
+# VScode / Cursor
 .vscode/settings.json
+.cursorrules

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,11 +2,20 @@
     "version": "0.2.0",
     "configurations": [      
         {
+            "name": "Run Acceptance Tests",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/fwprovider/test",
+            "envFile": "${workspaceFolder}/testacc.env",
+            "args": ["-test.v", "-test.timeout", "120s"]
+        },
+        {
             "name": "Debug Acceptance Tests",
             "type": "go",
             "request": "launch",
             "mode": "test",
-            "program": "${workspaceFolder}/fwprovider/tests",
+            "program": "${workspaceFolder}/fwprovider/test",
             "envFile": "${workspaceFolder}/testacc.env",
             "args": ["-debug", "-test.v", "-test.timeout", "120s"]
             

--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -127,6 +127,14 @@
       ]
     }
   ],
+  "psi-header.lang-config": [
+    {
+      "language": "go",
+      "ignoreLines": [
+        "//go:build"
+      ]
+    }
+  ],
   "makefile.configureOnOpen": false,
   "go.buildFlags": ["-tags=all"],
   "gopls": { "build.buildFlags": ["-tags=all"] }

--- a/fwprovider/nodes/apt/repo_test.go
+++ b/fwprovider/nodes/apt/repo_test.go
@@ -311,7 +311,7 @@ func TestAccResourceStandardRepoValidInput(t *testing.T) {
 					// 	PUT /api2/json/nodes/{node}/apt/repositories with handle = "no-subscription" will create a new
 					// entry in /etc/apt/sources.list on each call :/
 					SkipFunc: func() (bool, error) {
-						return true, fmt.Errorf("skipped due to API limitation: PUT request creates new entry on each call")
+						return true, nil
 					},
 					Config: te.RenderConfig(`
 					resource "proxmox_virtual_environment_apt_standard_repository" "test" {
@@ -337,8 +337,10 @@ func TestAccResourceStandardRepoValidInput(t *testing.T) {
 
 				// Test the "ImportState" implementation.
 				{
+					// 	PUT /api2/json/nodes/{node}/apt/repositories with handle = "no-subscription" will create a new
+					// entry in /etc/apt/sources.list on each call :/
 					SkipFunc: func() (bool, error) {
-						return true, fmt.Errorf("skipped due to API limitation: PUT request creates new entry on each call")
+						return true, nil
 					},
 					ImportState:       true,
 					ImportStateId:     fmt.Sprintf("%s,no-subscription", strings.ToLower(te.NodeName)),

--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -72,48 +72,46 @@ func TestAccResourceVM(t *testing.T) {
 				}),
 			),
 		}}},
-		{
-			"empty node_name", []resource.TestStep{{
+		{"empty node_name", []resource.TestStep{{
 			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_empty_node_name" {
 					node_name = ""
 					started   = false	
 				}`),
 			ExpectError: regexp.MustCompile(`expected "node_name" to not be an empty string, got `),
-		}},
-		},
-		{
-			"protection", []resource.TestStep{{
-			Config: te.RenderConfig(`
+		}}},
+		{"protection", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm4" {
 					node_name = "{{.NodeName}}"
 					started   = false
 					
 					protection = true
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm4", map[string]string{
-					"protection": "true",
-				}),
-			),
-		}, {
-			Config: te.RenderConfig(`
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm4", map[string]string{
+						"protection": "true",
+					}),
+				),
+			}, {
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm4" {
 					node_name = "{{.NodeName}}"
 					started   = false
 					
 					protection = false
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm4", map[string]string{
-					"protection": "false",
-				}),
-			),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm4", map[string]string{
+						"protection": "false",
+					}),
+				),
+			},
 		}},
-		},
-		{
-			"update cpu block", []resource.TestStep{{
-			Config: te.RenderConfig(`
+		{"update cpu block", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm5" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -122,13 +120,13 @@ func TestAccResourceVM(t *testing.T) {
 						cores = 2
 					}
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm5", map[string]string{
-					"cpu.0.sockets": "1",
-				}),
-			),
-		}, {
-			Config: te.RenderConfig(`
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm5", map[string]string{
+						"cpu.0.sockets": "1",
+					}),
+				),
+			}, {
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm5" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -137,16 +135,16 @@ func TestAccResourceVM(t *testing.T) {
 						cores = 1
 					}
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm5", map[string]string{
-					"cpu.0.sockets": "1",
-				}),
-			),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm5", map[string]string{
+						"cpu.0.sockets": "1",
+					}),
+				),
+			},
 		}},
-		},
-		{
-			"set cpu.architecture as non root is not supported", []resource.TestStep{{
-			Config: te.RenderConfig(`
+		{"set cpu.architecture as non root is not supported", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_cpu_arch" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -154,8 +152,8 @@ func TestAccResourceVM(t *testing.T) {
 						architecture = "x86_64"
 					}
 				}`, WithAPIToken()),
-			ExpectError: regexp.MustCompile(`can only be set by the root account`),
-		},
+				ExpectError: regexp.MustCompile(`can only be set by the root account`),
+			},
 			{
 				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "template" {
@@ -166,11 +164,11 @@ func TestAccResourceVM(t *testing.T) {
 					}
 				}`, WithRootUser()),
 				Destroy: false,
-			}},
-		},
-		{
-			"update memory block", []resource.TestStep{{
-			Config: te.RenderConfig(`
+			},
+		}},
+		{"update memory block", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm6" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -179,13 +177,13 @@ func TestAccResourceVM(t *testing.T) {
 						dedicated = 2048
 					}
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm6", map[string]string{
-					"memory.0.dedicated": "2048",
-				}),
-			),
-		}, {
-			Config: te.RenderConfig(`
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm6", map[string]string{
+						"memory.0.dedicated": "2048",
+					}),
+				),
+			}, {
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm6" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -194,27 +192,27 @@ func TestAccResourceVM(t *testing.T) {
 						dedicated = 1024
 					}
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm6", map[string]string{
-					"memory.0.dedicated": "1024",
-				}),
-			),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm6", map[string]string{
+						"memory.0.dedicated": "1024",
+					}),
+				),
+			},
 		}},
-		},
-		{
-			"create vga block", []resource.TestStep{{
-			Config: te.RenderConfig(`
+		{"create vga block", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-					"vga.#": "0",
-				}),
-			),
-		}, {
-			Config: te.RenderConfig(`
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+						"vga.#": "0",
+					}),
+				),
+			}, {
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -223,17 +221,16 @@ func TestAccResourceVM(t *testing.T) {
 						clipboard = "vnc"
 					}
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-					"vga.#": "1",
-				}),
-			),
-		},
-		},
-		},
-		{
-			"update vga block", []resource.TestStep{{
-			Config: te.RenderConfig(`
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+						"vga.#": "1",
+					}),
+				),
+			},
+		}},
+		{"update vga block", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -242,14 +239,14 @@ func TestAccResourceVM(t *testing.T) {
 						type = "none"
 					}
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-					"vga.0.type":      "none",
-					"vga.0.clipboard": "",
-				}),
-			),
-		}, {
-			Config: te.RenderConfig(`
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+						"vga.0.type":      "none",
+						"vga.0.clipboard": "",
+					}),
+				),
+			}, {
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -259,14 +256,14 @@ func TestAccResourceVM(t *testing.T) {
 						clipboard = "vnc"
 					}
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-					"vga.0.type":      "virtio-gl",
-					"vga.0.clipboard": "vnc",
-				}),
-			),
-		}, {
-			Config: te.RenderConfig(`
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+						"vga.0.type":      "virtio-gl",
+						"vga.0.clipboard": "vnc",
+					}),
+				),
+			}, {
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -276,17 +273,17 @@ func TestAccResourceVM(t *testing.T) {
 						clipboard = ""
 					}
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-					"vga.0.type":      "virtio-gl",
-					"vga.0.clipboard": "",
-				}),
-			),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+						"vga.0.type":      "virtio-gl",
+						"vga.0.clipboard": "",
+					}),
+				),
+			},
 		}},
-		},
-		{
-			"update watchdog block", []resource.TestStep{{
-			Config: te.RenderConfig(`
+		{"update watchdog block", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -295,14 +292,14 @@ func TestAccResourceVM(t *testing.T) {
 						enabled = "true"
 					}
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-					"watchdog.0.model":  "i6300esb",
-					"watchdog.0.action": "none",
-				}),
-			),
-		}, {
-			Config: te.RenderConfig(`
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+						"watchdog.0.model":  "i6300esb",
+						"watchdog.0.action": "none",
+					}),
+				),
+			}, {
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -313,14 +310,14 @@ func TestAccResourceVM(t *testing.T) {
 						action  = "reset"
 					}
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-					"watchdog.0.model":  "ib700",
-					"watchdog.0.action": "reset",
-				}),
-			),
-		}, {
-			Config: te.RenderConfig(`
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+						"watchdog.0.model":  "ib700",
+						"watchdog.0.action": "reset",
+					}),
+				),
+			}, {
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -331,15 +328,15 @@ func TestAccResourceVM(t *testing.T) {
 						action  = "reset"
 					}
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-					"watchdog.0.enabled": "false",
-					"watchdog.0.model":   "ib700",
-					"watchdog.0.action":  "reset",
-				}),
-			),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+						"watchdog.0.enabled": "false",
+						"watchdog.0.model":   "ib700",
+						"watchdog.0.action":  "reset",
+					}),
+				),
+			},
 		}},
-		},
 	}
 
 	for _, tt := range tests {
@@ -527,8 +524,9 @@ func TestAccResourceVMNetwork(t *testing.T) {
 				}),
 			),
 		}}},
-		{"network device disconnected", []resource.TestStep{{
-			Config: te.RenderConfig(`
+		{"network device disconnected", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm_network2" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -537,14 +535,14 @@ func TestAccResourceVMNetwork(t *testing.T) {
 						bridge = "vmbr0"
 					}
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm_network2", map[string]string{
-					"network_device.0.bridge":       "vmbr0",
-					"network_device.0.disconnected": "false",
-				}),
-			),
-		}, {
-			Config: te.RenderConfig(`
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm_network2", map[string]string{
+						"network_device.0.bridge":       "vmbr0",
+						"network_device.0.disconnected": "false",
+					}),
+				),
+			}, {
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm_network2" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -554,13 +552,14 @@ func TestAccResourceVMNetwork(t *testing.T) {
 						disconnected = true
 					}
 				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.test_vm_network2", map[string]string{
-					"network_device.0.bridge":       "vmbr0",
-					"network_device.0.disconnected": "true",
-				}),
-			),
-		}}},
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_vm_network2", map[string]string{
+						"network_device.0.bridge":       "vmbr0",
+						"network_device.0.disconnected": "true",
+					}),
+				),
+			},
+		}},
 	}
 
 	for _, tt := range tests {

--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -9,7 +9,6 @@
 package test
 
 import (
-	"math/rand"
 	"regexp"
 	"testing"
 
@@ -75,46 +74,46 @@ func TestAccResourceVM(t *testing.T) {
 		}}},
 		{
 			"empty node_name", []resource.TestStep{{
-				Config: te.RenderConfig(`
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_empty_node_name" {
 					node_name = ""
 					started   = false	
 				}`),
-				ExpectError: regexp.MustCompile(`expected "node_name" to not be an empty string, got `),
-			}},
+			ExpectError: regexp.MustCompile(`expected "node_name" to not be an empty string, got `),
+		}},
 		},
 		{
 			"protection", []resource.TestStep{{
-				Config: te.RenderConfig(`
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm4" {
 					node_name = "{{.NodeName}}"
 					started   = false
 					
 					protection = true
 				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_vm4", map[string]string{
-						"protection": "true",
-					}),
-				),
-			}, {
-				Config: te.RenderConfig(`
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm4", map[string]string{
+					"protection": "true",
+				}),
+			),
+		}, {
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm4" {
 					node_name = "{{.NodeName}}"
 					started   = false
 					
 					protection = false
 				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_vm4", map[string]string{
-						"protection": "false",
-					}),
-				),
-			}},
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm4", map[string]string{
+					"protection": "false",
+				}),
+			),
+		}},
 		},
 		{
 			"update cpu block", []resource.TestStep{{
-				Config: te.RenderConfig(`
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm5" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -123,13 +122,13 @@ func TestAccResourceVM(t *testing.T) {
 						cores = 2
 					}
 				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_vm5", map[string]string{
-						"cpu.0.sockets": "1",
-					}),
-				),
-			}, {
-				Config: te.RenderConfig(`
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm5", map[string]string{
+					"cpu.0.sockets": "1",
+				}),
+			),
+		}, {
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm5" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -138,16 +137,16 @@ func TestAccResourceVM(t *testing.T) {
 						cores = 1
 					}
 				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_vm5", map[string]string{
-						"cpu.0.sockets": "1",
-					}),
-				),
-			}},
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm5", map[string]string{
+					"cpu.0.sockets": "1",
+				}),
+			),
+		}},
 		},
 		{
 			"set cpu.architecture as non root is not supported", []resource.TestStep{{
-				Config: te.RenderConfig(`
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_cpu_arch" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -155,10 +154,10 @@ func TestAccResourceVM(t *testing.T) {
 						architecture = "x86_64"
 					}
 				}`, WithAPIToken()),
-				ExpectError: regexp.MustCompile(`can only be set by the root account`),
-			},
-				{
-					Config: te.RenderConfig(`
+			ExpectError: regexp.MustCompile(`can only be set by the root account`),
+		},
+			{
+				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "template" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -166,12 +165,12 @@ func TestAccResourceVM(t *testing.T) {
 						architecture = "x86_64"
 					}
 				}`, WithRootUser()),
-					Destroy: false,
-				}},
+				Destroy: false,
+			}},
 		},
 		{
 			"update memory block", []resource.TestStep{{
-				Config: te.RenderConfig(`
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm6" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -180,13 +179,13 @@ func TestAccResourceVM(t *testing.T) {
 						dedicated = 2048
 					}
 				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_vm6", map[string]string{
-						"memory.0.dedicated": "2048",
-					}),
-				),
-			}, {
-				Config: te.RenderConfig(`
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm6", map[string]string{
+					"memory.0.dedicated": "2048",
+				}),
+			),
+		}, {
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm6" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -195,16 +194,46 @@ func TestAccResourceVM(t *testing.T) {
 						dedicated = 1024
 					}
 				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_vm6", map[string]string{
-						"memory.0.dedicated": "1024",
-					}),
-				),
-			}},
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm6", map[string]string{
+					"memory.0.dedicated": "1024",
+				}),
+			),
+		}},
+		},
+		{
+			"create vga block", []resource.TestStep{{
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm" {
+					node_name = "{{.NodeName}}"
+					started   = false
+				}`),
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+					"vga.#": "0",
+				}),
+			),
+		}, {
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					vga {
+						type = "virtio-gl"
+						clipboard = "vnc"
+					}
+				}`),
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+					"vga.#": "1",
+				}),
+			),
+		},
+		},
 		},
 		{
 			"update vga block", []resource.TestStep{{
-				Config: te.RenderConfig(`
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -213,14 +242,14 @@ func TestAccResourceVM(t *testing.T) {
 						type = "none"
 					}
 				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-						"vga.0.type":      "none",
-						"vga.0.clipboard": "",
-					}),
-				),
-			}, {
-				Config: te.RenderConfig(`
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+					"vga.0.type":      "none",
+					"vga.0.clipboard": "",
+				}),
+			),
+		}, {
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -230,14 +259,14 @@ func TestAccResourceVM(t *testing.T) {
 						clipboard = "vnc"
 					}
 				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-						"vga.0.type":      "virtio-gl",
-						"vga.0.clipboard": "vnc",
-					}),
-				),
-			}, {
-				Config: te.RenderConfig(`
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+					"vga.0.type":      "virtio-gl",
+					"vga.0.clipboard": "vnc",
+				}),
+			),
+		}, {
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -247,17 +276,17 @@ func TestAccResourceVM(t *testing.T) {
 						clipboard = ""
 					}
 				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-						"vga.0.type":      "virtio-gl",
-						"vga.0.clipboard": "",
-					}),
-				),
-			}},
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+					"vga.0.type":      "virtio-gl",
+					"vga.0.clipboard": "",
+				}),
+			),
+		}},
 		},
 		{
 			"update watchdog block", []resource.TestStep{{
-				Config: te.RenderConfig(`
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -266,14 +295,14 @@ func TestAccResourceVM(t *testing.T) {
 						enabled = "true"
 					}
 				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-						"watchdog.0.model":  "i6300esb",
-						"watchdog.0.action": "none",
-					}),
-				),
-			}, {
-				Config: te.RenderConfig(`
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+					"watchdog.0.model":  "i6300esb",
+					"watchdog.0.action": "none",
+				}),
+			),
+		}, {
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -284,14 +313,14 @@ func TestAccResourceVM(t *testing.T) {
 						action  = "reset"
 					}
 				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-						"watchdog.0.model":  "ib700",
-						"watchdog.0.action": "reset",
-					}),
-				),
-			}, {
-				Config: te.RenderConfig(`
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+					"watchdog.0.model":  "ib700",
+					"watchdog.0.action": "reset",
+				}),
+			),
+		}, {
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
 					node_name = "{{.NodeName}}"
 					started   = false
@@ -302,14 +331,14 @@ func TestAccResourceVM(t *testing.T) {
 						action  = "reset"
 					}
 				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
-						"watchdog.0.enabled": "false",
-						"watchdog.0.model":   "ib700",
-						"watchdog.0.action":  "reset",
-					}),
-				),
-			}},
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
+					"watchdog.0.enabled": "false",
+					"watchdog.0.model":   "ib700",
+					"watchdog.0.action":  "reset",
+				}),
+			),
+		}},
 		},
 	}
 
@@ -552,9 +581,6 @@ func TestAccResourceVMClone(t *testing.T) {
 	}
 
 	te := InitEnvironment(t)
-	te.AddTemplateVars(map[string]interface{}{
-		"TemplateVMID": 100000 + rand.Intn(99999),
-	})
 
 	tests := []struct {
 		name string
@@ -564,8 +590,8 @@ func TestAccResourceVMClone(t *testing.T) {
 			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "template" {
 					node_name = "{{.NodeName}}"
-					vm_id = {{.TemplateVMID}}
 					started   = false
+					template  = true
 					cpu {
 						architecture = "x86_64"
 					}
@@ -577,6 +603,25 @@ func TestAccResourceVMClone(t *testing.T) {
 						vm_id = proxmox_virtual_environment_vm.template.vm_id
 					}
 				}`, WithRootUser()),
+		}}},
+		{"clone no vga block", []resource.TestStep{{
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "template" {
+					node_name = "{{.NodeName}}"
+					started   = false
+				}
+				resource "proxmox_virtual_environment_vm" "clone" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					clone {
+						vm_id = proxmox_virtual_environment_vm.template.vm_id
+					}
+				}`),
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.clone", map[string]string{
+					"vga.#": "0",
+				}),
+			),
 		}}},
 	}
 


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Cloning this simple VM:
<img width="727" alt="Screenshot 2025-01-30 at 9 27 28 PM" src="https://github.com/user-attachments/assets/c0f33106-00c9-4a84-a176-abb6228fb89f" />

Before fix:

```
❯ tofu apply -auto-approve

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.clone will be created
  + resource "proxmox_virtual_environment_vm" "clone" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + clone {
          + full    = true
          + retries = 1
          + vm_id   = 100
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.clone: Creating...
proxmox_virtual_environment_vm.clone: Creation complete after 0s [id=101]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
❯ tofu apply -auto-approve
proxmox_virtual_environment_vm.clone: Refreshing state... [id=101]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.clone will be updated in-place
  ~ resource "proxmox_virtual_environment_vm" "clone" {
        id                      = "101"
        # (26 unchanged attributes hidden)

      - vga {
          - memory = 0 -> null
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
proxmox_virtual_environment_vm.clone: Modifying... [id=101]
proxmox_virtual_environment_vm.clone: Modifications complete after 0s [id=101]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

```

After fix:

```❯ tofu apply -auto-approve

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.clone will be created
  + resource "proxmox_virtual_environment_vm" "clone" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + clone {
          + full    = true
          + retries = 1
          + vm_id   = 100
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.clone: Creating...
proxmox_virtual_environment_vm.clone: Creation complete after 0s [id=101]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
❯ tofu apply -auto-approve
proxmox_virtual_environment_vm.clone: Refreshing state... [id=101]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```



<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1700
Closes #1224

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added new test cases for virtual machine configurations.
  - Enhanced VGA device configuration handling.
  - Introduced a new launch configuration for acceptance tests in VSCode.

- **Bug Fixes**
  - Improved error handling for VM resource attributes.
  - Refined VM resource schema validation.
  - Modified test behavior to allow execution despite API limitations.

- **Chores**
  - Updated VSCode configuration and launch settings.
  - Modified `.gitignore` entries.

- **Tests**
  - Expanded test coverage for VM resource functionality.
  - Added network and initialization test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->