### PR TITLE
feat(lxc): increase number of supported mount points to 256

### DIFF
--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -120,7 +120,10 @@ func TestAccResourceContainer(t *testing.T) {
 
 						ctInfo, err := ct.GetContainer(ctx)
 						require.NoError(te.t, err, "failed to get container")
-						require.NotNil(te.t, ctInfo.DevicePassthrough0)
+						dev0, ok := ctInfo.PassthroughDevices["dev0"]
+						require.True(te.t, ok, `"dev0" passthrough device not found`)
+						require.NotNil(te.t, dev0, `"dev0" passthrough device is <nil>`)
+						require.Equal(te.t, "/dev/zero", dev0.Path)
 
 						return nil
 					},
@@ -309,7 +312,10 @@ func TestAccResourceContainer(t *testing.T) {
 
 					ctInfo, err := ct.GetContainer(ctx)
 					require.NoError(te.t, err, "failed to get container")
-					require.NotNil(te.t, ctInfo.DevicePassthrough0)
+					dev0, ok := ctInfo.PassthroughDevices["dev0"]
+					require.True(te.t, ok, `"dev0" passthrough device not found`)
+					require.NotNil(te.t, dev0, `"dev0" passthrough device is <nil>`)
+					require.Equal(te.t, "/dev/zero", dev0.Path)
 
 					return nil
 				},

--- a/proxmox/nodes/containers/containers_types.go
+++ b/proxmox/nodes/containers/containers_types.go
@@ -551,7 +551,7 @@ func (r *CustomRootFS) EncodeValues(key string, v *url.Values) error {
 	}
 
 	if r.Replicate != nil {
-		if *r.ReadOnly {
+		if *r.Replicate {
 			values = append(values, "replicate=1")
 		} else {
 			values = append(values, "replicate=0")

--- a/proxmox/nodes/containers/containers_types.go
+++ b/proxmox/nodes/containers/containers_types.go
@@ -10,10 +10,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
+)
+
+var (
+	// regexDeviceKey matches device keys like dev0, dev1, etc.
+	regexDeviceKey = regexp.MustCompile(`^dev\d+$`)
+	// regexNetworkKey matches network interface keys like net0, net1, etc.
+	regexNetworkKey = regexp.MustCompile(`^net\d+$`)
+	// regexMountPointKey matches mount point keys like mp0, mp1, etc.
+	regexMountPointKey = regexp.MustCompile(`^mp\d+$`)
 )
 
 // CloneRequestBody contains the data for an container clone request.
@@ -31,46 +41,46 @@ type CloneRequestBody struct {
 
 // CreateRequestBody contains the data for a user create request.
 type CreateRequestBody struct {
-	BandwidthLimit       *float64                     `json:"bwlimit,omitempty"              url:"bwlimit,omitempty"`
-	ConsoleEnabled       *types.CustomBool            `json:"console,omitempty"              url:"console,omitempty,int"`
-	ConsoleMode          *string                      `json:"cmode,omitempty"                url:"cmode,omitempty"`
-	CPUArchitecture      *string                      `json:"arch,omitempty"                 url:"arch,omitempty"`
-	CPUCores             *int                         `json:"cores,omitempty"                url:"cores,omitempty"`
-	CPULimit             *int                         `json:"cpulimit,omitempty"             url:"cpulimit,omitempty"`
-	CPUUnits             *int                         `json:"cpuunits,omitempty"             url:"cpuunits,omitempty"`
-	DatastoreID          *string                      `json:"storage,omitempty"              url:"storage,omitempty"`
-	DedicatedMemory      *int                         `json:"memory,omitempty"               url:"memory,omitempty"`
-	Delete               []string                     `json:"delete,omitempty"               url:"delete,omitempty"`
-	Description          *string                      `json:"description,omitempty"          url:"description,omitempty"`
-	DNSDomain            *string                      `json:"searchdomain,omitempty"         url:"searchdomain,omitempty"`
-	DNSServer            *string                      `json:"nameserver,omitempty"           url:"nameserver,omitempty"`
-	Features             *CustomFeatures              `json:"features,omitempty"             url:"features,omitempty"`
-	Force                *types.CustomBool            `json:"force,omitempty"                url:"force,omitempty,int"`
-	HookScript           *string                      `json:"hookscript,omitempty"           url:"hookscript,omitempty"`
-	Hostname             *string                      `json:"hostname,omitempty"             url:"hostname,omitempty"`
-	IgnoreUnpackErrors   *types.CustomBool            `json:"ignore-unpack-errors,omitempty" url:"force,omitempty,int"`
-	Lock                 *string                      `json:"lock,omitempty"                 url:"lock,omitempty,int"`
-	MountPoints          CustomMountPointArray        `json:"mp,omitempty"                   url:"mp,omitempty,numbered"`
-	DevicePassthrough    CustomDevicePassthroughArray `json:"dev,omitempty"                  url:"dev,omitempty,numbered"`
-	NetworkInterfaces    CustomNetworkInterfaceArray  `json:"net,omitempty"                  url:"net,omitempty,numbered"`
-	OSTemplateFileVolume *string                      `json:"ostemplate,omitempty"           url:"ostemplate,omitempty"`
-	OSType               *string                      `json:"ostype,omitempty"               url:"ostype,omitempty"`
-	Password             *string                      `json:"password,omitempty"             url:"password,omitempty"`
-	PoolID               *string                      `json:"pool,omitempty"                 url:"pool,omitempty"`
-	Protection           *types.CustomBool            `json:"protection,omitempty"           url:"protection,omitempty,int"`
-	Restore              *types.CustomBool            `json:"restore,omitempty"              url:"restore,omitempty,int"`
-	RootFS               *CustomRootFS                `json:"rootfs,omitempty"               url:"rootfs,omitempty"`
-	SSHKeys              *CustomSSHKeys               `json:"ssh-public-keys,omitempty"      url:"ssh-public-keys,omitempty"`
-	Start                *types.CustomBool            `json:"start,omitempty"                url:"start,omitempty,int"`
-	StartOnBoot          *types.CustomBool            `json:"onboot,omitempty"               url:"onboot,omitempty,int"`
-	StartupBehavior      *CustomStartupBehavior       `json:"startup,omitempty"              url:"startup,omitempty"`
-	Swap                 *int                         `json:"swap,omitempty"                 url:"swap,omitempty"`
-	Tags                 *string                      `json:"tags,omitempty"                 url:"tags,omitempty"`
-	Template             *types.CustomBool            `json:"template,omitempty"             url:"template,omitempty,int"`
-	TTY                  *int                         `json:"tty,omitempty"                  url:"tty,omitempty"`
-	Unique               *types.CustomBool            `json:"unique,omitempty"               url:"unique,omitempty,int"`
-	Unprivileged         *types.CustomBool            `json:"unprivileged,omitempty"         url:"unprivileged,omitempty,int"`
-	VMID                 *int                         `json:"vmid,omitempty"                 url:"vmid,omitempty"`
+	BandwidthLimit       *float64                 `json:"bwlimit,omitempty"              url:"bwlimit,omitempty"`
+	ConsoleEnabled       *types.CustomBool        `json:"console,omitempty"              url:"console,omitempty,int"`
+	ConsoleMode          *string                  `json:"cmode,omitempty"                url:"cmode,omitempty"`
+	CPUArchitecture      *string                  `json:"arch,omitempty"                 url:"arch,omitempty"`
+	CPUCores             *int                     `json:"cores,omitempty"                url:"cores,omitempty"`
+	CPULimit             *int                     `json:"cpulimit,omitempty"             url:"cpulimit,omitempty"`
+	CPUUnits             *int                     `json:"cpuunits,omitempty"             url:"cpuunits,omitempty"`
+	DatastoreID          *string                  `json:"storage,omitempty"              url:"storage,omitempty"`
+	DedicatedMemory      *int                     `json:"memory,omitempty"               url:"memory,omitempty"`
+	Delete               []string                 `json:"delete,omitempty"               url:"delete,omitempty"`
+	Description          *string                  `json:"description,omitempty"          url:"description,omitempty"`
+	DNSDomain            *string                  `json:"searchdomain,omitempty"         url:"searchdomain,omitempty"`
+	DNSServer            *string                  `json:"nameserver,omitempty"           url:"nameserver,omitempty"`
+	Features             *CustomFeatures          `json:"features,omitempty"             url:"features,omitempty"`
+	Force                *types.CustomBool        `json:"force,omitempty"                url:"force,omitempty,int"`
+	HookScript           *string                  `json:"hookscript,omitempty"           url:"hookscript,omitempty"`
+	Hostname             *string                  `json:"hostname,omitempty"             url:"hostname,omitempty"`
+	IgnoreUnpackErrors   *types.CustomBool        `json:"ignore-unpack-errors,omitempty" url:"force,omitempty,int"`
+	Lock                 *string                  `json:"lock,omitempty"                 url:"lock,omitempty,int"`
+	MountPoints          CustomMountPoints        `json:"mp,omitempty"                   url:"mp,omitempty,numbered"`
+	PassthroughDevices   CustomPassthroughDevices `json:"dev,omitempty"                  url:"dev,omitempty,numbered"`
+	NetworkInterfaces    CustomNetworkInterfaces  `json:"net,omitempty"                  url:"net,omitempty,numbered"`
+	OSTemplateFileVolume *string                  `json:"ostemplate,omitempty"           url:"ostemplate,omitempty"`
+	OSType               *string                  `json:"ostype,omitempty"               url:"ostype,omitempty"`
+	Password             *string                  `json:"password,omitempty"             url:"password,omitempty"`
+	PoolID               *string                  `json:"pool,omitempty"                 url:"pool,omitempty"`
+	Protection           *types.CustomBool        `json:"protection,omitempty"           url:"protection,omitempty,int"`
+	Restore              *types.CustomBool        `json:"restore,omitempty"              url:"restore,omitempty,int"`
+	RootFS               *CustomRootFS            `json:"rootfs,omitempty"               url:"rootfs,omitempty"`
+	SSHKeys              *CustomSSHKeys           `json:"ssh-public-keys,omitempty"      url:"ssh-public-keys,omitempty"`
+	Start                *types.CustomBool        `json:"start,omitempty"                url:"start,omitempty,int"`
+	StartOnBoot          *types.CustomBool        `json:"onboot,omitempty"               url:"onboot,omitempty,int"`
+	StartupBehavior      *CustomStartupBehavior   `json:"startup,omitempty"              url:"startup,omitempty"`
+	Swap                 *int                     `json:"swap,omitempty"                 url:"swap,omitempty"`
+	Tags                 *string                  `json:"tags,omitempty"                 url:"tags,omitempty"`
+	Template             *types.CustomBool        `json:"template,omitempty"             url:"template,omitempty,int"`
+	TTY                  *int                     `json:"tty,omitempty"                  url:"tty,omitempty"`
+	Unique               *types.CustomBool        `json:"unique,omitempty"               url:"unique,omitempty,int"`
+	Unprivileged         *types.CustomBool        `json:"unprivileged,omitempty"         url:"unprivileged,omitempty,int"`
+	VMID                 *int                     `json:"vmid,omitempty"                 url:"vmid,omitempty"`
 }
 
 // CustomFeatures contains the values for the "features" property.
@@ -96,8 +106,8 @@ type CustomMountPoint struct {
 	Volume       string            `json:"volume"                 url:"volume"`
 }
 
-// CustomMountPointArray is an array of CustomMountPoint.
-type CustomMountPointArray []CustomMountPoint
+// CustomMountPoints is a map of CustomMountPoint per mount point ID (i.e. `mp1`).
+type CustomMountPoints map[string]*CustomMountPoint
 
 // CustomNetworkInterface contains the values for the "net[n]" properties.
 type CustomNetworkInterface struct {
@@ -117,11 +127,11 @@ type CustomNetworkInterface struct {
 	Type        *string           `json:"type,omitempty"     url:"type,omitempty"`
 }
 
-// CustomDevicePassthroughArray is an array of CustomDevicePassthrough.
-type CustomDevicePassthroughArray []CustomDevicePassthrough
+// CustomPassthroughDevices is a map of CustomPassthroughDevice per passthrough device ID (i.e. `dev0`).
+type CustomPassthroughDevices map[string]*CustomPassthroughDevice
 
-// CustomDevicePassthrough contains the values for the "dev[n]" properties.
-type CustomDevicePassthrough struct {
+// CustomPassthroughDevice contains the values for the "dev[n]" properties.
+type CustomPassthroughDevice struct {
 	DenyWrite *types.CustomBool `json:"deny-write,omitempty" url:"deny-write,omitempty,int"`
 	Path      string            `json:"path"                 url:"path"`
 	UID       *int              `json:"uid,omitempty"        url:"uid,omitempty"`
@@ -129,8 +139,8 @@ type CustomDevicePassthrough struct {
 	Mode      *string           `json:"mode,omitempty"       url:"mode,omitempty"`
 }
 
-// CustomNetworkInterfaceArray is an array of CustomNetworkInterface.
-type CustomNetworkInterfaceArray []CustomNetworkInterface
+// CustomNetworkInterfaces is a map of CustomNetworkInterface per network interface ID (i.e. `net0`).
+type CustomNetworkInterfaces map[string]*CustomNetworkInterface
 
 // CustomRootFS contains the values for the "rootfs" property.
 type CustomRootFS struct {
@@ -184,30 +194,9 @@ type GetResponseData struct {
 	Hostname           *string                  `json:"hostname,omitempty"`
 	Lock               *types.CustomBool        `json:"lock,omitempty"`
 	LXCConfiguration   *[][2]string             `json:"lxc,omitempty"`
-	DevicePassthrough0 *CustomDevicePassthrough `json:"dev0,omitempty"`
-	DevicePassthrough1 *CustomDevicePassthrough `json:"dev1,omitempty"`
-	DevicePassthrough2 *CustomDevicePassthrough `json:"dev2,omitempty"`
-	DevicePassthrough3 *CustomDevicePassthrough `json:"dev3,omitempty"`
-	DevicePassthrough4 *CustomDevicePassthrough `json:"dev4,omitempty"`
-	DevicePassthrough5 *CustomDevicePassthrough `json:"dev5,omitempty"`
-	DevicePassthrough6 *CustomDevicePassthrough `json:"dev6,omitempty"`
-	DevicePassthrough7 *CustomDevicePassthrough `json:"dev7,omitempty"`
-	MountPoint0        *CustomMountPoint        `json:"mp0,omitempty"`
-	MountPoint1        *CustomMountPoint        `json:"mp1,omitempty"`
-	MountPoint2        *CustomMountPoint        `json:"mp2,omitempty"`
-	MountPoint3        *CustomMountPoint        `json:"mp3,omitempty"`
-	MountPoint4        *CustomMountPoint        `json:"mp4,omitempty"`
-	MountPoint5        *CustomMountPoint        `json:"mp5,omitempty"`
-	MountPoint6        *CustomMountPoint        `json:"mp6,omitempty"`
-	MountPoint7        *CustomMountPoint        `json:"mp7,omitempty"`
-	NetworkInterface0  *CustomNetworkInterface  `json:"net0,omitempty"`
-	NetworkInterface1  *CustomNetworkInterface  `json:"net1,omitempty"`
-	NetworkInterface2  *CustomNetworkInterface  `json:"net2,omitempty"`
-	NetworkInterface3  *CustomNetworkInterface  `json:"net3,omitempty"`
-	NetworkInterface4  *CustomNetworkInterface  `json:"net4,omitempty"`
-	NetworkInterface5  *CustomNetworkInterface  `json:"net5,omitempty"`
-	NetworkInterface6  *CustomNetworkInterface  `json:"net6,omitempty"`
-	NetworkInterface7  *CustomNetworkInterface  `json:"net7,omitempty"`
+	MountPoints        CustomMountPoints        `json:"mp,omitempty"`
+	PassthroughDevices CustomPassthroughDevices `json:"dev,omitempty"`
+	NetworkInterfaces  CustomNetworkInterfaces  `json:"net,omitempty"`
 	OSType             *string                  `json:"ostype,omitempty"`
 	Protection         *types.CustomBool        `json:"protection,omitempty"`
 	RootFS             *CustomRootFS            `json:"rootfs,omitempty"`
@@ -299,8 +288,8 @@ func (r *CustomFeatures) EncodeValues(key string, v *url.Values) error {
 	return nil
 }
 
-// EncodeValues converts a CustomDevicePassthrough struct to a URL value.
-func (r *CustomDevicePassthrough) EncodeValues(key string, v *url.Values) error {
+// EncodeValues converts a CustomPassthroughDevice struct to a URL value.
+func (r *CustomPassthroughDevice) EncodeValues(key string, v *url.Values) error {
 	var values []string
 
 	if r.DenyWrite != nil {
@@ -334,14 +323,14 @@ func (r *CustomDevicePassthrough) EncodeValues(key string, v *url.Values) error 
 	return nil
 }
 
-// EncodeValues converts a CustomDevicePassthroughArray array to multiple URL values.
-func (r CustomDevicePassthroughArray) EncodeValues(
-	key string,
+// EncodeValues converts a CustomPassthroughDevices array to multiple URL values.
+func (r CustomPassthroughDevices) EncodeValues(
+	_ string,
 	v *url.Values,
 ) error {
-	for i, d := range r {
-		if err := d.EncodeValues(fmt.Sprintf("%s%d", key, i), v); err != nil {
-			return fmt.Errorf("failed to encode CustomDevicePassthroughArray: %w", err)
+	for key, d := range r {
+		if err := d.EncodeValues(key, v); err != nil {
+			return fmt.Errorf("failed to encode CustomPassthroughDevices: %w", err)
 		}
 	}
 
@@ -421,14 +410,14 @@ func (r *CustomMountPoint) EncodeValues(key string, v *url.Values) error {
 	return nil
 }
 
-// EncodeValues converts a CustomMountPointArray array to multiple URL values.
-func (r CustomMountPointArray) EncodeValues(
-	key string,
+// EncodeValues converts a CustomMountPoints array to multiple URL values.
+func (r CustomMountPoints) EncodeValues(
+	_ string,
 	v *url.Values,
 ) error {
-	for i, d := range r {
-		if err := d.EncodeValues(fmt.Sprintf("%s%d", key, i), v); err != nil {
-			return fmt.Errorf("failed to encode CustomMountPointArray: %w", err)
+	for key, d := range r {
+		if err := d.EncodeValues(key, v); err != nil {
+			return fmt.Errorf("failed to encode CustomMountPoints: %w", err)
 		}
 	}
 
@@ -509,14 +498,14 @@ func (r *CustomNetworkInterface) EncodeValues(
 	return nil
 }
 
-// EncodeValues converts a CustomNetworkInterfaceArray array to multiple URL values.
-func (r CustomNetworkInterfaceArray) EncodeValues(
-	key string,
+// EncodeValues converts a CustomNetworkInterfaces array to multiple URL values.
+func (r CustomNetworkInterfaces) EncodeValues(
+	_ string,
 	v *url.Values,
 ) error {
-	for i, d := range r {
-		if err := d.EncodeValues(fmt.Sprintf("%s%d", key, i), v); err != nil {
-			return fmt.Errorf("failed to encode CustomNetworkInterfaceArray: %w", err)
+	for key, d := range r {
+		if err := d.EncodeValues(key, v); err != nil {
+			return fmt.Errorf("failed to encode CustomNetworkInterfaces: %w", err)
 		}
 	}
 
@@ -659,13 +648,13 @@ func (r *CustomFeatures) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// UnmarshalJSON converts a CustomDevicePassthrough string to an object.
-func (r *CustomDevicePassthrough) UnmarshalJSON(b []byte) error {
+// UnmarshalJSON converts a CustomPassthroughDevice string to an object.
+func (r *CustomPassthroughDevice) UnmarshalJSON(b []byte) error {
 	var s string
 
 	err := json.Unmarshal(b, &s)
 	if err != nil {
-		return fmt.Errorf("unable to unmarshal CustomDevicePassthrough: %w", err)
+		return fmt.Errorf("unable to unmarshal CustomPassthroughDevice: %w", err)
 	}
 
 	pairs := strings.Split(s, ",")
@@ -944,6 +933,69 @@ func (r *CustomStartupBehavior) UnmarshalJSON(b []byte) error {
 			}
 		}
 	}
+
+	return nil
+}
+
+// UnmarshalJSON unmarshals the data from the JSON response, populating the CustomStorageDevices field.
+func (d *GetResponseData) UnmarshalJSON(b []byte) error {
+	type Alias GetResponseData
+
+	var data Alias
+
+	// get original struct
+	if err := json.Unmarshal(b, &data); err != nil {
+		return fmt.Errorf("failed to unmarshal data: %w", err)
+	}
+
+	var byAttr map[string]interface{}
+
+	// now get map by attribute name
+	err := json.Unmarshal(b, &byAttr)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal data: %w", err)
+	}
+
+	data.PassthroughDevices = make(CustomPassthroughDevices)
+	data.NetworkInterfaces = make(CustomNetworkInterfaces)
+	data.MountPoints = make(CustomMountPoints)
+
+	for key, value := range byAttr {
+		valueStr, ok := value.(string)
+		if !ok {
+			continue // Skip non-string values
+		}
+
+		jsonValue := []byte(`"` + valueStr + `"`)
+
+		switch {
+		case regexDeviceKey.MatchString(key):
+			var device CustomPassthroughDevice
+			if e := json.Unmarshal(jsonValue, &device); e != nil {
+				return fmt.Errorf("failed to unmarshal %s: %w", key, e)
+			}
+
+			data.PassthroughDevices[key] = &device
+
+		case regexNetworkKey.MatchString(key):
+			var net CustomNetworkInterface
+			if e := json.Unmarshal(jsonValue, &net); e != nil {
+				return fmt.Errorf("failed to unmarshal %s: %w", key, e)
+			}
+
+			data.NetworkInterfaces[key] = &net
+
+		case regexMountPointKey.MatchString(key):
+			var mp CustomMountPoint
+			if e := json.Unmarshal(jsonValue, &mp); e != nil {
+				return fmt.Errorf("failed to unmarshal %s: %w", key, e)
+			}
+
+			data.MountPoints[key] = &mp
+		}
+	}
+
+	*d = GetResponseData(data)
 
 	return nil
 }

--- a/proxmox/nodes/containers/containers_types.go
+++ b/proxmox/nodes/containers/containers_types.go
@@ -343,7 +343,7 @@ func (r *CustomMountPoint) EncodeValues(key string, v *url.Values) error {
 
 	if r.ACL != nil {
 		if *r.ACL {
-			values = append(values, "acl=%d")
+			values = append(values, "acl=1")
 		} else {
 			values = append(values, "acl=0")
 		}
@@ -518,7 +518,7 @@ func (r *CustomRootFS) EncodeValues(key string, v *url.Values) error {
 
 	if r.ACL != nil {
 		if *r.ACL {
-			values = append(values, "acl=%d")
+			values = append(values, "acl=1")
 		} else {
 			values = append(values, "acl=0")
 		}
@@ -972,7 +972,7 @@ func (d *GetResponseData) UnmarshalJSON(b []byte) error {
 		case regexDeviceKey.MatchString(key):
 			var device CustomPassthroughDevice
 			if e := json.Unmarshal(jsonValue, &device); e != nil {
-				return fmt.Errorf("failed to unmarshal %s: %w", key, e)
+				return fmt.Errorf("failed to unmarshal %s with value %q: %w", key, valueStr, e)
 			}
 
 			data.PassthroughDevices[key] = &device
@@ -980,7 +980,7 @@ func (d *GetResponseData) UnmarshalJSON(b []byte) error {
 		case regexNetworkKey.MatchString(key):
 			var net CustomNetworkInterface
 			if e := json.Unmarshal(jsonValue, &net); e != nil {
-				return fmt.Errorf("failed to unmarshal %s: %w", key, e)
+				return fmt.Errorf("failed to unmarshal %s with value %q: %w", key, valueStr, e)
 			}
 
 			data.NetworkInterfaces[key] = &net
@@ -988,7 +988,7 @@ func (d *GetResponseData) UnmarshalJSON(b []byte) error {
 		case regexMountPointKey.MatchString(key):
 			var mp CustomMountPoint
 			if e := json.Unmarshal(jsonValue, &mp); e != nil {
-				return fmt.Errorf("failed to unmarshal %s: %w", key, e)
+				return fmt.Errorf("failed to unmarshal %s with value %q: %w", key, valueStr, e)
 			}
 
 			data.MountPoints[key] = &mp

--- a/utils/maps_test.go
+++ b/utils/maps_test.go
@@ -1,8 +1,16 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 package utils
 
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOrderedListFromMap(t *testing.T) {
@@ -70,5 +78,43 @@ func TestOrderedListFromMapByKeyValues(t *testing.T) {
 
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("OrderedListFromMapByKeyValues() = %v, want %v", result, expected)
+	}
+}
+
+func TestCompareWithPrefix(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		a string
+		b string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{"equal", args{"a", "a"}, 0},
+		{"a < b", args{"a", "b"}, -1},
+		{"b > a", args{"b", "a"}, 1},
+		{"a < b with prefix", args{"a1", "a2"}, -1},
+		{"b > a with prefix", args{"a2", "a1"}, 1},
+		{"a < b with different prefix", args{"a1", "b1"}, -1},
+		{"b > a with different prefix", args{"b1", "a1"}, 1},
+		{"a < b with different prefix and numbers", args{"a1", "a10"}, -1},
+		{"b > a with different prefix and numbers", args{"a10", "a1"}, 1},
+		{"a < b with different prefix and numbers", args{"a10", "b1"}, -1},
+		{"b > a with different prefix and numbers", args{"b1", "a10"}, 1},
+		{"a < b with different prefix and numbers", args{"a10", "b10"}, -1},
+		{"b > a with different prefix and numbers", args{"b10", "a10"}, 1},
+		{"b > a with different numbers leading zeros", args{"dev01", "dev001"}, 1},
+		{"a > b with different numbers leading zeros", args{"dev001", "dev01"}, -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equalf(t, tt.want, compareWithPrefix(tt.args.a, tt.args.b), "compareWithPrefix(%v, %v)", tt.args.a, tt.args.b)
+		})
 	}
 }


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

```hcl
resource "proxmox_virtual_environment_container" "ubuntu_container" {
  description = "Managed by Terraform"

  node_name = "pve"
  vm_id     = 1234

  initialization {
    hostname = "terraform-provider-proxmox-ubuntu-container"

    ip_config {
      ipv4 {
         address = "dhcp"
        # address = "192.168.3.233/24"
        # gateway = "192.168.3.1"
      }
    }

    user_account {
      keys     = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOQCHPhOV9XsJa3uq4bmKymklNy6ktgBB/+2umizgnnY"]
      password = "password"
    }
  }

  network_interface {
    name = "veth0"
  }

  disk {
    datastore_id = "local-lvm"
    size         = 4
  }

  operating_system {
    template_file_id = "local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz"
    type             = "ubuntu"
  }

  mount_point {
    # bind mount, *requires* root@pam authentication
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared1"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared2"
  }


  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared3"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared4"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared5"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared6"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared7"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared8"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared9"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared10"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared11"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared12"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared13"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared14"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared15"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared16"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared17"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared18"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared19"
  }

  mount_point {
    volume = "/mnt/bindmounts/shared"
    path   = "/mnt/shared20"
  }
}
```

```
❯ tofu apply -auto-approve

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_container.ubuntu_container will be created
  + resource "proxmox_virtual_environment_container" "ubuntu_container" {
      + description    = <<-EOT
            Managed by Terraform
        EOT
      + id             = (known after apply)
      + node_name      = "pve"
      + protection     = false
      + start_on_boot  = true
      + started        = true
      + template       = false
      + timeout_clone  = 1800
      + timeout_create = 1800
      + timeout_delete = 60
      + timeout_start  = 300
      + timeout_update = 1800
      + unprivileged   = false
      + vm_id          = 1234

      + disk {
          + datastore_id = "local-lvm"
          + size         = 4
        }

      + initialization {
          + hostname = "terraform-provider-proxmox-ubuntu-container"

          + ip_config {
              + ipv4 {
                  + address = "dhcp"
                }
            }

          + user_account {
              + keys     = [
                  + "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOQCHPhOV9XsJa3uq4bmKymklNy6ktgBB/+2umizgnnY",
                ]
              + password = (sensitive value)
            }
        }

      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared1"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared2"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared3"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared4"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared5"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared6"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared7"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared8"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared9"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared10"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared11"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared12"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared13"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared14"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared15"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared16"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared17"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared18"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared19"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }
      + mount_point {
          + acl       = false
          + backup    = false
          + path      = "/mnt/shared20"
          + quota     = false
          + read_only = false
          + replicate = true
          + shared    = false
          + volume    = "/mnt/bindmounts/shared"
        }

      + network_interface {
          + bridge     = "vmbr0"
          + enabled    = true
          + firewall   = false
          + mtu        = 0
          + name       = "veth0"
          + rate_limit = 0
          + vlan_id    = 0
        }

      + operating_system {
          + template_file_id = "local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz"
          + type             = "ubuntu"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_container.ubuntu_container: Creating...
proxmox_virtual_environment_container.ubuntu_container: Creation complete after 9s [id=1234]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

<img width="583" alt="Screenshot 2025-04-29 at 8 18 19 PM" src="https://github.com/user-attachments/assets/873aeb83-f610-48a2-b9a4-406a37290e10" />

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1392

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Increased maximum supported mount points to 256, network interfaces to 10, and passthrough devices to 8 for containers.

- **Refactor**
  - Improved configuration flexibility by switching from fixed arrays to dynamic maps for mount points, network interfaces, and passthrough devices in container management.
  - Streamlined data handling for container resources, allowing more scalable and maintainable configuration.
  - Enhanced JSON handling to support dynamic device and interface mappings.
  - Centralized and optimized regular expressions for virtual machine resource parsing.
  - Introduced natural numeric ordering for string keys with common prefixes to improve sorting behavior.

- **Tests**
  - Updated tests to reflect new map-based device passthrough assertions.
  - Added tests validating the new natural ordering comparator for string keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->