### PR TITLE
feat(vm): deprecate `enabled` attribute on `cdrom`/`disk` devices

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -144,7 +144,8 @@ output "ubuntu_vm_public_key" {
     they appear in the list (defaults to `[]`).
 - `cdrom` - (Optional) The CDROM configuration.
     - `enabled` - (Optional) Whether to enable the CDROM drive (defaults
-        to `false`).
+        to `false`). *Deprecated*. The attribute will be removed in the next version of the provider. 
+        Set `file_id` to `none` to leave the CDROM drive empty.
     - `file_id` - (Optional) A file ID for an ISO file (defaults to `cdrom` as
         in the physical drive). Use `none` to leave the CDROM drive empty.
     - `interface` - (Optional) A hardware interface to connect CDROM drive to,

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -142,13 +142,13 @@ output "ubuntu_vm_public_key" {
     - `seabios` - SeaBIOS.
 - `boot_order` - (Optional) Specify a list of devices to boot from in the order
     they appear in the list (defaults to `[]`).
-- `cdrom` - (Optional) The CDROM configuration.
-    - `enabled` - (Optional) Whether to enable the CDROM drive (defaults
-        to `false`). *Deprecated*. The attribute will be removed in the next version of the provider. 
-        Set `file_id` to `none` to leave the CDROM drive empty.
+- `cdrom` - (Optional) The CD-ROM configuration.
+    - `enabled` - (Optional) Whether to enable the CD-ROM drive (defaults
+        to `false`). *Deprecated*. The attribute will be removed in the next version of the provider.
+        Set `file_id` to `none` to leave the CD-ROM drive empty.
     - `file_id` - (Optional) A file ID for an ISO file (defaults to `cdrom` as
-        in the physical drive). Use `none` to leave the CDROM drive empty.
-    - `interface` - (Optional) A hardware interface to connect CDROM drive to,
+        in the physical drive). Use `none` to leave the CD-ROM drive empty.
+    - `interface` - (Optional) A hardware interface to connect CD-ROM drive to,
         must be `ideN` (defaults to `ide3`). Note that `q35` machine type only
         supports `ide0` and `ide2`.
 - `clone` - (Optional) The cloning configuration.

--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -90,7 +90,6 @@ resource "proxmox_virtual_environment_vm" "example_template" {
   name    = "terraform-provider-proxmox-example-template"
 
   cdrom {
-    enabled = true
     file_id = "none"
   }
 

--- a/fwprovider/test/resource_vm_cdrom_test.go
+++ b/fwprovider/test/resource_vm_cdrom_test.go
@@ -23,36 +23,15 @@ func TestAccResourceVMCDROM(t *testing.T) {
 		name  string
 		steps []resource.TestStep
 	}{
-		{"default no cdrom", []resource.TestStep{
-			{
-				Config: te.RenderConfig(`
+		{"default no cdrom", []resource.TestStep{{
+			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_cdrom" {
 					node_name = "{{.NodeName}}"
 					started   = false
 					name 	  = "test-cdrom"
 				}`),
-				Check: NoResourceAttributesSet("proxmox_virtual_environment_vm.test_cdrom", []string{"cdrom.#"}),
-			},
-		}},
-		{"default cdrom", []resource.TestStep{
-			{
-				Config: te.RenderConfig(`
-				resource "proxmox_virtual_environment_vm" "test_cdrom" {
-					node_name = "{{.NodeName}}"
-					started   = false
-					name 	  = "test-cdrom"
-					cdrom {
-						enabled   = true
-					}
-				}`),
-				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom", map[string]string{
-					"cdrom.0.enabled": "true",
-				}),
-			},
-			{
-				RefreshState: true,
-			},
-		}},
+			Check: NoResourceAttributesSet("proxmox_virtual_environment_vm.test_cdrom", []string{"cdrom.#"}),
+		}}},
 		{"none cdrom", []resource.TestStep{
 			{
 				Config: te.RenderConfig(`
@@ -61,17 +40,45 @@ func TestAccResourceVMCDROM(t *testing.T) {
 					started   = false
 					name 	  = "test-cdrom"
 					cdrom {
-						enabled   = true
 						file_id   = "none"
 					}
 				}`),
 				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom", map[string]string{
-					"cdrom.0.enabled": "true",
 					"cdrom.0.file_id": "none",
 				}),
 			},
 			{
 				RefreshState: true,
+			},
+		}},
+		{"enable cdrom", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name 	  = "test-cdrom"
+					cdrom {
+						file_id   = "none"
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom", map[string]string{
+					"cdrom.0.file_id": "none",
+				}),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name 	  = "test-cdrom"
+					cdrom {
+						file_id   = "cdrom"
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom", map[string]string{
+					"cdrom.0.file_id": "cdrom",
+				}),
 			},
 		}},
 	}

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -45,7 +45,6 @@ type CustomStorageDevice struct {
 	Size                    *types.DiskSize   `json:"size,omitempty"        url:"size,omitempty"`
 	SSD                     *types.CustomBool `json:"ssd,omitempty"         url:"ssd,omitempty,int"`
 	DatastoreID             *string           `json:"-"                     url:"-"`
-	Enabled                 bool              `json:"-"                     url:"-"`
 	FileID                  *string           `json:"-"                     url:"-"`
 }
 
@@ -358,8 +357,6 @@ func (d *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 		}
 	}
 
-	d.Enabled = true
-
 	return nil
 }
 
@@ -379,7 +376,8 @@ func (d CustomStorageDevices) Filter(fn func(*CustomStorageDevice) bool) CustomS
 // EncodeValues converts a CustomStorageDevices array to multiple URL values.
 func (d CustomStorageDevices) EncodeValues(_ string, v *url.Values) error {
 	for s, d := range d {
-		if d.Enabled {
+		// Explicitly skip disks which have FileID set, so it won't be encoded in "Create" or "Update" operations.
+		if d.FileID == nil || *d.FileID == "" {
 			if err := d.EncodeValues(s, v); err != nil {
 				return fmt.Errorf("error encoding storage device %s: %w", s, err)
 			}

--- a/proxmox/nodes/vms/custom_storage_device_test.go
+++ b/proxmox/nodes/vms/custom_storage_device_test.go
@@ -32,7 +32,6 @@ func TestCustomStorageDevice_UnmarshalJSON(t *testing.T) {
 			want: &CustomStorageDevice{
 				Cache:      ptr.Ptr("writeback"),
 				Discard:    ptr.Ptr("on"),
-				Enabled:    true,
 				FileVolume: "local-lvm:vm-2041-disk-0",
 				IOThread:   types.CustomBool(true).Pointer(),
 				Size:       ds8gig,
@@ -44,7 +43,6 @@ func TestCustomStorageDevice_UnmarshalJSON(t *testing.T) {
 			line: `"nfs:2041/vm-2041-disk-0.raw,discard=ignore,ssd=1,iothread=1,size=8G"`,
 			want: &CustomStorageDevice{
 				Discard:    ptr.Ptr("ignore"),
-				Enabled:    true,
 				FileVolume: "nfs:2041/vm-2041-disk-0.raw",
 				Format:     ptr.Ptr("raw"),
 				IOThread:   types.CustomBool(true).Pointer(),

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -106,8 +106,6 @@ type CreateRequestBody struct {
 
 // AddCustomStorageDevice adds a custom storage device to the create request body.
 func (b *CreateRequestBody) AddCustomStorageDevice(iface string, device CustomStorageDevice) {
-	device.Enabled = true
-
 	if b.CustomStorageDevices == nil {
 		b.CustomStorageDevices = make(CustomStorageDevices, 1)
 	}

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -162,9 +162,7 @@ func GetDiskDeviceObjects(
 	diskDeviceObjects := vms.CustomStorageDevices{}
 
 	for _, diskEntry := range diskDevices {
-		diskDevice := &vms.CustomStorageDevice{
-			Enabled: true,
-		}
+		diskDevice := &vms.CustomStorageDevice{}
 
 		block := diskEntry.(map[string]interface{})
 		datastoreID, _ := block[mkDiskDatastoreID].(string)
@@ -200,11 +198,6 @@ func GetDiskDeviceObjects(
 
 		if fileFormat == "" {
 			fileFormat = dvDiskFileFormat
-		}
-
-		// Explicitly disable the disk, so it won't be encoded in "Create" or "Update" operations.
-		if fileID != "" {
-			diskDevice.Enabled = false
 		}
 
 		if pathInDatastore != "" {


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

The `enabled` attribute on a disk/CD-ROM is a bit confusing since it doesn’t map to any specific device property in PVE. In PVE, there’s no concept of “enabling” a block device—it either exists or it doesn’t. (There is a concept of "unattached" disks, but that’s outside the scope of this feature.)

Setting `enabled = false` in the configuration essentially means omitting (or removing) the block device from the VM. This creates a challenge when mapping the remote VM state in PVE to the local Terraform state. In PVE, a missing device could mean either it’s not in the config at all or it’s there but marked as disabled, which leads to ambiguity.

Rather than trying to work around this across different scenarios (create, update, clone, update clone, etc.), I decided to remove this attribute altogether since it doesn’t seem to add much practical value to the config.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1672

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the configuration guide for CD-ROM settings with a deprecation notice. Users are now advised to set the `file_id` to "none" when leaving the CD-ROM drive empty.
  
- **Refactor**
	- Streamlined CD-ROM and storage device configurations by removing default enablement, making the system behavior more explicit.
  
- **Tests**
	- Updated and consolidated test cases to ensure alignment with the revised CD-ROM and storage configuration logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->