### PR TITLE
fix(vm): prevent cloud-init username reset to `" "` during create

### DIFF
--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -494,6 +494,24 @@ func TestAccResourceVMInitialization(t *testing.T) {
 				}),
 			),
 		}}},
+		{"native cloud-init: username should not change", []resource.TestStep{{
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm_cloudinit4" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					initialization {
+						user_account {
+							keys = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOQCHPhOV9XsJa3uq4bmKymklNy6ktgBB/+2umizgnnY"]
+						}
+					}
+				}`),
+			Check: resource.ComposeTestCheckFunc(
+				NoResourceAttributesSet("proxmox_virtual_environment_vm.test_vm_cloudinit4", []string{
+					"initialization.0.username",
+					"initialization.0.password",
+				}),
+			),
+		}}},
 	}
 
 	for _, tt := range tests {

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -2937,7 +2937,9 @@ func vmGetCloudInitConfig(d *schema.ResourceData) *vms.CustomCloudInitConfig {
 		}
 
 		username := initializationUserAccountBlock[mkInitializationUserAccountUsername].(string)
-		initializationConfig.Username = &username
+		if username != "" {
+			initializationConfig.Username = &username
+		}
 	}
 
 	initializationUserDataFileID := initializationBlock[mkInitializationUserDataFileID].(string)


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Create a simple VM
```hcl
resource "proxmox_virtual_environment_vm" "test" {
  node_name = "pve"
  started   = false
  initialization {
    user_account {
      keys = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOQCHPhOV9XsJa3uq4bmKymklNy6ktgBB/+2umizgnnY"]
    }
  }
}
```

Before the fix:
```
❯ tofu state show proxmox_virtual_environment_vm.test
# proxmox_virtual_environment_vm.test:ronment_vm.test                   
resource "proxmox_virtual_environment_vm" "test" {

<SKIPPED>

    vm_id                   = 100

    initialization {
        datastore_id = "local-lvm"
        interface    = "ide2"
        upgrade      = false

        user_account {
            keys     = [
                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOQCHPhOV9XsJa3uq4bmKymklNy6ktgBB/+2umizgnnY",
            ]
            username = " "
        }
    }
}
```

After the fix:
```
❯ tofu state show proxmox_virtual_environment_vm.test
# proxmox_virtual_environment_vm.test:ronment_vm.test
resource "proxmox_virtual_environment_vm" "test" {

<SKIPPED>

    vm_id                   = 100

    initialization {
        datastore_id = "local-lvm"
        interface    = "ide2"
        upgrade      = false

        user_account {
            keys = [
                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOQCHPhOV9XsJa3uq4bmKymklNy6ktgBB/+2umizgnnY",
            ]
        }
    }
}
```

<img width="480" alt="Screenshot 2025-03-29 at 12 25 11 PM" src="https://github.com/user-attachments/assets/4d0d9c54-1b32-41a3-be4f-962139b890b1" />


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1797

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cloud-init configuration to ensure that user account details are only applied when valid, preventing unintended modifications.

- **Tests**
  - Added a test case to confirm that virtual machine initialization retains the original user account settings when using cloud-init.
  - New test case added to verify that the username does not change when specified in the cloud-init configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->