### PR TITLE
fix(lxc): allow container disk size 0 for lxc zfs/brfs subvols

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -127,7 +127,8 @@ output "ubuntu_container_public_key" {
     - `datastore_id` - (Optional) The identifier for the datastore to create the
         disk in (defaults to `local`).
     - `size` - (Optional) The size of the root filesystem in gigabytes (defaults
-        to `4`). Requires `datastore_id` to be set.
+        to `4`). When set to 0 a directory or zfs/btrfs subvolume will be created.
+        Requires `datastore_id` to be set.
 - `initialization` - (Optional) The initialization configuration.
     - `dns` - (Optional) The DNS configuration.
         - `domain` - (Optional) The DNS search domain.

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -342,7 +342,7 @@ func Container() *schema.Resource {
 							Optional:         true,
 							ForceNew:         true,
 							Default:          dvDiskSize,
-							ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
+							ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
 						},
 					},
 				},


### PR DESCRIPTION
### Contributor's Note
The proxmox pct command allows for `disk size = 0`  to create containers backed by ZFS or BTRFS subvolumes. (Note that this is still not allowed by the GUI.) This would allow the provider to use this feature as well.

https://pve.proxmox.com/pve-docs/pct.1.html

    Storage Backed Mount Points

        Directories: passing size=0 triggers a special case where instead of a raw image a directory is created.

- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

### Proof of Work
```
# tofu show
# proxmox_virtual_environment_container.k3s-controller[0]:
resource "proxmox_virtual_environment_container" "k3s-controller" {
    id             = "134"
    node_name      = "pve-host"
    protection     = false
    start_on_boot  = true
    started        = true
    tags           = [
        "k3s-controller",
    ]
    template       = false
    timeout_clone  = 1800
    timeout_create = 1800
    timeout_delete = 60
    timeout_start  = 300
    timeout_update = 1800
    unprivileged   = false
    vm_id          = 134

    cpu {
        architecture = "amd64"
        cores        = 2
        units        = 1024
    }

    disk {
        datastore_id = "local-btrfs"
        size         = 0
    }

    features {
        fuse    = false
        keyctl  = false
        mount   = []
        nesting = true
    }

    initialization {
        hostname = "k3s-controller-01"

        ip_config {
            ipv4 {
                address = "dhcp"
            }
        }

        user_account {
            keys = [
                "<SNIP>",
            ]
        }
    }

    memory {
        dedicated = 4096
        swap      = 0
    }

    network_interface {
        bridge      = "vmbr0"
        enabled     = true
        firewall    = false
        mac_address = "BC:24:11:93:9B:B9"
        mtu         = 0
        name        = "eth0"
        rate_limit  = 0
        vlan_id     = 0
    }

    operating_system {
        template_file_id = "local-btrfs:vztmpl/debian-12-standard_12.7-1_amd64.tar.zst"
        type             = "debian"
    }
}

```

```
pve-host:~# btrfs subvolume list / | grep 134
ID 13885 gen 4345930 top level 256 path var/lib/pve/local-btrfs/images/134/subvol-134-disk-0.subvol
```


### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000 | Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
