### PR TITLE
feat(lxc): add container datasource

### DIFF
--- a/docs/data-sources/virtual_environment_container.md
+++ b/docs/data-sources/virtual_environment_container.md
@@ -1,0 +1,31 @@
+---
+layout: page
+title: proxmox_virtual_environment_container
+parent: Data Sources
+subcategory: Virtual Environment
+---
+
+# Data Source: proxmox_virtual_environment_container
+
+Retrieves information about a specific Container.
+
+## Example Usage
+
+```hcl
+data "proxmox_virtual_environment_container" "test_container" {
+    node_name = "test"
+    vm_id = 100
+}
+```
+
+## Argument Reference
+
+- `node_name` - (Required) The node name.
+- `vm_id` - (Required) The container identifier.
+
+## Attribute Reference
+
+- `name` - The container name.
+- `tags` - A list of tags of the container.
+- `status` - Status of the container
+- `template` - Is container a template (true) or a regular container (false)

--- a/example/data_source_virtual_environment_container.tf
+++ b/example/data_source_virtual_environment_container.tf
@@ -1,0 +1,9 @@
+data "proxmox_virtual_environment_container" "example" {
+  depends_on = [proxmox_virtual_environment_container.example]
+  vm_id      = proxmox_virtual_environment_container.example.vm_id
+  node_name  = data.proxmox_virtual_environment_nodes.example.names[0]
+}
+
+output "proxmox_virtual_environment_container_example" {
+  value = data.proxmox_virtual_environment_container.example
+}

--- a/proxmoxtf/datasource/container.go
+++ b/proxmoxtf/datasource/container.go
@@ -1,0 +1,140 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package datasource
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
+	"github.com/bpg/terraform-provider-proxmox/proxmoxtf"
+)
+
+const (
+	mkDataSourceVirtualEnvironmentContainerName     = "name"
+	mkDataSourceVirtualEnvironmentContainerNodeName = "node_name"
+	mkDataSourceVirtualEnvironmentContainerTags     = "tags"
+	mkDataSourceVirtualEnvironmentContainerTemplate = "template"
+	mkDataSourceVirtualEnvironmentContainerStatus   = "status"
+	mkDataSourceVirtualEnvironmentContainerVMID     = "vm_id"
+)
+
+// Container returns a resource for a single Proxmox Container.
+func Container() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			mkDataSourceVirtualEnvironmentContainerName: {
+				Type:        schema.TypeString,
+				Description: "The Container name",
+				Computed:    true,
+			},
+			mkDataSourceVirtualEnvironmentContainerNodeName: {
+				Type:        schema.TypeString,
+				Description: "The node name",
+				Required:    true,
+			},
+			mkDataSourceVirtualEnvironmentContainerTags: {
+				Type:        schema.TypeList,
+				Description: "Tags of the Container",
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			mkDataSourceVirtualEnvironmentContainerTemplate: {
+				Type:        schema.TypeBool,
+				Description: "Is Container a template (true) or a regular Container (false)",
+				Optional:    true,
+			},
+			mkDataSourceVirtualEnvironmentContainerStatus: {
+				Type:        schema.TypeString,
+				Description: "Status of the Container",
+				Optional:    true,
+			},
+			mkDataSourceVirtualEnvironmentContainerVMID: {
+				Type:        schema.TypeInt,
+				Description: "The Container identifier",
+				Required:    true,
+			},
+		},
+		ReadContext: containerRead,
+	}
+}
+
+// containerRead reads the data of a Container by ID.
+func containerRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	config := m.(proxmoxtf.ProviderConfiguration)
+
+	client, err := config.GetClient()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	nodeName := d.Get(mkDataSourceVirtualEnvironmentContainerNodeName).(string)
+	containerID := d.Get(mkDataSourceVirtualEnvironmentContainerVMID).(int)
+
+	containerStatus, err := client.Node(nodeName).Container(containerID).GetContainerStatus(ctx)
+	if err != nil {
+		if errors.Is(err, api.ErrNoDataObjectInResponse) {
+			d.SetId("")
+
+			return nil
+		}
+
+		return diag.FromErr(err)
+	}
+
+	containerConfig, err := client.Node(nodeName).Container(containerID).GetContainer(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if containerStatus.Name != nil {
+		err = d.Set(mkDataSourceVirtualEnvironmentContainerName, *containerStatus.Name)
+	} else {
+		err = d.Set(mkDataSourceVirtualEnvironmentContainerName, "")
+	}
+
+	diags = append(diags, diag.FromErr(err)...)
+
+	var tags []string
+
+	if containerStatus.Tags != nil {
+		for _, tag := range strings.Split(*containerStatus.Tags, ";") {
+			t := strings.TrimSpace(tag)
+			if len(t) > 0 {
+				tags = append(tags, t)
+			}
+		}
+
+		sort.Strings(tags)
+	}
+
+	err = d.Set(mkDataSourceVirtualEnvironmentContainerStatus, containerStatus.Status)
+	diags = append(diags, diag.FromErr(err)...)
+
+	if containerConfig.Template == nil {
+		err = d.Set(mkDataSourceVirtualEnvironmentContainerTemplate, false)
+	} else {
+		err = d.Set(mkDataSourceVirtualEnvironmentContainerTemplate, *containerConfig.Template)
+	}
+
+	diags = append(diags, diag.FromErr(err)...)
+
+	err = d.Set(mkDataSourceVirtualEnvironmentContainerTags, tags)
+	diags = append(diags, diag.FromErr(err)...)
+
+	d.SetId(strconv.Itoa(containerID))
+
+	return diags
+}

--- a/proxmoxtf/datasource/container.go
+++ b/proxmoxtf/datasource/container.go
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+//nolint:dupl
 package datasource
 
 import (

--- a/proxmoxtf/datasource/container_test.go
+++ b/proxmoxtf/datasource/container_test.go
@@ -1,0 +1,47 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package datasource
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/test"
+)
+
+// TestContainerInstantiation tests whether the Container instance can be instantiated.
+func TestContainerInstantiation(t *testing.T) {
+	t.Parallel()
+
+	s := Container()
+
+	if s == nil {
+		t.Fatalf("Cannot instantiate Container")
+	}
+}
+
+// TestContainerSchema tests the Container schema.
+func TestContainerSchema(t *testing.T) {
+	t.Parallel()
+
+	s := Container().Schema
+
+	test.AssertComputedAttributes(t, s, []string{
+		mkDataSourceVirtualEnvironmentContainerName,
+		mkDataSourceVirtualEnvironmentContainerTags,
+	})
+
+	test.AssertValueTypes(t, s, map[string]schema.ValueType{
+		mkDataSourceVirtualEnvironmentContainerName:     schema.TypeString,
+		mkDataSourceVirtualEnvironmentContainerNodeName: schema.TypeString,
+		mkDataSourceVirtualEnvironmentContainerTags:     schema.TypeList,
+		mkDataSourceVirtualEnvironmentContainerTemplate: schema.TypeBool,
+		mkDataSourceVirtualEnvironmentContainerStatus:   schema.TypeString,
+		mkDataSourceVirtualEnvironmentContainerVMID:     schema.TypeInt,
+	})
+}

--- a/proxmoxtf/datasource/vm.go
+++ b/proxmoxtf/datasource/vm.go
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+//nolint:dupl
 package datasource
 
 import (

--- a/proxmoxtf/provider/datasources.go
+++ b/proxmoxtf/provider/datasources.go
@@ -30,5 +30,6 @@ func createDatasourceMap() map[string]*schema.Resource {
 		"proxmox_virtual_environment_users":      datasource.Users(),
 		"proxmox_virtual_environment_vm":         datasource.VM(),
 		"proxmox_virtual_environment_vms":        datasource.VMs(),
+		"proxmox_virtual_environment_container":  datasource.Container(),
 	}
 }


### PR DESCRIPTION
### Contributor's Note

- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

### Proof of Work
```
$ cat datasource.tf 
data "proxmox_virtual_environment_container" "test" {
  vm_id = "133"
  node_name    = "pve-host"
}

output "ip_address" {
  value = data.proxmox_virtual_environment_container.test
}
$ tofu apply
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI configuration:
│  - bpg/proxmox in /home/harm/go/bin
│ 
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
data.proxmox_virtual_environment_container.test: Reading...
data.proxmox_virtual_environment_container.test: Read complete after 0s [id=133]

Changes to Outputs:
  + ip_address = {
      + id        = "133"
      + name      = "k3s-controller-02"
      + node_name = "pve-host"
      + status    = "running"
      + tags      = [
          + "k3s_cluster",
          + "master",
        ]
      + template  = false
      + vm_id     = 133
    }
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #965

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
