### PR TITLE
fix(lxc): multiple issues during container import

### DIFF
--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -104,9 +104,11 @@ func TestAccResourceContainer(t *testing.T) {
 				}`, WithRootUser()),
 				Check: resource.ComposeTestCheckFunc(
 					ResourceAttributes(accTestContainerName, map[string]string{
-						"description":            "my\ndescription\nvalue\n",
-						"device_passthrough.#":   "1",
-						"initialization.0.dns.#": "0",
+						"unprivileged":              "true",
+						"description":               "my\ndescription\nvalue\n",
+						"device_passthrough.#":      "1",
+						"device_passthrough.0.mode": "0660",
+						"initialization.0.dns.#":    "0",
 					}),
 					func(*terraform.State) error {
 						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -50,6 +50,7 @@ const (
 	dvCPUCores                          = 1
 	dvCPUUnits                          = 1024
 	dvDescription                       = ""
+	dvDevicePassthroughMode             = "0660"
 	dvDiskDatastoreID                   = "local"
 	dvDiskSize                          = 4
 	dvFeaturesNesting                   = false
@@ -710,6 +711,7 @@ func Container() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: "Access mode to be set on the device node (e.g. 0666)",
 							Optional:    true,
+							Default:     dvDevicePassthroughMode,
 							ValidateDiagFunc: validation.ToDiagFunc(validation.StringMatch(
 								regexp.MustCompile(`0[0-7]{3}`), "Octal access mode",
 							)),
@@ -2376,7 +2378,7 @@ func containerRead(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		if dp.Mode != nil {
 			devicePassthrough[mkDevicePassthroughMode] = *dp.Mode
 		} else {
-			devicePassthrough[mkDevicePassthroughMode] = "0660"
+			devicePassthrough[mkDevicePassthroughMode] = dvDevicePassthroughMode
 		}
 
 		devicePassthrough[mkDevicePassthroughPath] = dp.Path

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -2744,6 +2744,21 @@ func containerRead(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
+	currentUnprivileged := types.CustomBool(d.Get(mkUnprivileged).(bool))
+
+	if len(clone) == 0 || currentUnprivileged {
+		if containerConfig.Unprivileged != nil {
+			e = d.Set(
+				mkUnprivileged,
+				bool(*containerConfig.Unprivileged),
+			)
+		} else {
+			e = d.Set(mkUnprivileged, false)
+		}
+
+		diags = append(diags, diag.FromErr(e)...)
+	}
+
 	currentProtection := types.CustomBool(d.Get(mkProtection).(bool))
 
 	if len(clone) == 0 || currentProtection {

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -2376,7 +2376,7 @@ func containerRead(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		if dp.Mode != nil {
 			devicePassthrough[mkDevicePassthroughMode] = *dp.Mode
 		} else {
-			devicePassthrough[mkDevicePassthroughMode] = ""
+			devicePassthrough[mkDevicePassthroughMode] = "0660"
 		}
 
 		devicePassthrough[mkDevicePassthroughPath] = dp.Path


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
Previously, a configuration generated from an existing container looked like this:
```tf
resource "proxmox_virtual_environment_container" "testcontainer" {
  ...
  timeout_update      = null
  unprivileged        = null
  vm_id               = null
  ...
```

This led to tofu wanting to replace the container based on the just generated config `unprivileged = null` (which results in false) and the difference to the imported state `unprivileged = null`. This is also an issue with `unprivileged = true|false`, as it's compared against null.

Now, the property `unprivileged` is imported correctly:
```tf
resource "proxmox_virtual_environment_container" "testcontainer" {
  ...
  timeout_update      = null
  unprivileged        = true
  vm_id               = null
  ...
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1787

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
