### PR TITLE
fix(vm): cloned VM may be recreated/updated on re-apply

### DIFF
--- a/proxmoxtf/resource/vm/network/schema.go
+++ b/proxmoxtf/resource/vm/network/schema.go
@@ -75,9 +75,7 @@ func Schema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Description: "The network devices",
 			Optional:    true,
-			DefaultFunc: func() (interface{}, error) {
-				return make([]interface{}, 1), nil
-			},
+			Computed:    true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					mkNetworkDeviceBridge: {

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -85,10 +85,6 @@ const (
 	dvInitializationIPConfigIPv6Address = ""
 	dvInitializationIPConfigIPv6Gateway = ""
 	dvInitializationUserAccountPassword = ""
-	dvInitializationUserDataFileID      = ""
-	dvInitializationVendorDataFileID    = ""
-	dvInitializationNetworkDataFileID   = ""
-	dvInitializationMetaDataFileID      = ""
 	dvInitializationType                = ""
 	dvKeyboardLayout                    = "en-us"
 	dvKVMArguments                      = ""
@@ -890,40 +886,40 @@ func VM() *schema.Resource {
 						Type:             schema.TypeString,
 						Description:      "The ID of a file containing custom user data",
 						Optional:         true,
+						Computed:         true,
 						ForceNew:         true,
-						Default:          dvInitializationUserDataFileID,
 						ValidateDiagFunc: validators.FileID(),
 					},
 					mkInitializationVendorDataFileID: {
 						Type:             schema.TypeString,
 						Description:      "The ID of a file containing vendor data",
 						Optional:         true,
+						Computed:         true,
 						ForceNew:         true,
-						Default:          dvInitializationVendorDataFileID,
 						ValidateDiagFunc: validators.FileID(),
 					},
 					mkInitializationNetworkDataFileID: {
 						Type:             schema.TypeString,
 						Description:      "The ID of a file containing network config",
 						Optional:         true,
+						Computed:         true,
 						ForceNew:         true,
-						Default:          dvInitializationNetworkDataFileID,
 						ValidateDiagFunc: validators.FileID(),
 					},
 					mkInitializationMetaDataFileID: {
 						Type:             schema.TypeString,
 						Description:      "The ID of a file containing meta data config",
 						Optional:         true,
+						Computed:         true,
 						ForceNew:         true,
-						Default:          dvInitializationMetaDataFileID,
 						ValidateDiagFunc: validators.FileID(),
 					},
 					mkInitializationType: {
 						Type:             schema.TypeString,
 						Description:      "The cloud-init configuration format",
 						Optional:         true,
+						Computed:         true,
 						ForceNew:         true,
-						Default:          dvInitializationType,
 						ValidateDiagFunc: CloudInitTypeValidator(),
 					},
 				},
@@ -1445,6 +1441,7 @@ func VM() *schema.Resource {
 			Type:        schema.TypeList,
 			Description: "The VGA configuration",
 			Optional:    true,
+			Computed:    true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					mkVGAClipboard: {


### PR DESCRIPTION
This fixes an edge case when a cloned VM does not properly "inherit" some configuration blocks form a template. An [example](https://registry.terraform.io/providers/bpg/proxmox/latest/docs/guides/clone-vm) form the guide is a good test to reproduce this scenario.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

Before the fix:
```
❯ tofu apply -auto-approve
data.local_file.ssh_public_key: Reading...
data.local_file.ssh_public_key: Read complete after 0s [id=84cdc3a1d1eaa8e821cd6dd4287f04ae996b8309]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_download_file.ubuntu_cloud_image will be created
  + resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
      + content_type        = "iso"
      + datastore_id        = "local"
      + file_name           = (known after apply)
      + id                  = (known after apply)
      + node_name           = "pve"
      + overwrite           = true
      + overwrite_unmanaged = false
      + size                = (known after apply)
      + upload_timeout      = 600
      + url                 = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
      + verify              = true
    }

  # proxmox_virtual_environment_file.user_data_cloud_config will be created
  + resource "proxmox_virtual_environment_file" "user_data_cloud_config" {
      + content_type           = "snippets"
      + datastore_id           = "local"
      + file_modification_date = (known after apply)
      + file_name              = (known after apply)
      + file_size              = (known after apply)
      + file_tag               = (known after apply)
      + id                     = (known after apply)
      + node_name              = "pve"
      + overwrite              = true
      + timeout_upload         = 1800

      + source_raw {
          + data      = <<-EOT
                #cloud-config
                hostname: test-ubuntu
                timezone: America/Toronto
                users:
                  - default
                  - name: ubuntu
                    groups:
                      - sudo
                    shell: /bin/bash
                    ssh_authorized_keys:
                      - ssh-rsa REDACTER
                    sudo: ALL=(ALL) NOPASSWD:ALL
                package_update: true
                packages:
                  - qemu-guest-agent
                  - net-tools
                  - curl
                runcmd:
                  - systemctl enable qemu-guest-agent
                  - systemctl start qemu-guest-agent
                  - echo "done" > /tmp/cloud-config.done
            EOT
          + file_name = "user-data-cloud-config.yaml"
          + resize    = 0
        }
    }

  # proxmox_virtual_environment_vm.ubuntu_clone will be created
  + resource "proxmox_virtual_environment_vm" "ubuntu_clone" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "ubuntu-clone"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = true
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + agent {
          + enabled = true
          + timeout = "15m"
          + trim    = false
          + type    = "virtio"
        }

      + clone {
          + full    = true
          + retries = 1
          + vm_id   = (known after apply)
        }

      + initialization {
          + datastore_id = "local-lvm"

          + dns {
              + servers = [
                  + "1.1.1.1",
                ]
            }

          + ip_config {
              + ipv4 {
                  + address = "dhcp"
                }
            }
        }

      + memory {
          + dedicated      = 768
          + floating       = 0
          + keep_hugepages = false
          + shared         = 0
        }
    }

  # proxmox_virtual_environment_vm.ubuntu_template will be created
  + resource "proxmox_virtual_environment_vm" "ubuntu_template" {
      + acpi                    = true
      + bios                    = "ovmf"
      + description             = "Managed by Terraform"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + machine                 = "q35"
      + migrate                 = false
      + name                    = "ubuntu-template"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = true
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + cpu {
          + cores      = 2
          + hotplugged = 0
          + limit      = 0
          + numa       = false
          + sockets    = 1
          + type       = "qemu64"
          + units      = 1024
        }

      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "on"
          + file_format       = (known after apply)
          + file_id           = (known after apply)
          + interface         = "virtio0"
          + iothread          = true
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 20
          + ssd               = false
        }

      + efi_disk {
          + datastore_id      = "local"
          + file_format       = (known after apply)
          + pre_enrolled_keys = false
          + type              = "4m"
        }

      + initialization {
          + datastore_id      = "local-lvm"
          + user_data_file_id = (known after apply)

          + ip_config {
              + ipv4 {
                  + address = "dhcp"
                }
            }
        }

      + memory {
          + dedicated      = 2048
          + floating       = 0
          + keep_hugepages = false
          + shared         = 0
        }

      + network_device {
          + bridge      = "vmbr0"
          + enabled     = true
          + firewall    = false
          + mac_address = (known after apply)
          + model       = "virtio"
          + mtu         = 0
          + queues      = 0
          + rate_limit  = 0
          + vlan_id     = 0
        }
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + vm_ipv4_address = (known after apply)
proxmox_virtual_environment_file.user_data_cloud_config: Creating...
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Creating...
proxmox_virtual_environment_file.user_data_cloud_config: Creation complete after 1s [id=local:snippets/user-data-cloud-config.yaml]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Still creating... [10s elapsed]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Still creating... [20s elapsed]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Still creating... [30s elapsed]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Still creating... [40s elapsed]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Creation complete after 46s [id=local:iso/jammy-server-cloudimg-amd64.img]
proxmox_virtual_environment_vm.ubuntu_template: Creating...
proxmox_virtual_environment_vm.ubuntu_template: Still creating... [10s elapsed]
proxmox_virtual_environment_vm.ubuntu_template: Creation complete after 15s [id=100]
proxmox_virtual_environment_vm.ubuntu_clone: Creating...
proxmox_virtual_environment_vm.ubuntu_clone: Still creating... [10s elapsed]
proxmox_virtual_environment_vm.ubuntu_clone: Still creating... [20s elapsed]
proxmox_virtual_environment_vm.ubuntu_clone: Still creating... [30s elapsed]
proxmox_virtual_environment_vm.ubuntu_clone: Still creating... [40s elapsed]
proxmox_virtual_environment_vm.ubuntu_clone: Still creating... [50s elapsed]
proxmox_virtual_environment_vm.ubuntu_clone: Creation complete after 59s [id=101]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

vm_ipv4_address = "172.17.225.25"

❯ tofu plan
data.local_file.ssh_public_key: Reading...
data.local_file.ssh_public_key: Read complete after 0s [id=84cdc3a1d1eaa8e821cd6dd4287f04ae996b8309]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Refreshing state... [id=local:iso/jammy-server-cloudimg-amd64.img]
proxmox_virtual_environment_file.user_data_cloud_config: Refreshing state... [id=local:snippets/user-data-cloud-config.yaml]
proxmox_virtual_environment_vm.ubuntu_template: Refreshing state... [id=100]
proxmox_virtual_environment_vm.ubuntu_clone: Refreshing state... [id=101]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.ubuntu_clone must be replaced
-/+ resource "proxmox_virtual_environment_vm" "ubuntu_clone" {
      ~ id                      = "101" -> (known after apply)
      ~ ipv4_addresses          = [
          - [
              - "127.0.0.1",
            ],
          - [
              - "172.17.225.25",
            ],
        ] -> (known after apply)
      ~ ipv6_addresses          = [
          - [
              - "::1",
            ],
          - [
              - "fe80::be24:11ff:febd:d7eb",
            ],
        ] -> (known after apply)
      ~ mac_addresses           = [
          - "00:00:00:00:00:00",
          - "BC:24:11:BD:D7:EB",
        ] -> (known after apply)
        name                    = "ubuntu-clone"
      ~ network_interface_names = [
          - "lo",
          - "eth0",
        ] -> (known after apply)
      ~ vm_id                   = 101 -> (known after apply)
        # (22 unchanged attributes hidden)

      ~ initialization {
          - interface         = "ide2" -> null
          - user_data_file_id = "local:snippets/user-data-cloud-config.yaml" -> null # forces replacement
            # (1 unchanged attribute hidden)

            # (2 unchanged blocks hidden)
        }

      - network_device {
          - bridge       = "vmbr0" -> null
          - disconnected = false -> null
          - enabled      = true -> null
          - firewall     = false -> null
          - mac_address  = "BC:24:11:BD:D7:EB" -> null
          - model        = "virtio" -> null
          - mtu          = 0 -> null
          - queues       = 0 -> null
          - rate_limit   = 0 -> null
          - vlan_id      = 0 -> null
        }

        # (3 unchanged blocks hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  ~ vm_ipv4_address = "172.17.225.25" -> (known after apply)

```

After the fix
```
❯ tofu apply -auto-approve
data.local_file.ssh_public_key: Reading...
data.local_file.ssh_public_key: Read complete after 0s [id=84cdc3a1d1eaa8e821cd6dd4287f04ae996b8309]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_download_file.ubuntu_cloud_image will be created
  + resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
      + content_type        = "iso"
      + datastore_id        = "local"
      + file_name           = (known after apply)
      + id                  = (known after apply)
      + node_name           = "pve"
      + overwrite           = true
      + overwrite_unmanaged = false
      + size                = (known after apply)
      + upload_timeout      = 600
      + url                 = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
      + verify              = true
    }

  # proxmox_virtual_environment_file.user_data_cloud_config will be created
  + resource "proxmox_virtual_environment_file" "user_data_cloud_config" {
      + content_type           = "snippets"
      + datastore_id           = "local"
      + file_modification_date = (known after apply)
      + file_name              = (known after apply)
      + file_size              = (known after apply)
      + file_tag               = (known after apply)
      + id                     = (known after apply)
      + node_name              = "pve"
      + overwrite              = true
      + timeout_upload         = 1800

      + source_raw {
          + data      = <<-EOT
                #cloud-config
                hostname: test-ubuntu
                timezone: America/Toronto
                users:
                  - default
                  - name: ubuntu
                    groups:
                      - sudo
                    shell: /bin/bash
                    ssh_authorized_keys:
                      - ssh-rsa REDACTED
                    sudo: ALL=(ALL) NOPASSWD:ALL
                package_update: true
                packages:
                  - qemu-guest-agent
                  - net-tools
                  - curl
                runcmd:
                  - systemctl enable qemu-guest-agent
                  - systemctl start qemu-guest-agent
                  - echo "done" > /tmp/cloud-config.done
            EOT
          + file_name = "user-data-cloud-config.yaml"
          + resize    = 0
        }
    }

  # proxmox_virtual_environment_vm.ubuntu_clone will be created
  + resource "proxmox_virtual_environment_vm" "ubuntu_clone" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "ubuntu-clone"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = true
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + agent {
          + enabled = true
          + timeout = "15m"
          + trim    = false
          + type    = "virtio"
        }

      + clone {
          + full    = true
          + retries = 1
          + vm_id   = (known after apply)
        }

      + initialization {
          + datastore_id         = "local-lvm"
          + meta_data_file_id    = (known after apply)
          + network_data_file_id = (known after apply)
          + type                 = (known after apply)
          + user_data_file_id    = (known after apply)
          + vendor_data_file_id  = (known after apply)

          + dns {
              + servers = [
                  + "1.1.1.1",
                ]
            }

          + ip_config {
              + ipv4 {
                  + address = "dhcp"
                }
            }
        }

      + memory {
          + dedicated      = 768
          + floating       = 0
          + keep_hugepages = false
          + shared         = 0
        }

      + network_device (known after apply)
    }

  # proxmox_virtual_environment_vm.ubuntu_template will be created
  + resource "proxmox_virtual_environment_vm" "ubuntu_template" {
      + acpi                    = true
      + bios                    = "ovmf"
      + description             = "Managed by Terraform"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + machine                 = "q35"
      + migrate                 = false
      + name                    = "ubuntu-template"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = true
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + cpu {
          + cores      = 2
          + hotplugged = 0
          + limit      = 0
          + numa       = false
          + sockets    = 1
          + type       = "qemu64"
          + units      = 1024
        }

      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "on"
          + file_format       = (known after apply)
          + file_id           = (known after apply)
          + interface         = "virtio0"
          + iothread          = true
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 20
          + ssd               = false
        }

      + efi_disk {
          + datastore_id      = "local"
          + file_format       = (known after apply)
          + pre_enrolled_keys = false
          + type              = "4m"
        }

      + initialization {
          + datastore_id         = "local-lvm"
          + meta_data_file_id    = (known after apply)
          + network_data_file_id = (known after apply)
          + type                 = (known after apply)
          + user_data_file_id    = (known after apply)
          + vendor_data_file_id  = (known after apply)

          + ip_config {
              + ipv4 {
                  + address = "dhcp"
                }
            }
        }

      + memory {
          + dedicated      = 2048
          + floating       = 0
          + keep_hugepages = false
          + shared         = 0
        }

      + network_device {
          + bridge      = "vmbr0"
          + enabled     = true
          + firewall    = false
          + mac_address = (known after apply)
          + model       = "virtio"
          + mtu         = 0
          + queues      = 0
          + rate_limit  = 0
          + vlan_id     = 0
        }
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + vm_ipv4_address = (known after apply)
proxmox_virtual_environment_file.user_data_cloud_config: Creating...
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Creating...
proxmox_virtual_environment_file.user_data_cloud_config: Creation complete after 1s [id=local:snippets/user-data-cloud-config.yaml]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Still creating... [10s elapsed]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Still creating... [20s elapsed]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Still creating... [30s elapsed]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Still creating... [40s elapsed]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Creation complete after 43s [id=local:iso/jammy-server-cloudimg-amd64.img]
proxmox_virtual_environment_vm.ubuntu_template: Creating...
proxmox_virtual_environment_vm.ubuntu_template: Still creating... [10s elapsed]
proxmox_virtual_environment_vm.ubuntu_template: Creation complete after 15s [id=100]
proxmox_virtual_environment_vm.ubuntu_clone: Creating...
proxmox_virtual_environment_vm.ubuntu_clone: Still creating... [10s elapsed]
proxmox_virtual_environment_vm.ubuntu_clone: Still creating... [20s elapsed]
proxmox_virtual_environment_vm.ubuntu_clone: Still creating... [30s elapsed]
proxmox_virtual_environment_vm.ubuntu_clone: Still creating... [40s elapsed]
proxmox_virtual_environment_vm.ubuntu_clone: Still creating... [50s elapsed]
proxmox_virtual_environment_vm.ubuntu_clone: Creation complete after 56s [id=101]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

vm_ipv4_address = "172.17.225.27"
❯ tofu plan
data.local_file.ssh_public_key: Reading...
data.local_file.ssh_public_key: Read complete after 0s [id=84cdc3a1d1eaa8e821cd6dd4287f04ae996b8309]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Refreshing state... [id=local:iso/jammy-server-cloudimg-amd64.img]
proxmox_virtual_environment_file.user_data_cloud_config: Refreshing state... [id=local:snippets/user-data-cloud-config.yaml]
proxmox_virtual_environment_vm.ubuntu_template: Refreshing state... [id=100]
proxmox_virtual_environment_vm.ubuntu_clone: Refreshing state... [id=101]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1299
Relates #1788

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Certain VM and network device attributes are now automatically set by the provider if not specified by the user.

- **Refactor**
  - Updated several VM and network device settings to remove default values and instead mark them as computed, streamlining configuration and reducing the need for manual input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->