### PR TITLE
fix(vm): remove `qcow2` as the default for `disk.file_format`

### DIFF
--- a/docs/guides/clone-vm.md
+++ b/docs/guides/clone-vm.md
@@ -36,7 +36,6 @@ resource "proxmox_virtual_environment_vm" "ubuntu_template" {
 
   efi_disk {
     datastore_id = "local"
-    file_format  = "raw"
     type         = "4m"
   }
 

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -273,11 +273,11 @@ output "ubuntu_vm_public_key" {
     - `discard` - (Optional) Whether to pass discard/trim requests to the
         underlying storage. Supported values are `on`/`ignore` (defaults
         to `ignore`).
-    - `file_format` - (Optional) The file format (defaults to `qcow2`).
+    - `file_format` - (Optional) The file format.
         - `qcow2` - QEMU Disk Image v2.
         - `raw` - Raw Disk Image.
         - `vmdk` - VMware Disk Image.
-    - `file_id` - (Optional) The file ID for a disk image. The ID format is
+    - `file_id` - (Optional) The file ID for a disk image when importing a disk into VM. The ID format is
           `<datastore_id>:<content_type>/<file_name>`, for example `local:iso/centos8.img`. Can be also taken from
           `proxmox_virtual_environment_download_file` resource.
     - `interface` - (Required) The disk interface for Proxmox, currently `scsi`,
@@ -685,14 +685,12 @@ resource "proxmox_virtual_environment_vm" "data_vm" {
 
   disk {
     datastore_id = "local-zfs"
-    file_format  = "raw"
     interface    = "scsi0"
     size         = 1
   }
 
   disk {
     datastore_id = "local-zfs"
-    file_format  = "raw"
     interface    = "scsi1"
     size         = 4
   }
@@ -702,7 +700,6 @@ resource "proxmox_virtual_environment_vm" "data_user_vm" {
   # boot disk
   disk {
     datastore_id = "local-zfs"
-    file_format  = "raw"
     interface    = "scsi0"
     size         = 8
   }

--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -31,7 +31,6 @@ resource "proxmox_virtual_environment_vm" "example_template" {
 
   efi_disk {
     datastore_id = local.datastore_id
-    file_format  = "raw"
     type         = "4m"
   }
 
@@ -42,7 +41,6 @@ resource "proxmox_virtual_environment_vm" "example_template" {
 
   disk {
     datastore_id = local.datastore_id
-    file_format  = "raw"
     interface    = "ide0"
     size         = 8
   }
@@ -61,7 +59,6 @@ resource "proxmox_virtual_environment_vm" "example_template" {
   #    datastore_id = "nfs"
   #    interface    = "scsi1"
   #    discard      = "ignore"
-  #    file_format  = "raw"
   #  }
 
   initialization {
@@ -166,7 +163,6 @@ resource "proxmox_virtual_environment_vm" "example" {
 
   efi_disk {
     datastore_id = local.datastore_id
-    file_format  = "raw"
     type         = "4m"
   }
 
@@ -234,13 +230,11 @@ resource "proxmox_virtual_environment_vm" "data_vm" {
 
   disk {
     datastore_id = local.datastore_id
-    file_format  = "raw"
     interface    = "scsi0"
     size         = 1
   }
   disk {
     datastore_id = local.datastore_id
-    file_format  = "raw"
     interface    = "scsi1"
     size         = 4
   }

--- a/examples/guides/clone-vm/template.tf
+++ b/examples/guides/clone-vm/template.tf
@@ -19,7 +19,6 @@ resource "proxmox_virtual_environment_vm" "ubuntu_template" {
 
   efi_disk {
     datastore_id = "local"
-    file_format  = "raw"
     type         = "4m"
   }
 

--- a/fwprovider/test/resource_vm_disks_test.go
+++ b/fwprovider/test/resource_vm_disks_test.go
@@ -34,8 +34,6 @@ func TestAccResourceVMDisks(t *testing.T) {
 					name 	  = "test-disk"
 					
 					disk {
-						// note: default qcow2 is not supported by lvm (?)
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "virtio0"
 						size         = 8
@@ -67,8 +65,6 @@ func TestAccResourceVMDisks(t *testing.T) {
 					name 	  = "test-disk"
 
 					disk {
-						// note: default qcow2 is not supported by lvm (?)
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "virtio0"
 						serial	     = "-dead_beef-"
@@ -155,7 +151,6 @@ func TestAccResourceVMDisks(t *testing.T) {
 					template  = "true"
 					
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "virtio0"
 						size         = 8
@@ -190,13 +185,11 @@ func TestAccResourceVMDisks(t *testing.T) {
 					template  = "true"
 					
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "virtio0"
 						size         = 8
 					}
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "scsi0"
 						size         = 8
@@ -222,7 +215,6 @@ func TestAccResourceVMDisks(t *testing.T) {
 					name 	  = "test-disk"
 					
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "scsi0"
 						size         = 8
@@ -241,14 +233,12 @@ func TestAccResourceVMDisks(t *testing.T) {
 					name 	  = "test-disk"
 					
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "scsi0"
 						size         = 8
 					}
 
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "scsi1"
 						size         = 8
@@ -279,14 +269,12 @@ func TestAccResourceVMDisks(t *testing.T) {
 					name 	  = "test-disk"
 					
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "scsi0"
 						size         = 8
 					}
 
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "scsi1"
 						size         = 8
@@ -307,7 +295,6 @@ func TestAccResourceVMDisks(t *testing.T) {
 					name 	  = "test-disk"
 					
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "scsi0"
 						size         = 8
@@ -349,7 +336,6 @@ func TestAccResourceVMDisks(t *testing.T) {
 					name 	  = "test-disks-ide"
 					
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "ide0"
 						size         = 8
@@ -368,13 +354,11 @@ func TestAccResourceVMDisks(t *testing.T) {
 					name 	  = "test-disks-ide"
 					
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "ide0"
 						size         = 8
 					}
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "ide1"
 						size         = 8
@@ -402,7 +386,6 @@ func TestAccResourceVMDisks(t *testing.T) {
 					template  = "true"
 		
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "scsi0"
 						size         = 8
@@ -451,7 +434,6 @@ func TestAccResourceVMDisks(t *testing.T) {
 					template  = "true"
 					
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "virtio0"
 						size         = 8
@@ -498,7 +480,6 @@ func TestAccResourceVMDisks(t *testing.T) {
 					template  = "true"
 					
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "virtio0"
 						size         = 8
@@ -514,7 +495,6 @@ func TestAccResourceVMDisks(t *testing.T) {
 					}
 
 					disk {
-						file_format  = "raw"
 						datastore_id = "local-lvm"
 						interface    = "scsi0"
 						size         = 10
@@ -543,7 +523,6 @@ func TestAccResourceVMDisks(t *testing.T) {
 					disk {
 						datastore_id = "local-lvm"
 						interface    = "virtio0"
-						file_format  = "raw"
 						size         = 20
 					}
 				}
@@ -591,7 +570,6 @@ func TestAccResourceVMDisks(t *testing.T) {
 					disk {
 						datastore_id = "local-lvm"
 						interface    = "virtio0"
-						file_format  = "raw"
 						size         = 20
 					}
 				}
@@ -604,7 +582,6 @@ func TestAccResourceVMDisks(t *testing.T) {
 					disk {
 						datastore_id = "tank"
 						interface    = "virtio0"
-						file_format  = "raw"
 						size         = 20
 					}
 				}`),

--- a/proxmoxtf/resource/vm/disk/schema.go
+++ b/proxmoxtf/resource/vm/disk/schema.go
@@ -17,7 +17,6 @@ import (
 const (
 	dvDiskInterface   = "scsi0"
 	dvDiskDatastoreID = "local-lvm"
-	dvDiskFileFormat  = "qcow2"
 	dvDiskSize        = 8
 	dvDiskAIO         = "io_uring"
 	dvDiskDiscard     = "ignore"


### PR DESCRIPTION
No more need to explicitly set `file_format = "raw"` when defining new disks!
Also, removing `file_format = "raw"` (where applicable) from configs should not cause the plan diff. 

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

This simple template just works:
```hcl
resource "proxmox_virtual_environment_vm" "template" {
  node_name = "pve"
  started   = false
  efi_disk {
    datastore_id = "local"
    type         = "4m"
  }
  disk {
    datastore_id = "local-lvm"
    interface    = "virtio0"
    size         = 20
  }
}

resource "proxmox_virtual_environment_vm" "clone" {
  node_name = "pve"
  started   = false
  clone {
    vm_id = proxmox_virtual_environment_vm.template.vm_id
  }
  disk {
    datastore_id = "local-lvm"
    interface    = "virtio0"
    iothread     = true
    discard      = "on"
    size         = 30
  }
  disk {
    datastore_id = "local-lvm"
    interface    = "virtio1"
    size         = 10
  }
}
```
```
❯ tofu apply -auto-approve
data.local_file.ssh_public_key: Reading...
data.local_file.ssh_public_key: Read complete after 0s [id=84cdc3a1d1eaa8e821cd6dd4287f04ae996b8309]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.clone will be created
  + resource "proxmox_virtual_environment_vm" "clone" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + clone {
          + full    = true
          + retries = 1
          + vm_id   = (known after apply)
        }

      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "on"
          + file_format       = (known after apply)
          + interface         = "virtio0"
          + iothread          = true
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 30
          + ssd               = false
        }
      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "ignore"
          + file_format       = (known after apply)
          + interface         = "virtio1"
          + iothread          = false
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 10
          + ssd               = false
        }
    }

  # proxmox_virtual_environment_vm.template will be created
  + resource "proxmox_virtual_environment_vm" "template" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "ignore"
          + file_format       = (known after apply)
          + interface         = "virtio0"
          + iothread          = false
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 20
          + ssd               = false
        }

      + efi_disk {
          + datastore_id      = "local"
          + file_format       = (known after apply)
          + pre_enrolled_keys = false
          + type              = "4m"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.template: Creating...
proxmox_virtual_environment_vm.template: Creation complete after 1s [id=100]
proxmox_virtual_environment_vm.clone: Creating...
proxmox_virtual_environment_vm.clone: Creation complete after 7s [id=101]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

<img width="1035" alt="Screenshot 2025-03-29 at 11 35 10 AM" src="https://github.com/user-attachments/assets/b87639aa-f64f-4cb2-bf4d-8dc3b405d4a4" />


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1458

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced descriptions for disk configuration parameters, improving guidance and clarity on optional disk settings and import procedures by omitting outdated default values.

- **Refactor**
  - Streamlined virtual disk configuration by removing explicit file format declarations, allowing system defaults to drive settings. End-users benefit from a cleaner and more consistent virtual machine setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->