### PR TITLE
file(file): handle remote file size check error in `download_file` resource

### DIFF
--- a/fwprovider/nodes/resource_download_file_test.go
+++ b/fwprovider/nodes/resource_download_file_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/storage"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/ssh"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 	"github.com/bpg/terraform-provider-proxmox/utils"
 )
 
@@ -163,6 +164,7 @@ func TestAccResourceDownloadFile(t *testing.T) {
 					Node:     ptr.Ptr(te.NodeName),
 					Storage:  ptr.Ptr(te.DatastoreID),
 					URL:      ptr.Ptr(fakeFileISO),
+					Verify:   ptr.Ptr(types.CustomBool(false)),
 				})
 				require.NoError(t, err)
 

--- a/fwprovider/test/resource_file_test.go
+++ b/fwprovider/test/resource_file_test.go
@@ -42,9 +42,9 @@ func TestAccResourceFile(t *testing.T) {
 
 	snippetRaw := fmt.Sprintf("snippet-raw-%s.txt", gofakeit.Word())
 	snippetURL := "https://raw.githubusercontent.com/yaml/yaml-test-suite/main/src/229Q.yaml"
-	snippetFile1 := strings.ReplaceAll(createFile(t, "snippet-file-1-*.yaml", "test snippet 1 - file").Name(), `\`, `/`)
-	snippetFile2 := strings.ReplaceAll(createFile(t, "snippet-file-2-*.yaml", "test snippet 2 - file").Name(), `\`, `/`)
-	fileISO := strings.ReplaceAll(createFile(t, "file-*.iso", "pretend it is an ISO").Name(), `\`, `/`)
+	snippetFile1 := strings.ReplaceAll(CreateTempFile(t, "snippet-file-1-*.yaml", "test snippet 1 - file").Name(), `\`, `/`)
+	snippetFile2 := strings.ReplaceAll(CreateTempFile(t, "snippet-file-2-*.yaml", "test snippet 2 - file").Name(), `\`, `/`)
+	fileISO := strings.ReplaceAll(CreateTempFile(t, "file-*.iso", "pretend this is an ISO").Name(), `\`, `/`)
 
 	te.AddTemplateVars(map[string]interface{}{
 		"SnippetRaw":   snippetRaw,
@@ -262,26 +262,6 @@ func uploadSnippetFile(t *testing.T, fileName string) {
 			File:        f,
 		})
 	require.NoError(t, err)
-}
-
-func createFile(t *testing.T, namePattern string, content string) *os.File {
-	t.Helper()
-
-	f, err := os.CreateTemp("", namePattern)
-	require.NoError(t, err)
-
-	_, err = f.WriteString(content)
-	require.NoError(t, err)
-
-	defer func(f *os.File) {
-		_ = f.Close()
-	}(f)
-
-	t.Cleanup(func() {
-		_ = os.Remove(f.Name())
-	})
-
-	return f
 }
 
 func deleteSnippet(te *Environment, fname string) {

--- a/fwprovider/test/test_support.go
+++ b/fwprovider/test/test_support.go
@@ -8,10 +8,13 @@ package test
 
 import (
 	"fmt"
+	"os"
 	"regexp"
+	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/require"
 )
 
 // ResourceAttributes is a helper function to test resource attributes.
@@ -68,4 +71,24 @@ func ResourceAttributesSet(res string, attrs []string) resource.TestCheckFunc {
 
 		return nil
 	}
+}
+
+func CreateTempFile(t *testing.T, namePattern string, content string) *os.File {
+	t.Helper()
+
+	f, err := os.CreateTemp(t.TempDir(), namePattern)
+	require.NoError(t, err)
+
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+
+	defer func(f *os.File) {
+		_ = f.Close()
+	}(f)
+
+	t.Cleanup(func() {
+		_ = os.Remove(f.Name())
+	})
+
+	return f
 }


### PR DESCRIPTION

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

When remote file renamed, the provider will show a warning and **no** pending changes:
```
❯ tofu apply
proxmox_virtual_environment_download_file.cloud_image: Refreshing state... [id=local:iso/image.img]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
╷
│ Warning: Could not read the file metadata from URL.
│ 
│   with proxmox_virtual_environment_download_file.cloud_image,
│   on main.tf line 323, in resource "proxmox_virtual_environment_download_file" "cloud_image":
│  323: resource "proxmox_virtual_environment_download_file" "cloud_image" {
│ 
│ The remote file at URL "https://REDACTED/index.html.old" most likely doesn’t exist or can’t be accessed.
│ To skip the remote file check, set `overwrite` to `false`.
╵

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

```
Subsequent URL change and plan `apply` downloads a new file:
```
❯ tofu apply
proxmox_virtual_environment_download_file.cloud_image: Refreshing state... [id=local:iso/image.img]

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_download_file.cloud_image must be replaced
-/+ resource "proxmox_virtual_environment_download_file" "cloud_image" {
      ~ id                  = "local:iso/image.img" -> (known after apply)
      ~ size                = 10673 -> (known after apply)
      ~ url                 = "https://REDACTED/index.html.old" -> "https://REDACTED/index.html" # forces replacement
        # (8 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Do you want to perform these actions?
  OpenTofu will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

proxmox_virtual_environment_download_file.cloud_image: Destroying... [id=local:iso/image.img]
proxmox_virtual_environment_download_file.cloud_image: Destruction complete after 0s
proxmox_virtual_environment_download_file.cloud_image: Creating...
proxmox_virtual_environment_download_file.cloud_image: Creation complete after 2s [id=local:iso/image.img]

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1724

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling when fetching remote file metadata, preventing failures during resource reads and providing clearer warnings for inaccessible URLs.
- **New Features**
	- Added warnings for remote file metadata issues and guidance on disabling overwrite checks if needed.
- **Tests**
	- Updated tests to use a new helper for creating temporary files, improving test reliability and maintainability.
	- Enhanced test coverage for scenarios involving file verification and metadata access.
- **Chores**
	- Introduced a reusable helper function for temporary file creation in test support utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->