### PR TITLE
misc(provider): add missing acc tests

### DIFF
--- a/fwprovider/provider_test.go
+++ b/fwprovider/provider_test.go
@@ -174,6 +174,15 @@ func TestProviderAuth(t *testing.T) {
 					`,
 			ExpectError: regexp.MustCompile(`must provide either username and password, an API token, or a ticket`),
 		}}},
+		{"invalid api token", []resource.TestStep{{
+			Config: `
+					provider "proxmox" {
+						api_token = "invalid-token"
+					}
+					data "proxmox_virtual_environment_version" "test" {}
+					`,
+			ExpectError: regexp.MustCompile(`the API token must be in the format 'USER@REALM!TOKENID=UUID'`),
+		}}},
 		{"invalid username", []resource.TestStep{{
 			Config: `
 					provider "proxmox" {
@@ -183,6 +192,17 @@ func TestProviderAuth(t *testing.T) {
 					data "proxmox_virtual_environment_version" "test" {}
 					`,
 			ExpectError: regexp.MustCompile(`username must end with '@pve' or '@pam'`),
+		}}},
+		{"missing password", []resource.TestStep{{
+			Config: `
+					provider "proxmox" {
+						api_token              = ""
+						username               = "root@pam"
+						password			   = ""
+					}
+					data "proxmox_virtual_environment_version" "test" {}
+					`,
+			ExpectError: regexp.MustCompile(`must provide either username and password, an API token, or a ticket`),
 		}}},
 	}
 


### PR DESCRIPTION
a follow-up on #1754, a few tests got missed from the PR

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000 | Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes  
  - Enhanced authentication error handling to provide clearer, more descriptive feedback when credentials are missing or formatted incorrectly. Users will now see improved guidance if an API token does not meet the required format or if a necessary password is not provided, ensuring quicker identification and resolution of configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->