### PR TITLE
fix(file): fix for datastore does not support content type "dump"

### DIFF
--- a/docs/resources/virtual_environment_file.md
+++ b/docs/resources/virtual_environment_file.md
@@ -11,7 +11,7 @@ Use this resource to upload files to a Proxmox VE node. The file can be a backup
 
 ## Example Usage
 
-### Backups (`dump`)
+### Backups (`backup`)
 
 -> The resource with this content type uses SSH access to the node. You might need to configure the [`ssh` option in the `provider` section](../index.md#node-ip-address-used-for-ssh-connection).
 
@@ -19,12 +19,12 @@ Use this resource to upload files to a Proxmox VE node. The file can be a backup
 
 ```hcl
 resource "proxmox_virtual_environment_file" "backup" {
-  content_type = "dump"
+  content_type = "backup"
   datastore_id = "local"
   node_name    = "pve"
 
   source_file {
-    path = "vzdump-lxc-100-2023_11_08-23_10_05.tar"
+    path = "vzdump-lxc-100-2023_11_08-23_10_05.tar.zst"
   }
 }
 ```
@@ -123,7 +123,7 @@ resource "proxmox_virtual_environment_file" "ubuntu_container_template" {
 
 - `content_type` - (Optional) The content type. If not specified, the content
     type will be inferred from the file extension. Valid values are:
-    - `dump` (allowed extensions: `.vzdump`)
+    - `backup` (allowed extensions: `.vzdump`, `.tar.gz`, `.tar.xz`, `tar.zst`)
     - `iso` (allowed extensions: `.iso`, `.img`)
     - `snippets` (allowed extensions: any)
     - `vztmpl` (allowed extensions: `.tar.gz`, `.tar.xz`, `tar.zst`)

--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -551,9 +551,6 @@ func fileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 		File:        file,
 		Mode:        fileMode,
 	}
-	if *contentType == "backup" {
-		request.ContentType = "dump"
-	}
 
 	switch *contentType {
 	case "iso", "vztmpl":
@@ -588,6 +585,11 @@ func fileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 					),
 				},
 			}...)
+		}
+
+		// PVE expects backups to be located at the "dump" directory of the datastore.
+		if *contentType == "backup" {
+			request.ContentType = "dump"
 		}
 
 		err = capi.SSH().NodeStreamUpload(ctx, nodeName, *datastore.Path, request)

--- a/proxmoxtf/resource/file.go
+++ b/proxmoxtf/resource/file.go
@@ -551,6 +551,9 @@ func fileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag
 		File:        file,
 		Mode:        fileMode,
 	}
+	if *contentType == "backup" {
+		request.ContentType = "dump"
+	}
 
 	switch *contentType {
 	case "iso", "vztmpl":

--- a/proxmoxtf/resource/validators/file.go
+++ b/proxmoxtf/resource/validators/file.go
@@ -20,7 +20,7 @@ import (
 // ContentType returns a schema validation function for a content type on a storage device.
 func ContentType() schema.SchemaValidateDiagFunc {
 	return validation.ToDiagFunc(validation.StringInSlice([]string{
-		"dump",
+		"backup",
 		"iso",
 		"snippets",
 		"vztmpl",


### PR DESCRIPTION
### Contributor's Note
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
Updated the validation file.go file as mentioned by @bpg at the relevant issue. Additionally, needed to update the contentType FileUploadRequest to keep it from using backup. Proxmox expects backups to be located at the "dump" directory


```hcl
resource "proxmox_virtual_environment_file" "fetch_debian_lxc_template" {
  content_type = "backup"
  datastore_id = "local"
  node_name    = "pve"
  overwrite    = true
 
  source_file {
    path      = "vzdump-lxc-104-2025_02_06-03_17_59.tar.zst"
    file_name = "vzdump-lxc-104.tar.zst"
  }
}
```

```
❯ tofu apply

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_file.fetch_debian_lxc_template will be created
  + resource "proxmox_virtual_environment_file" "fetch_debian_lxc_template" {
      + content_type           = "backup"
      + datastore_id           = "local"
      + file_modification_date = (known after apply)
      + file_name              = (known after apply)
      + file_size              = (known after apply)
      + file_tag               = (known after apply)
      + id                     = (known after apply)
      + node_name              = "pve"
      + overwrite              = true
      + timeout_upload         = 1800

      + source_file {
          + changed   = false
          + file_name = "vzdump-lxc-104.tar.zst"
          + insecure  = false
          + path      = "vzdump-lxc-104-2025_02_06-03_17_59.tar.zst"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

proxmox_virtual_environment_file.fetch_debian_lxc_template: Creating...
proxmox_virtual_environment_file.fetch_debian_lxc_template: Still creating... [10s elapsed]
proxmox_virtual_environment_file.fetch_debian_lxc_template: Still creating... [20s elapsed]
proxmox_virtual_environment_file.fetch_debian_lxc_template: Still creating... [30s elapsed]
proxmox_virtual_environment_file.fetch_debian_lxc_template: Still creating... [40s elapsed]
proxmox_virtual_environment_file.fetch_debian_lxc_template: Still creating... [50s elapsed]
proxmox_virtual_environment_file.fetch_debian_lxc_template: Creation complete after 57s [id=local:backup/vzdump-lxc-104.tar.zst]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.   
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1748

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->