### PR TITLE
fix(vm,lxc): error parsing disk ID when datastore name contains `.`

### DIFF
--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -243,10 +243,17 @@ func (d *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 		if len(v) == 1 {
 			d.FileVolume = v[0]
 
-			ext := filepath.Ext(v[0])
-			if ext != "" {
-				format := string([]byte(ext)[1:])
-				d.Format = &format
+			// split file volume into datastore ID and path
+			_, pathInDatastore, hasDatastoreID := strings.Cut(v[0], ":")
+			if hasDatastoreID {
+				// we don't set them here,... but probably should
+				//d.DatastoreID = &probablyDatastoreID
+				//d.FileID = &pathInDatastore
+				ext := filepath.Ext(pathInDatastore)
+				if ext != "" {
+					format := string([]byte(ext)[1:])
+					d.Format = &format
+				}
 			}
 		} else if len(v) == 2 {
 			switch v[0] {

--- a/proxmox/nodes/vms/custom_storage_device_test.go
+++ b/proxmox/nodes/vms/custom_storage_device_test.go
@@ -39,6 +39,18 @@ func TestCustomStorageDevice_UnmarshalJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "volume with dot",
+			line: `"volumes.hdd:base-269-disk-0,cache=writeback,discard=on,iothread=1,size=8G,ssd=1"`,
+			want: &CustomStorageDevice{
+				Cache:      ptr.Ptr("writeback"),
+				Discard:    ptr.Ptr("on"),
+				FileVolume: "volumes.hdd:base-269-disk-0",
+				IOThread:   types.CustomBool(true).Pointer(),
+				Size:       ds8gig,
+				SSD:        types.CustomBool(true).Pointer(),
+			},
+		},
+		{
 			name: "raw volume type",
 			line: `"nfs:2041/vm-2041-disk-0.raw,discard=ignore,ssd=1,iothread=1,size=8G"`,
 			want: &CustomStorageDevice{


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Added a unit test for that specific case from the linked issue, which passes after the fix.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1889

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
