### PR TITLE
feat(vm): add support for amd-sev parameter

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -134,6 +134,18 @@ output "ubuntu_vm_public_key" {
     - `type` - (Optional) The QEMU agent interface type (defaults to `virtio`).
         - `isa` - ISA Serial Port.
         - `virtio` - VirtIO (paravirtualized).
+- `amd_sev` - (Optional) Secure Encrypted Virtualization (SEV) features by AMD CPUs.
+    - `type` - (Optional) Enable standard SEV with `std` or enable experimental 
+        SEV-ES with the `es` option or enable experimental SEV-SNP with the `snp` option 
+        (defaults to `std`).
+    - `allow_smt` - (Optional) Sets policy bit to allow Simultaneous Multi Threading (SMT)
+        (Ignored unless for SEV-SNP) (defaults to `true`).
+    - `kernel_hashes` - (Optional) Add kernel hashes to guest firmware for measured 
+        linux kernel launch (defaults to `false`).
+    - `no_debug` - (Optional) Sets policy bit to disallow debugging of guest (defaults
+        to `false`).
+    - `no_key_sharing` - (Optional) Sets policy bit to disallow key sharing with 
+        other guests (Ignored for SEV-SNP) (defaults to `false`).
 - `audio_device` - (Optional) An audio device.
     - `device` - (Optional) The device (defaults to `intel-hda`).
         - `AC97` - Intel 82801AA AC97 Audio.
@@ -641,6 +653,25 @@ and when refreshing resources.  The provider has no way to distinguish between
 "qemu-guest-agent not installed" and "very long boot due to a disk check", it
 trusts the user to set `agent.enabled` correctly and waits for
 `qemu-guest-agent` to start.
+
+## AMD SEV
+AMD SEV (-ES, -SNP) are security features for AMD processors. SEV-SNP support
+is included in Proxmox version **8.4**, see [Proxmox Wiki](
+https://pve.proxmox.com/wiki/Qemu/KVM_Virtual_Machines#qm_virtual_machines_settings)
+and [Proxmox Documentation](https://pve.proxmox.com/pve-docs/pve-admin-guide.html#qm_memory_encryption)
+for more information.
+
+SEV-SNP requires `bios = OVMF` and a supported AMD CPU (`EPYC-v4` for instance), 
+`machine = q35` is also advised. No EFI disk is required since SEV-SNP uses 
+consolidated read-only firmware. A configured EFI will be ignored.
+
+All changes made to `amd_sev` will trigger reboots. Removing or adding the 
+`amd_sev` block will force a replacement of the resource. Modifying the `amd_sev` 
+block will not trigger replacements. 
+
+`allow_smt` is by default set to `true` even if `snp` is not the selected type. 
+Proxmox will ignore this value when `snp` is not in use. Likewise `no_key_sharing`
+is `false` by default but ignored by Proxmox when `snp` is in use.
 
 ## Important Notes
 

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -146,6 +146,8 @@ output "ubuntu_vm_public_key" {
         to `false`).
     - `no_key_sharing` - (Optional) Sets policy bit to disallow key sharing with 
         other guests (Ignored for SEV-SNP) (defaults to `false`).
+
+    The `amd_sev` setting is only allowed for a `root@pam` authenticated user.
 - `audio_device` - (Optional) An audio device.
     - `device` - (Optional) The device (defaults to `intel-hda`).
         - `AC97` - Intel 82801AA AC97 Audio.
@@ -660,6 +662,8 @@ is included in Proxmox version **8.4**, see [Proxmox Wiki](
 https://pve.proxmox.com/wiki/Qemu/KVM_Virtual_Machines#qm_virtual_machines_settings)
 and [Proxmox Documentation](https://pve.proxmox.com/pve-docs/pve-admin-guide.html#qm_memory_encryption)
 for more information.
+
+`amd-sev` requires root and therefore `root@pam` auth.
 
 SEV-SNP requires `bios = OVMF` and a supported AMD CPU (`EPYC-v4` for instance), 
 `machine = q35` is also advised. No EFI disk is required since SEV-SNP uses 

--- a/proxmox/nodes/vms/custom_amdsev.go
+++ b/proxmox/nodes/vms/custom_amdsev.go
@@ -16,9 +16,9 @@ import (
 )
 
 // CustomAMDSEV handles AMDSEV parameters.
-type CustomAMDSEV struct { // TODO verify the json parameters, "omitempty"?
+type CustomAMDSEV struct {
 	Type         *string           `json:"type"           url:"type"`
-	AllowSMT     *types.CustomBool `json:"allow-smt" 			url:"allow-smt,int"`
+	AllowSMT     *types.CustomBool `json:"allow-smt"      url:"allow-smt,int"`
 	KernelHashes *types.CustomBool `json:"kernel-hashes"  url:"kernel-hashes,int"`
 	NoDebug      *types.CustomBool `json:"no-debug"       url:"no-debug,int"`
 	NoKeySharing *types.CustomBool `json:"no-key-sharing" url:"no-key-sharing,int"`

--- a/proxmox/nodes/vms/custom_amdsev.go
+++ b/proxmox/nodes/vms/custom_amdsev.go
@@ -1,0 +1,113 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package vms
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
+)
+
+// CustomAMDSEV handles AMDSEV parameters.
+type CustomAMDSEV struct { // TODO verify the json parameters, "omitempty"?
+	Type         *string           `json:"type"           url:"type"`
+	AllowSMT     *types.CustomBool `json:"allow-smt" 			url:"allow-smt,int"`
+	KernelHashes *types.CustomBool `json:"kernel-hashes"  url:"kernel-hashes,int"`
+	NoDebug      *types.CustomBool `json:"no-debug"       url:"no-debug,int"`
+	NoKeySharing *types.CustomBool `json:"no-key-sharing" url:"no-key-sharing,int"`
+}
+
+// EncodeValues converts a CustomAMDSEV struct to a URL value.
+func (r *CustomAMDSEV) EncodeValues(key string, v *url.Values) error {
+	var values []string
+
+	if r.Type != nil {
+		values = append(values, fmt.Sprintf("type=%s", *r.Type))
+	}
+
+	if r.AllowSMT != nil {
+		if *r.AllowSMT {
+			values = append(values, "allow-smt=1")
+		} else {
+			values = append(values, "allow-smt=0")
+		}
+	}
+
+	if r.KernelHashes != nil {
+		if *r.KernelHashes {
+			values = append(values, "kernel-hashes=1")
+		} else {
+			values = append(values, "kernel-hashes=0")
+		}
+	}
+
+	if r.NoDebug != nil {
+		if *r.NoDebug {
+			values = append(values, "no-debug=1")
+		} else {
+			values = append(values, "no-debug=0")
+		}
+	}
+
+	if r.NoKeySharing != nil {
+		if *r.NoKeySharing {
+			values = append(values, "no-key-sharing=1")
+		} else {
+			values = append(values, "no-key-sharing=0")
+		}
+	}
+
+	if len(values) > 0 {
+		v.Add(key, strings.Join(values, ","))
+	}
+
+	return nil
+}
+
+// UnmarshalJSON converts a CustomAMDSEV string to an object.
+func (r *CustomAMDSEV) UnmarshalJSON(b []byte) error {
+	var s string
+
+	if err := json.Unmarshal(b, &s); err != nil {
+		return fmt.Errorf("error unmarshalling CustomAMDSEV: %w", err)
+	}
+
+	// TODO the get schema from proxmox only has `pve-qemu-sev-fmt` described, instead of each field
+	// is it still the same fields or is the format different?
+	pairs := strings.Split(s, ",")
+
+	for _, p := range pairs {
+		v := strings.Split(strings.TrimSpace(p), "=")
+
+		if len(v) == 1 {
+			// TODO: can args be passed without values? most likely bools in that case
+			continue
+		} else if len(v) == 2 {
+			switch v[0] {
+			case "type":
+				r.Type = &v[1]
+			case "allow-smt":
+				allow_smt := types.CustomBool(v[1] == "1")
+				r.AllowSMT = &allow_smt
+			case "kernel-hashes":
+				kernel_hashes := types.CustomBool(v[1] == "1")
+				r.KernelHashes = &kernel_hashes
+			case "no-debug":
+				no_debug := types.CustomBool(v[1] == "1")
+				r.NoDebug = &no_debug
+			case "no-key-sharing":
+				no_key_sharing := types.CustomBool(v[1] == "1")
+				r.NoKeySharing = &no_key_sharing
+			}
+		}
+	}
+
+	return nil
+}

--- a/proxmox/nodes/vms/custom_amdsev.go
+++ b/proxmox/nodes/vms/custom_amdsev.go
@@ -17,7 +17,7 @@ import (
 
 // CustomAMDSEV handles AMDSEV parameters.
 type CustomAMDSEV struct {
-	Type         *string           `json:"type"           url:"type"`
+	Type         string            `json:"type"           url:"type"`
 	AllowSMT     *types.CustomBool `json:"allow-smt"      url:"allow-smt,int"`
 	KernelHashes *types.CustomBool `json:"kernel-hashes"  url:"kernel-hashes,int"`
 	NoDebug      *types.CustomBool `json:"no-debug"       url:"no-debug,int"`
@@ -26,10 +26,8 @@ type CustomAMDSEV struct {
 
 // EncodeValues converts a CustomAMDSEV struct to a URL value.
 func (r *CustomAMDSEV) EncodeValues(key string, v *url.Values) error {
-	var values []string
-
-	if r.Type != nil {
-		values = append(values, fmt.Sprintf("type=%s", *r.Type))
+	values := []string{
+		fmt.Sprintf("type=%s", r.Type),
 	}
 
 	if r.AllowSMT != nil {
@@ -81,15 +79,17 @@ func (r *CustomAMDSEV) UnmarshalJSON(b []byte) error {
 
 	pairs := strings.Split(s, ",")
 
-	for _, p := range pairs {
+	for i, p := range pairs {
 		v := strings.Split(strings.TrimSpace(p), "=")
 
-		if len(v) == 1 {
-			r.Type = &v[0]
-		} else if len(v) == 2 {
+		if len(v) == 1 && i == 0 {
+			r.Type = v[0]
+		}
+
+		if len(v) == 2 {
 			switch v[0] {
 			case "type":
-				r.Type = &v[1]
+				r.Type = v[1]
 			case "allow-smt":
 				allow_smt := types.CustomBool(v[1] == "1")
 				r.AllowSMT = &allow_smt

--- a/proxmox/nodes/vms/custom_amdsev.go
+++ b/proxmox/nodes/vms/custom_amdsev.go
@@ -79,16 +79,13 @@ func (r *CustomAMDSEV) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("error unmarshalling CustomAMDSEV: %w", err)
 	}
 
-	// TODO the get schema from proxmox only has `pve-qemu-sev-fmt` described, instead of each field
-	// is it still the same fields or is the format different?
 	pairs := strings.Split(s, ",")
 
 	for _, p := range pairs {
 		v := strings.Split(strings.TrimSpace(p), "=")
 
 		if len(v) == 1 {
-			// TODO: can args be passed without values? most likely bools in that case
-			continue
+			r.Type = &v[0]
 		} else if len(v) == 2 {
 			switch v[0] {
 			case "type":

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -344,7 +344,7 @@ type GetStatusResponseBody struct {
 }
 
 // GetStatusResponseData contains the data from a VM get status response.
-type GetStatusResponseData struct { // TODO add AMDSEV status here?
+type GetStatusResponseData struct {
 	AgentEnabled     *types.CustomBool `json:"agent,omitempty"`
 	CPUCount         *int64            `json:"cpus,omitempty"`
 	Lock             *string           `json:"lock,omitempty"`

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -47,6 +47,7 @@ type CloneRequestBody struct {
 type CreateRequestBody struct {
 	ACPI                 *types.CustomBool              `json:"acpi,omitempty"               url:"acpi,omitempty,int"`
 	Agent                *CustomAgent                   `json:"agent,omitempty"              url:"agent,omitempty"`
+	AMDSEV               *CustomAMDSEV                  `json:"amd-sev,omitempty"            url:"amd-sev,omitempty"`
 	AllowReboot          *types.CustomBool              `json:"reboot,omitempty"             url:"reboot,omitempty,int"`
 	AudioDevices         CustomAudioDevices             `json:"audio,omitempty"              url:"audio,omitempty"`
 	Autostart            *types.CustomBool              `json:"autostart,omitempty"          url:"autostart,omitempty,int"`
@@ -183,6 +184,7 @@ type GetResponseBody struct {
 type GetResponseData struct {
 	ACPI                 *types.CustomBool               `json:"acpi,omitempty"`
 	Agent                *CustomAgent                    `json:"agent,omitempty"`
+	AMDSEV               *CustomAMDSEV                   `json:"amd-sev,omitempty"`
 	AllowReboot          *types.CustomBool               `json:"reboot,omitempty"`
 	AudioDevice          *CustomAudioDevice              `json:"audio0,omitempty"`
 	Autostart            *types.CustomBool               `json:"autostart,omitempty"`
@@ -342,7 +344,7 @@ type GetStatusResponseBody struct {
 }
 
 // GetStatusResponseData contains the data from a VM get status response.
-type GetStatusResponseData struct {
+type GetStatusResponseData struct { // TODO add AMDSEV status here?
 	AgentEnabled     *types.CustomBool `json:"agent,omitempty"`
 	CPUCount         *int64            `json:"cpus,omitempty"`
 	Lock             *string           `json:"lock,omitempty"`

--- a/proxmoxtf/resource/vm/validators.go
+++ b/proxmoxtf/resource/vm/validators.go
@@ -158,6 +158,11 @@ func QEMUAgentTypeValidator() schema.SchemaValidateDiagFunc {
 	return validation.ToDiagFunc(validation.StringInSlice([]string{"isa", "virtio"}, false))
 }
 
+// AMDSEVTypeValidator is a schema validation function for AMDSEV types.
+func AMDSEVTypeValidator() schema.SchemaValidateDiagFunc {
+	return validation.ToDiagFunc(validation.StringInSlice([]string{"std", "es", "snp"}, false))
+}
+
 // KeyboardLayoutValidator is a schema validation function for keyboard layouts.
 func KeyboardLayoutValidator() schema.SchemaValidateDiagFunc {
 	return validation.ToDiagFunc(validation.StringInSlice([]string{

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -407,21 +407,13 @@ func VM() *schema.Resource {
 			ForceNew:    true,
 			DefaultFunc: func() (interface{}, error) {
 				return []interface{}{}, nil
-				// return []interface{}{
-				// 	map[string]interface{}{
-				// 		mkAMDSEVType:         dvAMDSEVType,
-				// 		mkAMDSEVAllowSMT:     dvAMDSEVAllowSMT,
-				// 		mkAMDSEVKernelHashes: dvAMDSEVKernelHashes,
-				// 		mkAMDSEVNoDebug:      dvAMDSEVNoDebug,
-				// 		mkAMDSEVNoKeySharing: dvAMDSEVNoKeySharing,
-				// 	},
-				// }, nil
 			},
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					mkAMDSEVType: {
-						Type:             schema.TypeString,
-						Description:      "Enable standard SEV with type=std or enable experimental SEV-ES with the es option or enable experimental SEV-SNP with the snp option.",
+						Type: schema.TypeString,
+						Description: "Enable standard SEV with type=std or enable experimental SEV-ES with the es option" +
+							"or enable experimental SEV-SNP with the snp option.",
 						Optional:         true,
 						Default:          dvAMDSEVType,
 						ValidateDiagFunc: AMDSEVTypeValidator(),
@@ -2531,7 +2523,7 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 	agentType := agentBlock[mkAgentType].(string)
 
 	amdsev := vmGetAMDSEVObject(d)
- 
+
 	kvmArguments := d.Get(mkKVMArguments).(string)
 
 	audioDevices := vmGetAudioDeviceList(d)
@@ -2813,7 +2805,7 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 			TrimClonedDisks: &agentTrim,
 			Type:            &agentType,
 		},
-		AMDSEV: amdsev,
+		AMDSEV:       amdsev,
 		AudioDevices: audioDevices,
 		BIOS:         &bios,
 		Boot: &vms.CustomBoot{
@@ -2972,7 +2964,7 @@ func vmGetAMDSEVObject(d *schema.ResourceData) *vms.CustomAMDSEV {
 	if len(amdsevBlock) > 0 && amdsevBlock[0] != nil {
 		block := amdsevBlock[0].(map[string]interface{})
 
-		amdsevType := block[mkAMDSEVType].(string) 
+		amdsevType := block[mkAMDSEVType].(string)
 		amdsevAllowSMT := types.CustomBool(
 			block[mkAMDSEVAllowSMT].(bool),
 		)
@@ -4864,7 +4856,7 @@ func vmReadCustom(
 	vmAPI := client.Node(nodeName).VM(vmID)
 	started := d.Get(mkStarted).(bool)
 
-	agentTimeout, e := getAgentTimeout(d) // TODO: Investigate this (is something similar needed for amdsev?)
+	agentTimeout, e := getAgentTimeout(d)
 	if e != nil {
 		return diag.FromErr(e)
 	}
@@ -5253,7 +5245,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 		rebootRequired = true
 	}
 
-	// Prepare the new amdsev configuration.	
+	// Prepare the new amdsev configuration.
 	if d.HasChange(mkAMDSEV) {
 		amdsev := vmGetAMDSEVObject(d)
 
@@ -6145,7 +6137,7 @@ func parseImportIDWithNodeName(id string) (string, string, error) {
 	return nodeName, id, nil
 }
 
-func getAgentTimeout(d *schema.ResourceData) (time.Duration, error) { // TODO: Also look at this
+func getAgentTimeout(d *schema.ResourceData) (time.Duration, error) {
 	resource := VM()
 
 	agentBlock, err := structure.GetSchemaBlock(

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -2059,7 +2059,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m interface{}) d
 		)
 
 		updateBody.AMDSEV = &vms.CustomAMDSEV{
-			Type:         &amdsevType,
+			Type:         amdsevType,
 			AllowSMT:     &amdsevAllowSMT,
 			KernelHashes: &amdsevKernelHashes,
 			NoDebug:      &amdsevNoDebug,
@@ -2979,7 +2979,7 @@ func vmGetAMDSEVObject(d *schema.ResourceData) *vms.CustomAMDSEV {
 		)
 
 		amdsev = &vms.CustomAMDSEV{
-			Type:         &amdsevType,
+			Type:         amdsevType,
 			AllowSMT:     &amdsevAllowSMT,
 			KernelHashes: &amdsevKernelHashes,
 			NoDebug:      &amdsevNoDebug,
@@ -3757,11 +3757,7 @@ func vmReadCustom(
 		if vmConfig.AMDSEV != nil {
 			amdsev := map[string]interface{}{}
 
-			if vmConfig.AMDSEV.Type != nil {
-				amdsev[mkAMDSEVType] = *vmConfig.AMDSEV.Type
-			} else {
-				amdsev[mkAMDSEVType] = ""
-			}
+			amdsev[mkAMDSEVType] = vmConfig.AMDSEV.Type
 
 			if vmConfig.AMDSEV.AllowSMT != nil {
 				amdsev[mkAMDSEVAllowSMT] = bool(*vmConfig.AMDSEV.AllowSMT)


### PR DESCRIPTION
### Description
This pull request adds support for the `amd-sev` parameter to enable AMD SEV features on QEMU powered vms. Proxmox **8.4** adds support for AMD SEV-SNP. This was added onto the amd-sev parameter which already enabled SEV and SEV-ES. I have found no prior mention of amd-sev in this repository.

#### Implementation details
The `amd_sev` schema is defined with five parameters. The defaults match the defaults defined by Proxmox.
```
amd_sev {
  type = "snp" # default "std" (sev only)
  allow_smt = true # default true
  kernel_hashes = true # default false
  no_key_sharing = false # default false
  no_debug = false # default false
}
```
more details are available in the docs.

`CustomAMDSEV` object is added to the provider to communicate with Proxmox. The pve api docs is somewhat unclear on the format of the outgoing object ("pve-qemu-sev-fmt"), but it seems to be the same as the incoming, except that a single parameter can be used to describe the type. This only occurs when changing the AMD SEV field manually in the Proxmox GUI, or when removing the `amd_sev` block.

By default AMD SEV is disabled, but none of its fields can be set to disable it, unlike QEMU agent for instance. Therefore, `ForceNew: true` in the schema was used to disable the feature. This also forces the resource to be replaced when adding the `amd_sev` block, which is not necessary needed. I did not find a better solution for this. 

All parameters are sent to Proxmox even if they are ignored by Proxmox depending on the type, read more about this in the docs. 

##### References
- [pve api docs](https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/qemu/{vmid}/config) (`amd-sev` parameter)
- [Proxmox docs](https://pve.proxmox.com/pve-docs/pve-admin-guide.html#qm_memory_encryption)


### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
This has been tested manually with an AMD SEV-SNP enabled host running Proxmox 8.4 (pve-manager/8.4.1/2a5fa54a8503f96d (running kernel: 6.11.11-2-pve)). The cloud image used is available [here](https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img). AMD SEV and SEV-ES was also tested on the same version.

I connected to Proxmox using username and password for the `root@pam`  user, since AMD SEV requires root.

Relevant part of the configuration:
```
cpu {
  type = "EPYC-v4"
}

bios = "ovmf"
machine = "q35"

amd_sev {
  type = "snp"
}
```
Terraform plan output for creation:
![image](https://github.com/user-attachments/assets/9836d606-c541-475f-b6c8-d979466eefdb)

Proxmox GUI:
![image](https://github.com/user-attachments/assets/1cd1f30c-1489-42e6-a025-be5db614ea30)

Changing a parameter:
![image](https://github.com/user-attachments/assets/52281626-0e9c-40c0-ab7c-6843bd576eb4)
![image](https://github.com/user-attachments/assets/53970cee-4b46-44ce-a5cc-3c31eb30879c)

Removing the `amd_sev` block causes:
![image](https://github.com/user-attachments/assets/eeeca1ef-1241-410e-9d6e-c348a06a8813)
![image](https://github.com/user-attachments/assets/c6ef3342-1c68-4e3b-9755-5510f6181474)


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--- Closes #0000 | Relates #0000 --->

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
