### PR TITLE
fix(vm): handle update of disks moved during VM clone

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -43,4 +43,5 @@ jobs:
         uses: golangci/golangci-lint-action@v7
         with: 
           version: v2.0.2 # renovate: depName=golangci/golangci-lint datasource=github-releases
+          skip-cache: true
           args: -v --timeout=10m

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,8 @@ testacc:
 .PHONY: lint
 lint:
 	# NOTE: This target is for local runs only. For linting in CI see .github/workflows/golangci-lint.yml
-	@docker run -t --rm -v $$(pwd):/app -v ~/.cache/golangci-lint/$(GOLANGCI_LINT_VERSION):/root/.cache -w /app golangci/golangci-lint:$(GOLANGCI_LINT_VERSION) golangci-lint format run --fix
+	@docker run -t --rm -v $$(pwd):/app -v ~/.cache/golangci-lint/$(GOLANGCI_LINT_VERSION):/root/.cache -w /app golangci/golangci-lint:$(GOLANGCI_LINT_VERSION) golangci-lint fmt
+	@docker run -t --rm -v $$(pwd):/app -v ~/.cache/golangci-lint/$(GOLANGCI_LINT_VERSION):/root/.cache -w /app golangci/golangci-lint:$(GOLANGCI_LINT_VERSION) golangci-lint run
 
 .PHONY: release-build
 release-build:

--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -704,50 +704,6 @@ func TestAccResourceVMClone(t *testing.T) {
 				}`),
 			ExpectError: regexp.MustCompile(`storage 'doesnotexist' does not exist`),
 		}}},
-		{"update disk speed and resize in a clone", []resource.TestStep{{
-			Config: te.RenderConfig(`
-				resource "proxmox_virtual_environment_vm" "template" {
-					node_name = "{{.NodeName}}"
-					started   = false
-					disk {
-						datastore_id = "local-lvm"
-						interface    = "virtio0"
-						file_format  = "raw"
-						size         = 20
-					}
-				}
-				resource "proxmox_virtual_environment_vm" "clone" {
-					node_name = "{{.NodeName}}"
-					started   = false
-					clone {
-						vm_id = proxmox_virtual_environment_vm.template.vm_id
-					}
-					disk {
-						datastore_id = "local-lvm"
-						interface    = "virtio0"
-						iothread     = true
-						discard      = "on"
-						size         = 30
-						speed {
-						  iops_read = 100
-						  iops_read_burstable = 1000
-						  iops_write = 400
-						  iops_write_burstable = 800
-						}
-					}
-				}`),
-			Check: resource.ComposeTestCheckFunc(
-				ResourceAttributes("proxmox_virtual_environment_vm.clone", map[string]string{
-					"disk.0.iothread":                     "true",
-					"disk.0.discard":                      "on",
-					"disk.0.size":                         "30",
-					"disk.0.speed.0.iops_read":            "100",
-					"disk.0.speed.0.iops_read_burstable":  "1000",
-					"disk.0.speed.0.iops_write":           "400",
-					"disk.0.speed.0.iops_write_burstable": "800",
-				}),
-			),
-		}}},
 	}
 
 	for _, tt := range tests {

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -25,13 +25,17 @@ var StorageInterfaces = []string{"ide", "sata", "scsi", "virtio"}
 
 // CustomStorageDevice handles QEMU SATA device parameters.
 type CustomStorageDevice struct {
+	// FileVolume is the path to the storage device in format
+	// "STORAGE_ID:SIZE_IN_GiB" or "STORAGE_ID:PATH_TO_FILE".
+	// This is a required field.
+	FileVolume string `json:"file"                  url:"file"`
+
 	AIO                     *string           `json:"aio,omitempty"         url:"aio,omitempty"`
 	Backup                  *types.CustomBool `json:"backup,omitempty"      url:"backup,omitempty,int"`
 	BurstableReadSpeedMbps  *int              `json:"mbps_rd_max,omitempty" url:"mbps_rd_max,omitempty"`
 	BurstableWriteSpeedMbps *int              `json:"mbps_wr_max,omitempty" url:"mbps_wr_max,omitempty"`
 	Cache                   *string           `json:"cache,omitempty"       url:"cache,omitempty"`
 	Discard                 *string           `json:"discard,omitempty"     url:"discard,omitempty"`
-	FileVolume              string            `json:"file"                  url:"file"`
 	Format                  *string           `json:"format,omitempty"      url:"format,omitempty"`
 	IopsRead                *int              `json:"iops_rd,omitempty"     url:"iops_rd,omitempty"`
 	IopsWrite               *int              `json:"iops_wr,omitempty"     url:"iops_wr,omitempty"`

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -28,7 +28,7 @@ type CustomStorageDevice struct {
 	// FileVolume is the path to the storage device in format
 	// "STORAGE_ID:SIZE_IN_GiB" or "STORAGE_ID:PATH_TO_FILE".
 	// This is a required field.
-	FileVolume string `json:"file"                  url:"file"`
+	FileVolume string `json:"file" url:"file"`
 
 	AIO                     *string           `json:"aio,omitempty"         url:"aio,omitempty"`
 	Backup                  *types.CustomBool `json:"backup,omitempty"      url:"backup,omitempty,int"`

--- a/proxmoxtf/provider/provider.go
+++ b/proxmoxtf/provider/provider.go
@@ -80,7 +80,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		csrfPreventionToken = v.(string)
 	}
 
-	//nolint:staticcheck //using GetOkExists to check if the value is set, as it can be an empty string in tests
+	//nolint:staticcheck
 	if v, ok := d.GetOkExists(mkProviderAPIToken); ok {
 		apiToken = v.(string)
 	}
@@ -89,12 +89,12 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		otp = v.(string)
 	}
 
-	///nolint:staticcheck //using GetOkExists to check if the value is set, as it can be an empty string in tests
+	///nolint:staticcheck
 	if v, ok := d.GetOkExists(mkProviderUsername); ok {
 		username = v.(string)
 	}
 
-	//nolint:staticcheck //using GetOkExists to check if the value is set, as it can be an empty string in tests
+	//nolint:staticcheck
 	if v, ok := d.GetOkExists(mkProviderPassword); ok {
 		password = v.(string)
 	}

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -109,12 +109,12 @@ func UpdateClone(
 				TargetStorage:      *planDisk.DatastoreID,
 			}
 
+			// Note: after disk move, the actual disk volume ID will be different: both datastore id *and*
+			// path in datastore will change.
 			err := vmAPI.MoveVMDisk(ctx, diskMoveBody)
 			if err != nil {
 				return fmt.Errorf("disk move fails: %w", err)
 			}
-			// Note: after disk move, the actual disk volume ID will be different: both datastore id *and*
-			// path in datastore will change.
 		}
 
 		if planDisk.Size.InMegabytes() > currentDisk.Size.InMegabytes() {


### PR DESCRIPTION
Fix regression introduced in #1829

After moving a disk its file volume attribute changes, and subsequent update operation fails with error as no matching disc can be found. 

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

See the updated acceptance tests:
```
--- PASS: TestAccResourceVMDisks (0.00s)
    --- PASS: TestAccResourceVMDisks/efi_disk (15.37s)
    --- PASS: TestAccResourceVMDisks/create_disk_with_default_parameters,_then_update_it (17.47s)
    --- PASS: TestAccResourceVMDisks/clone_disk_with_overrides (0.26s)
    --- PASS: TestAccResourceVMDisks/clone_with_adding_disk (0.27s)
    --- PASS: TestAccResourceVMDisks/removing_disks (18.25s)
    --- PASS: TestAccResourceVMDisks/adding_disks (19.73s)
    --- PASS: TestAccResourceVMDisks/ide_disks (20.64s)
    --- PASS: TestAccResourceVMDisks/create_disk_from_an_image (20.78s)
    --- PASS: TestAccResourceVMDisks/multiple_disks (7.44s)
    --- PASS: TestAccResourceVMDisks/clone_default_disk_without_overrides (26.63s)
    --- PASS: TestAccResourceVMDisks/clone_with_disk_resize (26.98s)
    --- PASS: TestAccResourceVMDisks/clone_with_updating_disk_attributes (30.15s)
    --- PASS: TestAccResourceVMDisks/clone_with_moving_disk (35.30s)
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1845

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced VM cloning now supports customized disk attributes, including updated disk sizes and options to migrate disks across datastores.
  - Introduced a new FileVolume parameter for custom storage devices, enabling flexible volume specification.

- **Bug Fixes**
  - Removed outdated test case for disk speed and resizing in VM cloning to improve test accuracy.

- **Refactor**
  - Streamlined the disk update process during cloning to ensure consistent and reliable disk configuration handling.
  - Updated linting process for improved code quality checks.
  - Modified comments in provider configuration for clarity without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->