### PR TITLE
misc(datastores): update datasource references in `/example`

### DIFF
--- a/example/data_source_virtual_environment_datastores.tf
+++ b/example/data_source_virtual_environment_datastores.tf
@@ -2,42 +2,6 @@ data "proxmox_virtual_environment_datastores" "example" {
   node_name = data.proxmox_virtual_environment_nodes.example.names[0]
 }
 
-output "data_proxmox_virtual_environment_datastores_example_active" {
-  value = data.proxmox_virtual_environment_datastores.example.active
-}
-
-output "data_proxmox_virtual_environment_datastores_example_content_types" {
-  value = data.proxmox_virtual_environment_datastores.example.content_types
-}
-
-output "data_proxmox_virtual_environment_datastores_example_datastore_ids" {
-  value = data.proxmox_virtual_environment_datastores.example.datastore_ids
-}
-
-output "data_proxmox_virtual_environment_datastores_example_enabled" {
-  value = data.proxmox_virtual_environment_datastores.example.enabled
-}
-
-output "data_proxmox_virtual_environment_datastores_example_node_name" {
-  value = data.proxmox_virtual_environment_datastores.example.node_name
-}
-
-output "data_proxmox_virtual_environment_datastores_example_shared" {
-  value = data.proxmox_virtual_environment_datastores.example.shared
-}
-
-output "data_proxmox_virtual_environment_datastores_example_space_available" {
-  value = data.proxmox_virtual_environment_datastores.example.space_available
-}
-
-output "data_proxmox_virtual_environment_datastores_example_space_total" {
-  value = data.proxmox_virtual_environment_datastores.example.space_total
-}
-
-output "data_proxmox_virtual_environment_datastores_example_space_used" {
-  value = data.proxmox_virtual_environment_datastores.example.space_used
-}
-
-output "data_proxmox_virtual_environment_datastores_example_types" {
-  value = data.proxmox_virtual_environment_datastores.example.types
+output "data_proxmox_virtual_environment_datastores_example" {
+  value = data.proxmox_virtual_environment_datastores.example
 }

--- a/example/resource_virtual_environment_container.tf
+++ b/example/resource_virtual_environment_container.tf
@@ -4,13 +4,13 @@ resource "proxmox_virtual_environment_container" "example_template" {
   start_on_boot = "true"
 
   disk {
-    datastore_id = element(data.proxmox_virtual_environment_datastores.example.datastore_ids, index(data.proxmox_virtual_environment_datastores.example.datastore_ids, "local-lvm"))
+    datastore_id = "local-lvm"
     size         = 4
   }
 
   mount_point {
     // volume mount
-    volume = element(data.proxmox_virtual_environment_datastores.example.datastore_ids, index(data.proxmox_virtual_environment_datastores.example.datastore_ids, "local-lvm"))
+    volume = "local-lvm"
     size   = "4G"
     path   = "mnt/local"
   }
@@ -66,7 +66,7 @@ resource "proxmox_virtual_environment_container" "example_template" {
 
 resource "proxmox_virtual_environment_container" "example" {
   disk {
-    datastore_id = element(data.proxmox_virtual_environment_datastores.example.datastore_ids, index(data.proxmox_virtual_environment_datastores.example.datastore_ids, "local-lvm"))
+    datastore_id = "local-lvm"
   }
 
   clone {

--- a/example/resource_virtual_environment_file.tf
+++ b/example/resource_virtual_environment_file.tf
@@ -4,8 +4,8 @@
 
 resource "proxmox_virtual_environment_file" "user_config" {
   content_type = "snippets"
-  datastore_id = element(data.proxmox_virtual_environment_datastores.example.datastore_ids, index(data.proxmox_virtual_environment_datastores.example.datastore_ids, "local"))
-  node_name    = data.proxmox_virtual_environment_datastores.example.node_name
+  datastore_id = "local"
+  node_name    = data.proxmox_virtual_environment_nodes.example.names[0]
 
   source_raw {
     data = <<-EOF
@@ -31,8 +31,8 @@ resource "proxmox_virtual_environment_file" "user_config" {
 
 resource "proxmox_virtual_environment_file" "vendor_config" {
   content_type = "snippets"
-  datastore_id = element(data.proxmox_virtual_environment_datastores.example.datastore_ids, index(data.proxmox_virtual_environment_datastores.example.datastore_ids, "local"))
-  node_name    = data.proxmox_virtual_environment_datastores.example.node_name
+  datastore_id = "local"
+  node_name    = data.proxmox_virtual_environment_nodes.example.names[0]
 
   source_raw {
     data = <<-EOF
@@ -52,8 +52,8 @@ resource "proxmox_virtual_environment_file" "vendor_config" {
 
 resource "proxmox_virtual_environment_file" "meta_config" {
   content_type = "snippets"
-  datastore_id = element(data.proxmox_virtual_environment_datastores.example.datastore_ids, index(data.proxmox_virtual_environment_datastores.example.datastore_ids, "local"))
-  node_name    = data.proxmox_virtual_environment_datastores.example.node_name
+  datastore_id = "local"
+  node_name    = data.proxmox_virtual_environment_nodes.example.names[0]
 
   source_raw {
     data = <<-EOF

--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -1,5 +1,5 @@
 locals {
-  datastore_id = element(data.proxmox_virtual_environment_datastores.example.datastore_ids, index(data.proxmox_virtual_environment_datastores.example.datastore_ids, "local-lvm"))
+  datastore_id = "local-lvm"
 }
 
 resource "proxmox_virtual_environment_vm" "example_template" {


### PR DESCRIPTION
A follow up on #1875

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000 | Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated multiple datastore outputs into a single, comprehensive output for a simplified view.
  - Updated container, file, and virtual machine configurations to use static assignments for datastore and volume attributes, ensuring consistent and predictable behavior.
  - Streamlined the assignment of node identifiers to enhance clarity in resource configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->