### PR TITLE
chore(docs)!: clarify disk behaviour in clone operation

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -636,8 +636,12 @@ If you do not have `local-lvm` configured in your environment, you may need to e
 ### Cloning
 
 When cloning an existing virtual machine, whether it's a template or not, the
-resource will only detect changes to the arguments which are not set to their
-default values.
+resource will inherit the disks and other configuration from the source VM.
+
+*If* you modify any attributes of an existing disk in the clone, you also need to  
+explicitly provide values for any other attributes that differ from the schema defaults  
+in the source (e.g., `size`, `discard`, `cache`, `aio`).  
+Otherwise, the schema defaults will take effect and override the source values.
 
 Furthermore, when cloning from one node to a different one, the behavior changes
 depening on the datastores of the source VM. If at least one non-shared
@@ -645,7 +649,7 @@ datastore is used, the VM is first cloned to the source node before being
 migrated to the target node. This circumvents a limitation in the Proxmox clone
 API.
 
-**Note:** Because the migration step after the clone tries to preserve the used
+Because the migration step after the clone tries to preserve the used
 datastores by their name, it may fail if a datastore used in the source VM is
 not available on the target node (e.g. `local-lvm` is used on the source node in
 the VM but no `local-lvm` datastore is available on the target node). In this

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -372,7 +372,6 @@ func (d *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 //   - FileID
 //   - FileVolume
 //   - Format
-//   - Size
 //
 // It will return true if any attribute of the current CustomStorageDevice was changed.
 func (d *CustomStorageDevice) MergeWith(m CustomStorageDevice) bool {


### PR DESCRIPTION
This is a "meta" PR to bump the minor version due potentially breaking changes from https://github.com/bpg/terraform-provider-proxmox/pull/1840.

See documentation for more details.

> When cloning an existing virtual machine, whether it's a template or not, the
> resource will inherit the disks and other configuration from the source VM.
>
> *If* you modify any attributes of an existing disk in the clone, you also need to
> explicitly provide values for any other attributes that differ from the schema defaults
> in the source (e.g., `size`, `discard`, `cache`, `aio`).
> Otherwise, the schema defaults will take effect and override the source values.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000 | Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced the guidance for cloning virtual machines by clarifying that clones inherit disk configurations. The instructions now detail that if any disk attribute is modified, users must explicitly provide values for other altered attributes, ensuring more predictable cloning outcomes.
  
- **Chores**
  - Updated internal descriptions related to storage customization merging to reflect current behavior without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->