### PR TITLE
feat(vm): add optional `reboot_after_update` configuration flag

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -483,7 +483,8 @@ output "ubuntu_vm_public_key" {
         - `wxp` - Windows XP.
 - `pool_id` - (Optional) The identifier for a pool to assign the virtual machine to.
 - `protection` - (Optional) Sets the protection flag of the VM. This will disable the remove VM and remove disk operations (defaults to `false`).
-- `reboot` - (Optional) Reboot the VM after initial creation. (defaults to `false`)
+- `reboot` - (Optional) Reboot the VM after initial creation (defaults to `false`).
+- `reboot_after_update` - (Optional) Reboot the VM after update if needed (defaults to `true`).
 - `rng` - (Optional) The random number generator configuration. Can only be set by `root@pam.`
     - `source` - The file on the host to gather entropy from. In most cases, `/dev/urandom` should be preferred over `/dev/random` to avoid entropy-starvation issues on the host.
     - `max_bytes` - (Optional) Maximum bytes of entropy allowed to get injected into the guest every `period` milliseconds (defaults to `1024`). Prefer a lower value when using `/dev/random` as source.

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5655,8 +5655,8 @@ func vmUpdateDiskLocationAndSize(
 		if !canReboot {
 			return []diag.Diagnostic{{
 				Severity: diag.Warning,
-				Summary: "the VM reboot is required due to the configuration changes, but it is " +
-					"disabled by the configuration. Please reboot the VM manually.",
+				Summary: "a reboot is required to apply configuration changes, but automatic " +
+					"reboots are disabled by 'reboot_after_update = false'. Please reboot the VM manually.",
 			}}
 		}
 

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -42,6 +42,7 @@ import (
 
 const (
 	dvRebootAfterCreation = false
+	dvRebootAfterUpdate   = true
 	dvOnBoot              = true
 	dvACPI                = true
 	dvAgentEnabled        = false
@@ -144,6 +145,7 @@ const (
 	maxResourceVirtualEnvironmentVMNUMADevices = 8
 
 	mkRebootAfterCreation = "reboot"
+	mkRebootAfterUpdate   = "reboot_after_update"
 	mkOnBoot              = "on_boot"
 	mkBootOrder           = "boot_order"
 	mkACPI                = "acpi"
@@ -299,9 +301,15 @@ func VM() *schema.Resource {
 	s := map[string]*schema.Schema{
 		mkRebootAfterCreation: {
 			Type:        schema.TypeBool,
-			Description: "Whether to reboot vm after creation",
+			Description: "Whether to reboot VM after creation",
 			Optional:    true,
 			Default:     dvRebootAfterCreation,
+		},
+		mkRebootAfterUpdate: {
+			Type:        schema.TypeBool,
+			Description: "Whether to reboot VM after update if needed",
+			Optional:    true,
+			Default:     dvRebootAfterUpdate,
 		},
 		mkOnBoot: {
 			Type:        schema.TypeBool,
@@ -5643,6 +5651,16 @@ func vmUpdateDiskLocationAndSize(
 
 	// Perform a regular reboot in case it's necessary and haven't already been done.
 	if reboot {
+
+		canReboot := d.Get(mkRebootAfterUpdate).(bool)
+		if !canReboot {
+			return []diag.Diagnostic{{
+				Severity: diag.Warning,
+				Summary: "the VM reboot is required due to the configuration changes, but it is " +
+					"disabled by the configuration. Please reboot the VM manually.",
+			}}
+		}
+
 		vmStatus, err := vmAPI.GetVMStatus(ctx)
 		if err != nil {
 			return diag.FromErr(err)

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5651,7 +5651,6 @@ func vmUpdateDiskLocationAndSize(
 
 	// Perform a regular reboot in case it's necessary and haven't already been done.
 	if reboot {
-
 		canReboot := d.Get(mkRebootAfterUpdate).(bool)
 		if !canReboot {
 			return []diag.Diagnostic{{


### PR DESCRIPTION
- Add `reboot_after_update` parameter to VM resource
- Update documentation to reflect new configuration option
- Implement logic to control VM reboot after configuration changes
- Provide warning if reboot is required but disabled by configuration

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Create a VM, for example, from https://registry.terraform.io/providers/bpg/proxmox/latest/docs/guides/cloud-image

Then, add to the VM config
```hcl
  reboot_after_update = false
  vga {
    type = "virtio"
  }
```
And `tofu apply`
```
> tofu apply -auto-approve

data.local_file.ssh_public_key: Reading...
data.local_file.ssh_public_key: Read complete after 0s [id=84cdc3a1d1eaa8e821cd6dd4287f04ae996b8309]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Refreshing state... [id=local:iso/jammy-server-cloudimg-amd64.img]
proxmox_virtual_environment_vm.ubuntu_vm: Refreshing state... [id=100]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.ubuntu_vm will be updated in-place
  ~ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
        id                      = "100"
        name                    = "test-ubuntu"
      ~ reboot_after_update     = true -> false
        tags                    = []
        # (26 unchanged attributes hidden)

      + vga {
          + memory = 16
          + type   = "virtio"
        }

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
proxmox_virtual_environment_vm.ubuntu_vm: Modifying... [id=100]
proxmox_virtual_environment_vm.ubuntu_vm: Modifications complete after 1s [id=100]
╷
│ Warning: the VM reboot is required due to the configuration changes, but it is disabled by the configuration. Please reboot the VM manually.
│ 
│   with proxmox_virtual_environment_vm.ubuntu_vm,
│   on main.tf line 5, in resource "proxmox_virtual_environment_vm" "ubuntu_vm":
│    5: resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
│ 
╵

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

Configuration change is saved, but not applied, pending the VM restart:

<img width="1005" alt="Screenshot 2025-02-17 at 11 05 24 AM" src="https://github.com/user-attachments/assets/cb56be5d-466a-4c2e-abf1-ba0588b4132a" />

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1467

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional setting to automatically reboot virtual machines after updates (default enabled).
	- Enhanced the reboot configuration with clearer default behaviors and warnings when reboot conditions are not met.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->