### PR TITLE
fix(vm): fix and improve disk management for cloned VMs

### DIFF
--- a/example/variables.tf
+++ b/example/variables.tf
@@ -28,5 +28,5 @@ variable "release_20240725_ubuntu_24_noble_lxc_img_url" {
 variable "release_20240725_ubuntu_24_noble_lxc_img_checksum" {
   type        = string
   description = "The checksum for the Ubuntu 24.04 LXC image"
-  default     = "10331782a01cd2348b421a261f0e15ba041358bd540f66f2432b162e70b90d28"
+  default     = "d767d38cb25b2c25d84edc31a80dd1c29a8c922b74188b0e14768b2b2fb6df8e"
 }

--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -9,6 +9,7 @@
 package test
 
 import (
+	"math/rand"
 	"regexp"
 	"testing"
 
@@ -638,6 +639,9 @@ func TestAccResourceVMClone(t *testing.T) {
 	}
 
 	te := InitEnvironment(t)
+	te.AddTemplateVars(map[string]interface{}{
+		"TemplateVMID": 100000 + rand.Intn(99999),
+	})
 
 	tests := []struct {
 		name string
@@ -695,14 +699,58 @@ func TestAccResourceVMClone(t *testing.T) {
 					initialization {
 						datastore_id = "doesnotexist"
 						ip_config {
-						  ipv4 {
-							address = "172.16.2.57/32"
-							gateway = "172.16.2.10"
-						  }
+							ipv4 {
+								address = "172.16.2.57/32"
+								gateway = "172.16.2.10"
+							}
 						}
 					}
 				}`),
 			ExpectError: regexp.MustCompile(`storage 'doesnotexist' does not exist`),
+		}}},
+		{"update disk speed and resize in a clone", []resource.TestStep{{
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "template" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "virtio0"
+						file_format  = "raw"
+						size         = 20
+					}
+				}
+				resource "proxmox_virtual_environment_vm" "clone" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					clone {
+						vm_id = proxmox_virtual_environment_vm.template.vm_id
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "virtio0"
+						iothread     = true
+						discard      = "on"
+						size         = 30
+						speed {
+						  iops_read = 100
+						  iops_read_burstable = 1000
+						  iops_write = 400
+						  iops_write_burstable = 800
+						}
+					}
+				}`),
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.clone", map[string]string{
+					"disk.0.iothread":                     "true",
+					"disk.0.discard":                      "on",
+					"disk.0.size":                         "30",
+					"disk.0.speed.0.iops_read":            "100",
+					"disk.0.speed.0.iops_read_burstable":  "1000",
+					"disk.0.speed.0.iops_write":           "400",
+					"disk.0.speed.0.iops_write_burstable": "800",
+				}),
+			),
 		}}},
 	}
 

--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -9,7 +9,6 @@
 package test
 
 import (
-	"math/rand"
 	"regexp"
 	"testing"
 
@@ -639,9 +638,6 @@ func TestAccResourceVMClone(t *testing.T) {
 	}
 
 	te := InitEnvironment(t)
-	te.AddTemplateVars(map[string]interface{}{
-		"TemplateVMID": 100000 + rand.Intn(99999),
-	})
 
 	tests := []struct {
 		name string

--- a/fwprovider/vm/resource.go
+++ b/fwprovider/vm/resource.go
@@ -378,7 +378,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		resp.Diagnostics.AddError("Failed to get VM status", err.Error())
 	}
 
-	if resp.Diagnostics.HasError() {
+	if resp.Diagnostics.HasError() || status == nil {
 		return
 	}
 

--- a/proxmox/helpers/ptr/ptr.go
+++ b/proxmox/helpers/ptr/ptr.go
@@ -32,3 +32,14 @@ func Eq[T comparable](a, b *T) bool {
 
 	return *a == *b
 }
+
+// UpdateIfChanged updates dst with src if src is not nil and different from dst.
+// Returns true if an update was made.
+func UpdateIfChanged[T comparable](dst **T, src *T) bool {
+	if src != nil && !Eq(*dst, src) {
+		*dst = src
+		return true
+	}
+
+	return false
+}

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -373,82 +373,84 @@ func (d *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 func (d *CustomStorageDevice) MergeWith(m CustomStorageDevice) bool {
 	updated := false
 
-	if m.AIO != nil && m.AIO != d.AIO {
+	if m.AIO != nil && (d.AIO == nil || *m.AIO != *d.AIO) {
 		d.AIO = m.AIO
 		updated = true
 	}
 
-	if m.Backup != nil && m.Backup != d.Backup {
+	if m.Backup != nil && (d.Backup == nil || *m.Backup != *d.Backup) {
 		d.Backup = m.Backup
 		updated = true
 	}
 
-	if m.Cache != nil && m.Cache != d.Cache {
+	if m.Cache != nil && (d.Cache == nil || *m.Cache != *d.Cache) {
 		d.Cache = m.Cache
 		updated = true
 	}
 
-	if m.Discard != nil && m.Discard != d.Discard {
+	if m.Discard != nil && (d.Discard == nil || *m.Discard != *d.Discard) {
 		d.Discard = m.Discard
 		updated = true
 	}
 
-	if m.IOThread != nil && m.IOThread != d.IOThread {
+	if m.IOThread != nil && (d.IOThread == nil || *m.IOThread != *d.IOThread) {
 		d.IOThread = m.IOThread
 		updated = true
 	}
 
-	if m.Replicate != nil && m.Replicate != d.Replicate {
+	if m.Replicate != nil && (d.Replicate == nil || *m.Replicate != *d.Replicate) {
 		d.Replicate = m.Replicate
 		updated = true
 	}
 
-	if m.Serial != nil && m.Serial != d.Serial {
+	if m.Serial != nil && (d.Serial == nil || *m.Serial != *d.Serial) {
 		d.Serial = m.Serial
 		updated = true
 	}
 
-	if m.SSD != nil && m.SSD != d.SSD {
+	if m.SSD != nil && (d.SSD == nil || *m.SSD != *d.SSD) {
 		d.SSD = m.SSD
 		updated = true
 	}
 
-	if m.IopsRead != nil && m.IopsRead != d.IopsRead {
+	if m.IopsRead != nil && (d.IopsRead == nil || *m.IopsRead != *d.IopsRead) {
 		d.IopsRead = m.IopsRead
 		updated = true
 	}
 
-	if m.MaxIopsRead != nil && m.MaxIopsRead != d.MaxIopsRead {
+	if m.MaxIopsRead != nil && (d.MaxIopsRead == nil || *m.MaxIopsRead != *d.MaxIopsRead) {
 		d.MaxIopsRead = m.MaxIopsRead
 		updated = true
 	}
 
-	if m.IopsWrite != nil && m.IopsWrite != d.IopsWrite {
+	if m.IopsWrite != nil && (d.IopsWrite == nil || *m.IopsWrite != *d.IopsWrite) {
 		d.IopsWrite = m.IopsWrite
 		updated = true
 	}
 
-	if m.MaxIopsWrite != nil && m.MaxIopsWrite != d.MaxIopsWrite {
+	if m.MaxIopsWrite != nil && (d.MaxIopsWrite == nil || *m.MaxIopsWrite != *d.MaxIopsWrite) {
 		d.MaxIopsWrite = m.MaxIopsWrite
 		updated = true
 	}
 
-	if m.MaxReadSpeedMbps != nil && m.MaxReadSpeedMbps != d.MaxReadSpeedMbps {
+	if m.MaxReadSpeedMbps != nil && (d.MaxReadSpeedMbps == nil || *m.MaxReadSpeedMbps != *d.MaxReadSpeedMbps) {
 		d.MaxReadSpeedMbps = m.MaxReadSpeedMbps
 		updated = true
 	}
 
-	if m.MaxWriteSpeedMbps != nil && m.MaxWriteSpeedMbps != d.MaxWriteSpeedMbps {
+	if m.MaxWriteSpeedMbps != nil && (d.MaxWriteSpeedMbps == nil || *m.MaxWriteSpeedMbps != *d.MaxWriteSpeedMbps) {
 		d.MaxWriteSpeedMbps = m.MaxWriteSpeedMbps
 		updated = true
 	}
 
-	if m.BurstableReadSpeedMbps != nil && m.BurstableReadSpeedMbps != d.BurstableReadSpeedMbps {
+	if m.BurstableReadSpeedMbps != nil &&
+		(d.BurstableReadSpeedMbps == nil || *m.BurstableReadSpeedMbps != *d.BurstableReadSpeedMbps) {
 		d.BurstableReadSpeedMbps = m.BurstableReadSpeedMbps
 		updated = true
 	}
 
-	if m.BurstableWriteSpeedMbps != nil && m.BurstableWriteSpeedMbps != d.BurstableWriteSpeedMbps {
+	if m.BurstableWriteSpeedMbps != nil &&
+		(d.BurstableWriteSpeedMbps == nil || *m.BurstableWriteSpeedMbps != *d.BurstableWriteSpeedMbps) {
 		d.BurstableWriteSpeedMbps = m.BurstableWriteSpeedMbps
 		updated = true
 	}

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -363,11 +363,13 @@ func (d *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 // MergeWith merges attributes of the given CustomStorageDevice with the current one.
 // It will overwrite the current attributes with the given ones if they are not nil.
 // The attributes that are not merged are:
-// - DatastoreID
-// - FileID
-// - FileVolume
-// - Format
-// - Size
+//   - DatastoreID
+//   - FileID
+//   - FileVolume
+//   - Format
+//   - Size
+//
+// It will return true if any attribute of the current CustomStorageDevice was changed.
 func (d *CustomStorageDevice) MergeWith(m CustomStorageDevice) bool {
 	updated := false
 

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 )
 
@@ -373,87 +374,22 @@ func (d *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 func (d *CustomStorageDevice) MergeWith(m CustomStorageDevice) bool {
 	updated := false
 
-	if m.AIO != nil && (d.AIO == nil || *m.AIO != *d.AIO) {
-		d.AIO = m.AIO
-		updated = true
-	}
-
-	if m.Backup != nil && (d.Backup == nil || *m.Backup != *d.Backup) {
-		d.Backup = m.Backup
-		updated = true
-	}
-
-	if m.Cache != nil && (d.Cache == nil || *m.Cache != *d.Cache) {
-		d.Cache = m.Cache
-		updated = true
-	}
-
-	if m.Discard != nil && (d.Discard == nil || *m.Discard != *d.Discard) {
-		d.Discard = m.Discard
-		updated = true
-	}
-
-	if m.IOThread != nil && (d.IOThread == nil || *m.IOThread != *d.IOThread) {
-		d.IOThread = m.IOThread
-		updated = true
-	}
-
-	if m.Replicate != nil && (d.Replicate == nil || *m.Replicate != *d.Replicate) {
-		d.Replicate = m.Replicate
-		updated = true
-	}
-
-	if m.Serial != nil && (d.Serial == nil || *m.Serial != *d.Serial) {
-		d.Serial = m.Serial
-		updated = true
-	}
-
-	if m.SSD != nil && (d.SSD == nil || *m.SSD != *d.SSD) {
-		d.SSD = m.SSD
-		updated = true
-	}
-
-	if m.IopsRead != nil && (d.IopsRead == nil || *m.IopsRead != *d.IopsRead) {
-		d.IopsRead = m.IopsRead
-		updated = true
-	}
-
-	if m.MaxIopsRead != nil && (d.MaxIopsRead == nil || *m.MaxIopsRead != *d.MaxIopsRead) {
-		d.MaxIopsRead = m.MaxIopsRead
-		updated = true
-	}
-
-	if m.IopsWrite != nil && (d.IopsWrite == nil || *m.IopsWrite != *d.IopsWrite) {
-		d.IopsWrite = m.IopsWrite
-		updated = true
-	}
-
-	if m.MaxIopsWrite != nil && (d.MaxIopsWrite == nil || *m.MaxIopsWrite != *d.MaxIopsWrite) {
-		d.MaxIopsWrite = m.MaxIopsWrite
-		updated = true
-	}
-
-	if m.MaxReadSpeedMbps != nil && (d.MaxReadSpeedMbps == nil || *m.MaxReadSpeedMbps != *d.MaxReadSpeedMbps) {
-		d.MaxReadSpeedMbps = m.MaxReadSpeedMbps
-		updated = true
-	}
-
-	if m.MaxWriteSpeedMbps != nil && (d.MaxWriteSpeedMbps == nil || *m.MaxWriteSpeedMbps != *d.MaxWriteSpeedMbps) {
-		d.MaxWriteSpeedMbps = m.MaxWriteSpeedMbps
-		updated = true
-	}
-
-	if m.BurstableReadSpeedMbps != nil &&
-		(d.BurstableReadSpeedMbps == nil || *m.BurstableReadSpeedMbps != *d.BurstableReadSpeedMbps) {
-		d.BurstableReadSpeedMbps = m.BurstableReadSpeedMbps
-		updated = true
-	}
-
-	if m.BurstableWriteSpeedMbps != nil &&
-		(d.BurstableWriteSpeedMbps == nil || *m.BurstableWriteSpeedMbps != *d.BurstableWriteSpeedMbps) {
-		d.BurstableWriteSpeedMbps = m.BurstableWriteSpeedMbps
-		updated = true
-	}
+	updated = ptr.UpdateIfChanged(&d.AIO, m.AIO) || updated
+	updated = ptr.UpdateIfChanged(&d.Backup, m.Backup) || updated
+	updated = ptr.UpdateIfChanged(&d.Cache, m.Cache) || updated
+	updated = ptr.UpdateIfChanged(&d.Discard, m.Discard) || updated
+	updated = ptr.UpdateIfChanged(&d.IOThread, m.IOThread) || updated
+	updated = ptr.UpdateIfChanged(&d.Replicate, m.Replicate) || updated
+	updated = ptr.UpdateIfChanged(&d.Serial, m.Serial) || updated
+	updated = ptr.UpdateIfChanged(&d.SSD, m.SSD) || updated
+	updated = ptr.UpdateIfChanged(&d.IopsRead, m.IopsRead) || updated
+	updated = ptr.UpdateIfChanged(&d.MaxIopsRead, m.MaxIopsRead) || updated
+	updated = ptr.UpdateIfChanged(&d.IopsWrite, m.IopsWrite) || updated
+	updated = ptr.UpdateIfChanged(&d.MaxIopsWrite, m.MaxIopsWrite) || updated
+	updated = ptr.UpdateIfChanged(&d.MaxReadSpeedMbps, m.MaxReadSpeedMbps) || updated
+	updated = ptr.UpdateIfChanged(&d.MaxWriteSpeedMbps, m.MaxWriteSpeedMbps) || updated
+	updated = ptr.UpdateIfChanged(&d.BurstableReadSpeedMbps, m.BurstableReadSpeedMbps) || updated
+	updated = ptr.UpdateIfChanged(&d.BurstableWriteSpeedMbps, m.BurstableWriteSpeedMbps) || updated
 
 	return updated
 }

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -376,20 +376,21 @@ func (d *CustomStorageDevice) MergeWith(m CustomStorageDevice) bool {
 
 	updated = ptr.UpdateIfChanged(&d.AIO, m.AIO) || updated
 	updated = ptr.UpdateIfChanged(&d.Backup, m.Backup) || updated
+	updated = ptr.UpdateIfChanged(&d.BurstableReadSpeedMbps, m.BurstableReadSpeedMbps) || updated
+	updated = ptr.UpdateIfChanged(&d.BurstableWriteSpeedMbps, m.BurstableWriteSpeedMbps) || updated
 	updated = ptr.UpdateIfChanged(&d.Cache, m.Cache) || updated
 	updated = ptr.UpdateIfChanged(&d.Discard, m.Discard) || updated
 	updated = ptr.UpdateIfChanged(&d.IOThread, m.IOThread) || updated
-	updated = ptr.UpdateIfChanged(&d.Replicate, m.Replicate) || updated
-	updated = ptr.UpdateIfChanged(&d.Serial, m.Serial) || updated
-	updated = ptr.UpdateIfChanged(&d.SSD, m.SSD) || updated
 	updated = ptr.UpdateIfChanged(&d.IopsRead, m.IopsRead) || updated
-	updated = ptr.UpdateIfChanged(&d.MaxIopsRead, m.MaxIopsRead) || updated
 	updated = ptr.UpdateIfChanged(&d.IopsWrite, m.IopsWrite) || updated
+	updated = ptr.UpdateIfChanged(&d.Media, m.Media) || updated
+	updated = ptr.UpdateIfChanged(&d.MaxIopsRead, m.MaxIopsRead) || updated
 	updated = ptr.UpdateIfChanged(&d.MaxIopsWrite, m.MaxIopsWrite) || updated
 	updated = ptr.UpdateIfChanged(&d.MaxReadSpeedMbps, m.MaxReadSpeedMbps) || updated
 	updated = ptr.UpdateIfChanged(&d.MaxWriteSpeedMbps, m.MaxWriteSpeedMbps) || updated
-	updated = ptr.UpdateIfChanged(&d.BurstableReadSpeedMbps, m.BurstableReadSpeedMbps) || updated
-	updated = ptr.UpdateIfChanged(&d.BurstableWriteSpeedMbps, m.BurstableWriteSpeedMbps) || updated
+	updated = ptr.UpdateIfChanged(&d.Replicate, m.Replicate) || updated
+	updated = ptr.UpdateIfChanged(&d.SSD, m.SSD) || updated
+	updated = ptr.UpdateIfChanged(&d.Serial, m.Serial) || updated
 
 	return updated
 }

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -360,6 +360,100 @@ func (d *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MergeWith merges attributes of the given CustomStorageDevice with the current one.
+// It will overwrite the current attributes with the given ones if they are not nil.
+// The attributes that are not merged are:
+// - DatastoreID
+// - FileID
+// - FileVolume
+// - Format
+// - Size
+func (d *CustomStorageDevice) MergeWith(m CustomStorageDevice) bool {
+	updated := false
+
+	if m.AIO != nil && m.AIO != d.AIO {
+		d.AIO = m.AIO
+		updated = true
+	}
+
+	if m.Backup != nil && m.Backup != d.Backup {
+		d.Backup = m.Backup
+		updated = true
+	}
+
+	if m.Cache != nil && m.Cache != d.Cache {
+		d.Cache = m.Cache
+		updated = true
+	}
+
+	if m.Discard != nil && m.Discard != d.Discard {
+		d.Discard = m.Discard
+		updated = true
+	}
+
+	if m.IOThread != nil && m.IOThread != d.IOThread {
+		d.IOThread = m.IOThread
+		updated = true
+	}
+
+	if m.Replicate != nil && m.Replicate != d.Replicate {
+		d.Replicate = m.Replicate
+		updated = true
+	}
+
+	if m.Serial != nil && m.Serial != d.Serial {
+		d.Serial = m.Serial
+		updated = true
+	}
+
+	if m.SSD != nil && m.SSD != d.SSD {
+		d.SSD = m.SSD
+		updated = true
+	}
+
+	if m.IopsRead != nil && m.IopsRead != d.IopsRead {
+		d.IopsRead = m.IopsRead
+		updated = true
+	}
+
+	if m.MaxIopsRead != nil && m.MaxIopsRead != d.MaxIopsRead {
+		d.MaxIopsRead = m.MaxIopsRead
+		updated = true
+	}
+
+	if m.IopsWrite != nil && m.IopsWrite != d.IopsWrite {
+		d.IopsWrite = m.IopsWrite
+		updated = true
+	}
+
+	if m.MaxIopsWrite != nil && m.MaxIopsWrite != d.MaxIopsWrite {
+		d.MaxIopsWrite = m.MaxIopsWrite
+		updated = true
+	}
+
+	if m.MaxReadSpeedMbps != nil && m.MaxReadSpeedMbps != d.MaxReadSpeedMbps {
+		d.MaxReadSpeedMbps = m.MaxReadSpeedMbps
+		updated = true
+	}
+
+	if m.MaxWriteSpeedMbps != nil && m.MaxWriteSpeedMbps != d.MaxWriteSpeedMbps {
+		d.MaxWriteSpeedMbps = m.MaxWriteSpeedMbps
+		updated = true
+	}
+
+	if m.BurstableReadSpeedMbps != nil && m.BurstableReadSpeedMbps != d.BurstableReadSpeedMbps {
+		d.BurstableReadSpeedMbps = m.BurstableReadSpeedMbps
+		updated = true
+	}
+
+	if m.BurstableWriteSpeedMbps != nil && m.BurstableWriteSpeedMbps != d.BurstableWriteSpeedMbps {
+		d.BurstableWriteSpeedMbps = m.BurstableWriteSpeedMbps
+		updated = true
+	}
+
+	return updated
+}
+
 // Filter returns a map of CustomStorageDevices filtered by the given function.
 func (d CustomStorageDevices) Filter(fn func(*CustomStorageDevice) bool) CustomStorageDevices {
 	result := make(CustomStorageDevices)

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -2212,14 +2212,14 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		return diag.FromErr(e)
 	}
 
-	allDiskInfo := disk.GetInfo(vmConfig, d) // from the cloned VM
+	clonedDiskInfo := disk.GetInfo(vmConfig, d) // from the cloned VM
 
 	planDisks, e := disk.GetDiskDeviceObjects(d, VM(), nil) // from the resource config
 	if e != nil {
 		return diag.FromErr(e)
 	}
 
-	e = disk.CreateClone(ctx, d, planDisks, allDiskInfo, vmAPI)
+	e = disk.UpdateClone(ctx, planDisks, clonedDiskInfo, vmAPI)
 	if e != nil {
 		return diag.FromErr(e)
 	}
@@ -2268,8 +2268,8 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		if dataStoreID != "" {
 			moveDisk = true
 
-			if allDiskInfo[diskInterface] != nil {
-				fileIDParts := strings.Split(allDiskInfo[diskInterface].FileVolume, ":")
+			if clonedDiskInfo[diskInterface] != nil {
+				fileIDParts := strings.Split(clonedDiskInfo[diskInterface].FileVolume, ":")
 				moveDisk = dataStoreID != fileIDParts[0]
 			}
 		}
@@ -2319,8 +2319,8 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		if dataStoreID != "" {
 			moveDisk = true
 
-			if allDiskInfo[diskInterface] != nil {
-				fileIDParts := strings.Split(allDiskInfo[diskInterface].FileVolume, ":")
+			if clonedDiskInfo[diskInterface] != nil {
+				fileIDParts := strings.Split(clonedDiskInfo[diskInterface].FileVolume, ":")
 				moveDisk = dataStoreID != fileIDParts[0]
 			}
 		}


### PR DESCRIPTION
Allow setting disk speed and updating other attributes of existing disks when cloning a VM.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

```hcl
resource "proxmox_virtual_environment_vm" "template" {
  node_name = "pve"
  started   = false
  disk {
    datastore_id = "local-lvm"
    interface    = "virtio0"
    file_format  = "raw"
    size         = 20
  }
}

resource "proxmox_virtual_environment_vm" "clone" {
  node_name = "pve"
  started   = false
  clone {
    vm_id = proxmox_virtual_environment_vm.template.vm_id
  }
  disk {
    datastore_id = "local-lvm"
    interface    = "virtio0"
    iothread     = true
    discard      = "on"
    size         = 30
    speed {
      iops_read = 100
      iops_read_burstable = 1000
      iops_write = 400
      iops_write_burstable = 800
    }
  }
}
```

```
❯ tofu apply -auto-approve
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.clone will be created
  + resource "proxmox_virtual_environment_vm" "clone" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + clone {
          + full    = true
          + retries = 1
          + vm_id   = (known after apply)
        }

      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "on"
          + file_format       = (known after apply)
          + interface         = "virtio0"
          + iothread          = true
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 30
          + ssd               = false

          + speed {
              + iops_read            = 100
              + iops_read_burstable  = 1000
              + iops_write           = 400
              + iops_write_burstable = 800
              + read                 = 0
              + read_burstable       = 0
              + write                = 0
              + write_burstable      = 0
            }
        }
    }

  # proxmox_virtual_environment_vm.template will be created
  + resource "proxmox_virtual_environment_vm" "template" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "ignore"
          + file_format       = "raw"
          + interface         = "virtio0"
          + iothread          = false
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 20
          + ssd               = false
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.template: Creating...
proxmox_virtual_environment_vm.template: Creation complete after 1s [id=100]
proxmox_virtual_environment_vm.clone: Creating...
proxmox_virtual_environment_vm.clone: Creation complete after 7s [id=102]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

Second apply of the same config does not show any pending changes:
```
❯ tofu apply -auto-approve
proxmox_virtual_environment_vm.template: Refreshing state... [id=100]
proxmox_virtual_environment_vm.clone: Refreshing state... [id=102]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1829
Closes #1771
Closes #360
Closes #873

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated a configuration value for verifying VM image integrity.

- **Bug Fixes**
  - Strengthened error handling during VM deletion to avoid processing when critical status information is missing.

- **New Features**
  - Enhanced the VM cloning process with improved disk resizing and disk speed adjustments for a more robust and reliable cloning experience.
  - Introduced a method for merging attributes in custom storage devices, allowing for more flexible configuration updates.
  - Added a new function to update pointer values only when changes occur, enhancing data management efficiency.
  - Renamed and streamlined the process for updating disks in cloned VMs for better clarity and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->