### PR TITLE
fix(vm): improve error handling when updating `initialization` block

### DIFF
--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5168,14 +5168,17 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 				tflog.Debug(ctx, fmt.Sprintf("CloudInit must be moved from %s to %s", existingInterface, initializationInterface))
 			}
 
+			mustChangeDatastore := false
 			oldInit, _ := d.GetChange(mkInitialization)
-			oldInitBlock := oldInit.([]interface{})[0].(map[string]interface{})
-			prevDatastoreID := oldInitBlock[mkInitializationDatastoreID].(string)
+			if len(oldInit.([]interface{})) > 0 {
+				oldInitBlock := oldInit.([]interface{})[0].(map[string]interface{})
+				prevDatastoreID := oldInitBlock[mkInitializationDatastoreID].(string)
 
-			mustChangeDatastore := prevDatastoreID != initializationDatastoreID
-			if mustChangeDatastore {
-				tflog.Debug(ctx, fmt.Sprintf("CloudInit must be moved from datastore %s to datastore %s",
-					prevDatastoreID, initializationDatastoreID))
+				mustChangeDatastore = prevDatastoreID != initializationDatastoreID
+				if mustChangeDatastore {
+					tflog.Debug(ctx, fmt.Sprintf("CloudInit must be moved from datastore %s to datastore %s",
+						prevDatastoreID, initializationDatastoreID))
+				}
 			}
 
 			if mustMove || mustChangeDatastore || existingInterface == "" {

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5169,6 +5169,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 			}
 
 			mustChangeDatastore := false
+
 			oldInit, _ := d.GetChange(mkInitialization)
 			if len(oldInit.([]interface{})) > 0 {
 				oldInitBlock := oldInit.([]interface{})[0].(map[string]interface{})


### PR DESCRIPTION
Fix for an edge case where a VM is created without an initialization block, then any subsequent update to the block would cause a panic.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
Before:
```
❯ tofu apply -auto-approve
data.local_file.ssh_public_key: Reading...
data.local_file.ssh_public_key: Read complete after 0s [id=84cdc3a1d1eaa8e821cd6dd4287f04ae996b8309]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Refreshing state... [id=local:iso/jammy-server-cloudimg-amd64.img]
proxmox_virtual_environment_vm.ubuntu_vm: Refreshing state... [id=100]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.ubuntu_vm will be updated in-place
  ~ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
        id                      = "100"
        name                    = "test-ubuntu"
        tags                    = []
        # (27 unchanged attributes hidden)

      + initialization {
          + datastore_id = "local-lvm"

          + ip_config {
              + ipv4 {
                  + address = "192.168.3.233/24"
                  + gateway = "192.168.3.1"
                }
            }
        }

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
proxmox_virtual_environment_vm.ubuntu_vm: Modifying... [id=100]
╷
│ Error: Request cancelled
│ 
│ The plugin6.(*GRPCProvider).ApplyResourceChange request was cancelled.
╵

Stack trace from the terraform-provider-proxmox plugin:

panic: runtime error: index out of range [0] with length 0

goroutine 81 [running]:
github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm.vmUpdate({0x103b0a420, 0x140006bbe30}, 0x140002daf80, {0x103a5d400, 0x140000ea690})
        /code/terraform-provider-proxmox/proxmoxtf/resource/vm/vm.go:5172 +0x492c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).update(0x14000324900, {0x103b0a378, 0x1400011e1e0}, 0x140002daf80, {0x103a5d400, 0x140000ea690})
        /go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.36.1/helper/schema/resource.go:872 +0xe4
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0x14000324900, {0x103b0a378, 0x1400011e1e0}, 0x14000462340, 0x140002dac00, {0x103a5d400, 0x140000ea690})
        /go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.36.1/helper/schema/resource.go:979 +0x66c
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0x1400000d998, {0x103b0a378?, 0x140003bda70?}, 0x14000612c30)
        /go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.36.1/helper/schema/grpc_provider.go:1188 +0xa70
github.com/hashicorp/terraform-plugin-mux/tf5to6server.v5tov6Server.ApplyResourceChange({{0x103b17df8?, 0x1400000d998?}}, {0x103b0a378, 0x140003bda70}, 0x0?)
        /go/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.18.0/tf5to6server/tf5to6server.go:38 +0x58
github.com/hashicorp/terraform-plugin-mux/tf6muxserver.(*muxServer).ApplyResourceChange(0x140002da680, {0x103b0a378?, 0x140003bd7a0?}, 0x1400041c410)
        /go/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.18.0/tf6muxserver/mux_server_ApplyResourceChange.go:36 +0x17c
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ApplyResourceChange(0x1400028ae60, {0x103b0a378?, 0x140003bc630?}, 0x140006ba070)
        /go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov6/tf6server/server.go:866 +0x294
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ApplyResourceChange_Handler({0x103ad0ba0, 0x1400028ae60}, {0x103b0a378, 0x140003bc630}, 0x140002da080, 0x0)
        /go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:611 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x14000278400, {0x103b0a378, 0x140003bc450}, 0x140001c40c0, 0x140003bcd80, 0x10425c078, 0x0)
        /go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1400 +0xc9c
google.golang.org/grpc.(*Server).handleStream(0x14000278400, {0x103b0aea8, 0x140004fe000}, 0x140001c40c0)
        /go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1810 +0x900
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        /go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1030 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 23
        /go/pkg/mod/google.golang.org/grpc@v1.70.0/server.go:1041 +0x138

Error: The terraform-provider-proxmox plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```
After
```
❯ tofu apply -auto-approve
data.local_file.ssh_public_key: Reading...
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Refreshing state... [id=local:iso/jammy-server-cloudimg-amd64.img]
data.local_file.ssh_public_key: Read complete after 0s [id=84cdc3a1d1eaa8e821cd6dd4287f04ae996b8309]
proxmox_virtual_environment_vm.ubuntu_vm: Refreshing state... [id=100]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.ubuntu_vm will be updated in-place
  ~ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
        id                      = "100"
        name                    = "test-ubuntu"
        tags                    = []
        # (27 unchanged attributes hidden)

      + initialization {
          + datastore_id = "local-lvm"

          + ip_config {
              + ipv4 {
                  + address = "192.168.3.233/24"
                  + gateway = "192.168.3.1"
                }
            }
        }

        # (3 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
proxmox_virtual_environment_vm.ubuntu_vm: Modifying... [id=100]
proxmox_virtual_environment_vm.ubuntu_vm: Modifications complete after 6s [id=100]
╷
│ Warning: a reboot is required to apply configuration changes, but automatic reboots are disabled by 'reboot_after_update = false'. Please reboot the VM manually.
│ 
│   with proxmox_virtual_environment_vm.ubuntu_vm,
│   on main.tf line 5, in resource "proxmox_virtual_environment_vm" "ubuntu_vm":
│    5: resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
│ 
╵

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```


<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1400

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced stability in cloud configuration updates by adding extra safeguards. This improvement ensures updates only occur when valid data is present, preventing runtime errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->