### PR TITLE
fix(container): do not reboot for cpu block changes

### DIFF
--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -2912,8 +2912,6 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m interface{})
 		updateBody.CPUArchitecture = &cpuArchitecture
 		updateBody.CPUCores = &cpuCores
 		updateBody.CPUUnits = &cpuUnits
-
-		rebootRequired = true
 	}
 
 	if d.HasChange(mkFeatures) {


### PR DESCRIPTION
### Contributor's Note

Removed rebootRequired in containerUpdate function when changes are being applied to the cpu. Tested the build in my cluster and this fixes the bug reported in #1920

<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.

### Proof of Work
![Screenshot from 2025-04-26 22-19-08](https://github.com/user-attachments/assets/a7b6b0ea-dd4b-442b-88f0-6ec7ff54ffda)

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes [#1920](https://github.com/bpg/terraform-provider-proxmox/issues/1920)

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
