### PR TITLE
fix(vm): allow `scsi` and `sata` for CD-ROM interface

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -168,9 +168,9 @@ output "ubuntu_vm_public_key" {
         Set `file_id` to `none` to leave the CD-ROM drive empty.
     - `file_id` - (Optional) A file ID for an ISO file (defaults to `cdrom` as
         in the physical drive). Use `none` to leave the CD-ROM drive empty.
-    - `interface` - (Optional) A hardware interface to connect CD-ROM drive to,
-        must be `ideN` (defaults to `ide3`). Note that `q35` machine type only
-        supports `ide0` and `ide2`.
+    - `interface` - (Optional) A hardware interface to connect CD-ROM drive to (defaults to `ide3`).
+      "Must be one of `ideN`, `sataN`, `scsiN`, where N is the index of the interface. " +
+      "Note that `q35` machine type only supports `ide0` and `ide2` of IDE interfaces.
 - `clone` - (Optional) The cloning configuration.
     - `datastore_id` - (Optional) The identifier for the target datastore.
     - `node_name` - (Optional) The name of the source node (leave blank, if

--- a/fwprovider/test/resource_vm_cdrom_test.go
+++ b/fwprovider/test/resource_vm_cdrom_test.go
@@ -51,6 +51,46 @@ func TestAccResourceVMCDROM(t *testing.T) {
 				RefreshState: true,
 			},
 		}},
+		{"sata cdrom", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name 	  = "test-cdrom"
+					cdrom {
+						file_id   = "none"
+						interface = "sata3"	
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom", map[string]string{
+					"cdrom.0.interface": "sata3",
+				}),
+			},
+			{
+				RefreshState: true,
+			},
+		}},
+		{"scsi cdrom", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name 	  = "test-cdrom"
+					cdrom {
+						file_id   = "none"
+						interface = "scsi5"	
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom", map[string]string{
+					"cdrom.0.interface": "scsi5",
+				}),
+			},
+			{
+				RefreshState: true,
+			},
+		}},
 		{"enable cdrom", []resource.TestStep{
 			{
 				Config: te.RenderConfig(`

--- a/proxmoxtf/resource/vm/validators.go
+++ b/proxmoxtf/resource/vm/validators.go
@@ -263,14 +263,12 @@ func SCSIHardwareValidator() schema.SchemaValidateDiagFunc {
 	}, false))
 }
 
-// IDEInterfaceValidator is a schema validation function for IDE interfaces.
-func IDEInterfaceValidator() schema.SchemaValidateDiagFunc {
-	return validation.ToDiagFunc(validation.StringInSlice([]string{
-		"ide0",
-		"ide1",
-		"ide2",
-		"ide3",
-	}, false))
+// CDROMInterfaceValidator is a schema validation function for IDE interfaces.
+func CDROMInterfaceValidator() schema.SchemaValidateDiagFunc {
+	return validation.ToDiagFunc(validation.StringMatch(
+		regexp.MustCompile(`^(ide[0-3]|sata[0-5]|scsi([0-9]|1[0-3]))$`),
+		"must be one of `ide[0-3]`, `sata[0-5]`, `scsi[0-13]`",
+	))
 }
 
 // VirtiofsCacheValidator is a schema validation function for virtiofs cache configs.

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -531,7 +531,7 @@ func VM() *schema.Resource {
 						Description:      "The CDROM interface",
 						Optional:         true,
 						Default:          dvCDROMInterface,
-						ValidateDiagFunc: IDEInterfaceValidator(),
+						ValidateDiagFunc: CDROMInterfaceValidator(),
 					},
 				},
 			},
@@ -6002,6 +6002,9 @@ func vmDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.D
 	if shutdownTimeout > timeout {
 		timeout = shutdownTimeout
 	}
+
+	// reset the default timeout for the delete operation
+	ctx = context.WithoutCancel(ctx)
 
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 	defer cancel()


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
```hcl
resource "proxmox_virtual_environment_vm" "example_vm" {
  node_name = "pve"
  name = "example-vm"

  started = false

  cdrom {
    interface = "sata4"
  }
}
```
```
❯ tofu apply -auto-approve

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.example_vm will be created
  + resource "proxmox_virtual_environment_vm" "example_vm" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "example-vm"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + cdrom {
          + enabled   = false
          + interface = "sata4"
        }

      + network_device (known after apply)

      + vga (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.example_vm: Creating...
proxmox_virtual_environment_vm.example_vm: Creation complete after 1s [id=101]

```


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1970

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify and expand the supported CD-ROM interface types, now including IDE, SATA, and SCSI interfaces, with improved readability.

- **Tests**
  - Added new test cases to verify support for SATA and SCSI CD-ROM interfaces.

- **Bug Fixes**
  - Broadened validation to accept IDE, SATA, and SCSI interface identifiers for CD-ROM devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->