### PR TITLE
fix(vm): allow to set `machine` type in clone

### DIFF
--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -714,6 +714,26 @@ func TestAccResourceVMClone(t *testing.T) {
 					}
 				}`, WithRootUser()),
 		}}},
+		{"clone machine type", []resource.TestStep{{
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "template" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					template  = true
+					machine   = "q35"
+				}
+				resource "proxmox_virtual_environment_vm" "clone" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					clone {
+						vm_id = proxmox_virtual_environment_vm.template.vm_id
+					}
+					machine = "pc"
+				}`),
+			Check: ResourceAttributes("proxmox_virtual_environment_vm.clone", map[string]string{
+				"machine": "pc",
+			}),
+		}}},
 		{"clone no vga block", []resource.TestStep{{
 			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "template" {

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -1898,26 +1898,27 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 	}
 
 	// Now that the virtual machine has been cloned, we need to perform some modifications.
-	acpi := types.CustomBool(d.Get(mkACPI).(bool))
-	agent := d.Get(mkAgent).([]interface{})
 	audioDevices := vmGetAudioDeviceList(d)
 
+	acpi := types.CustomBool(d.Get(mkACPI).(bool))
+	agent := d.Get(mkAgent).([]interface{})
 	bios := d.Get(mkBIOS).(string)
-	kvmArguments := d.Get(mkKVMArguments).(string)
-	scsiHardware := d.Get(mkSCSIHardware).(string)
 	cdrom := d.Get(mkCDROM).([]interface{})
 	cpu := d.Get(mkCPU).([]interface{})
-	initialization := d.Get(mkInitialization).([]interface{})
 	hostPCI := d.Get(mkHostPCI).([]interface{})
 	hostUSB := d.Get(mkHostUSB).([]interface{})
+	initialization := d.Get(mkInitialization).([]interface{})
 	keyboardLayout := d.Get(mkKeyboardLayout).(string)
+	kvmArguments := d.Get(mkKVMArguments).(string)
+	machine := d.Get(mkMachine).(string)
 	memory := d.Get(mkMemory).([]interface{})
 	numa := d.Get(mkNUMA).([]interface{})
-	operatingSystem := d.Get(mkOperatingSystem).([]interface{})
-	serialDevice := d.Get(mkSerialDevice).([]interface{})
 	onBoot := types.CustomBool(d.Get(mkOnBoot).(bool))
-	tabletDevice := types.CustomBool(d.Get(mkTabletDevice).(bool))
+	operatingSystem := d.Get(mkOperatingSystem).([]interface{})
 	protection := types.CustomBool(d.Get(mkProtection).(bool))
+	scsiHardware := d.Get(mkSCSIHardware).(string)
+	serialDevice := d.Get(mkSerialDevice).([]interface{})
+	tabletDevice := types.CustomBool(d.Get(mkTabletDevice).(bool))
 	template := types.CustomBool(d.Get(mkTemplate).(bool))
 	vga := d.Get(mkVGA).([]interface{})
 	watchdog := d.Get(mkWatchdog).([]interface{})
@@ -1956,6 +1957,10 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 
 	if bios != dvBIOS {
 		updateBody.BIOS = &bios
+	}
+
+	if machine != dvMachineType {
+		updateBody.Machine = &machine
 	}
 
 	if scsiHardware != dvSCSIHardware {


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

```hcl
resource "proxmox_virtual_environment_vm" "template" {
  node_name = "pve"
  started   = false
  template = true
  machine = "q35"
}

resource "proxmox_virtual_environment_vm" "clone" {
  node_name = "pve"
  started   = false
  machine = "pc"
  clone {
    vm_id = proxmox_virtual_environment_vm.template.vm_id
  }
}
```

Before the fix:
```
❯ tofu apply -auto-approve
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.clone will be created
  + resource "proxmox_virtual_environment_vm" "clone" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + machine                 = "pc"
      + migrate                 = false
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + clone {
          + full    = true
          + retries = 1
          + vm_id   = (known after apply)
        }
    }

  # proxmox_virtual_environment_vm.template will be created
  + resource "proxmox_virtual_environment_vm" "template" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + machine                 = "q35"
      + migrate                 = false
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = true
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.template: Creating...
proxmox_virtual_environment_vm.template: Creation complete after 0s [id=100]
proxmox_virtual_environment_vm.clone: Creating...
proxmox_virtual_environment_vm.clone: Creation complete after 0s [id=101]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```
second `apply`:
```
❯ tofu apply -auto-approve
proxmox_virtual_environment_vm.template: Refreshing state... [id=100]
proxmox_virtual_environment_vm.clone: Refreshing state... [id=101]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.clone will be updated in-place
  ~ resource "proxmox_virtual_environment_vm" "clone" {
        id                      = "101"
      ~ machine                 = "q35" -> "pc"
        # (27 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
proxmox_virtual_environment_vm.clone: Modifying... [id=101]
proxmox_virtual_environment_vm.clone: Modifications complete after 0s [id=101]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

After the fix:
```
❯ tofu apply -auto-approve
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.clone will be created
  + resource "proxmox_virtual_environment_vm" "clone" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + machine                 = "pc"
      + migrate                 = false
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + clone {
          + full    = true
          + retries = 1
          + vm_id   = (known after apply)
        }
    }

  # proxmox_virtual_environment_vm.template will be created
  + resource "proxmox_virtual_environment_vm" "template" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + machine                 = "q35"
      + migrate                 = false
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = true
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.template: Creating...
proxmox_virtual_environment_vm.template: Creation complete after 0s [id=100]
proxmox_virtual_environment_vm.clone: Creating...
proxmox_virtual_environment_vm.clone: Creation complete after 0s [id=101]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```
second `apply`:
```
❯ tofu apply -auto-approve
proxmox_virtual_environment_vm.template: Refreshing state... [id=100]
proxmox_virtual_environment_vm.clone: Refreshing state... [id=101]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1593 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved virtual machine cloning now supports specifying a custom machine type. Cloned VMs will reliably adopt the intended configuration, ensuring consistency with user-selected options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->