### PR TITLE
fix(network): improve error handling on `create`/`read`/`update`

### DIFF
--- a/fwprovider/nodes/network/resource_linux_bridge.go
+++ b/fwprovider/nodes/network/resource_linux_bridge.go
@@ -294,14 +294,18 @@ func (r *linuxBridgeResource) Create(ctx context.Context, req resource.CreateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
 	if !found {
 		resp.Diagnostics.AddError(
 			"Linux Bridge interface not found after creation",
-			fmt.Sprintf("Interface %q on node %q could not be read after creation", plan.Name.ValueString(), plan.NodeName.ValueString()),
+			fmt.Sprintf(
+				"Interface %q on node %q could not be read after creation",
+				plan.Name.ValueString(), plan.NodeName.ValueString()),
 		)
 
 		return
 	}
+
 	resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 
@@ -343,6 +347,7 @@ func (r *linuxBridgeResource) read(ctx context.Context, model *linuxBridgeResour
 
 		return true
 	}
+
 	return false
 }
 
@@ -362,6 +367,7 @@ func (r *linuxBridgeResource) Read(ctx context.Context, req resource.ReadRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
 	if !found {
 		resp.State.RemoveResource(ctx)
 		return
@@ -430,7 +436,9 @@ func (r *linuxBridgeResource) Update(ctx context.Context, req resource.UpdateReq
 	if !found {
 		resp.Diagnostics.AddError(
 			"Linux Bridge interface not found after update",
-			fmt.Sprintf("Interface %q on node %q could not be read after update", plan.Name.ValueString(), plan.NodeName.ValueString()),
+			fmt.Sprintf(
+				"Interface %q on node %q could not be read after update",
+				plan.Name.ValueString(), plan.NodeName.ValueString()),
 		)
 
 		return
@@ -526,6 +534,7 @@ func (r *linuxBridgeResource) ImportState(
 
 		return
 	}
+
 	diags := resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
 }

--- a/fwprovider/nodes/network/resource_linux_vlan.go
+++ b/fwprovider/nodes/network/resource_linux_vlan.go
@@ -270,7 +270,9 @@ func (r *linuxVLANResource) Create(ctx context.Context, req resource.CreateReque
 	if !found {
 		resp.Diagnostics.AddError(
 			"Linux VLAN interface not found after creation",
-			fmt.Sprintf("Interface %q on node %q could not be read after creation", plan.Name.ValueString(), plan.NodeName.ValueString()),
+			fmt.Sprintf(
+				"Interface %q on node %q could not be read after creation",
+				plan.Name.ValueString(), plan.NodeName.ValueString()),
 		)
 
 		return
@@ -309,6 +311,7 @@ func (r *linuxVLANResource) read(ctx context.Context, model *linuxVLANResourceMo
 
 		return true
 	}
+
 	return false
 }
 
@@ -381,7 +384,9 @@ func (r *linuxVLANResource) Update(ctx context.Context, req resource.UpdateReque
 	if !found {
 		resp.Diagnostics.AddError(
 			"Linux VLAN interface not found after update",
-			fmt.Sprintf("Interface %q on node %q could not be read after update", plan.Name.ValueString(), plan.NodeName.ValueString()),
+			fmt.Sprintf(
+				"Interface %q on node %q could not be read after update",
+				plan.Name.ValueString(), plan.NodeName.ValueString()),
 		)
 
 		return

--- a/fwprovider/nodes/network/resource_linux_vlan.go
+++ b/fwprovider/nodes/network/resource_linux_vlan.go
@@ -261,9 +261,18 @@ func (r *linuxVLANResource) Create(ctx context.Context, req resource.CreateReque
 
 	plan.ID = types.StringValue(plan.NodeName.ValueString() + ":" + plan.Name.ValueString())
 
-	r.read(ctx, &plan, &resp.Diagnostics)
+	found := r.read(ctx, &plan, &resp.Diagnostics)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !found {
+		resp.Diagnostics.AddError(
+			"Linux VLAN interface not found after creation",
+			fmt.Sprintf("Interface %q on node %q could not be read after creation", plan.Name.ValueString(), plan.NodeName.ValueString()),
+		)
+
 		return
 	}
 
@@ -280,7 +289,7 @@ func (r *linuxVLANResource) Create(ctx context.Context, req resource.CreateReque
 	}
 }
 
-func (r *linuxVLANResource) read(ctx context.Context, model *linuxVLANResourceModel, diags *diag.Diagnostics) {
+func (r *linuxVLANResource) read(ctx context.Context, model *linuxVLANResourceModel, diags *diag.Diagnostics) bool {
 	ifaces, err := r.client.Node(model.NodeName.ValueString()).ListNetworkInterfaces(ctx)
 	if err != nil {
 		diags.AddError(
@@ -288,7 +297,7 @@ func (r *linuxVLANResource) read(ctx context.Context, model *linuxVLANResourceMo
 			"Could not list network interfaces, unexpected error: "+err.Error(),
 		)
 
-		return
+		return false
 	}
 
 	for _, iface := range ifaces {
@@ -298,8 +307,9 @@ func (r *linuxVLANResource) read(ctx context.Context, model *linuxVLANResourceMo
 
 		model.importFromNetworkInterfaceList(iface)
 
-		break
+		return true
 	}
+	return false
 }
 
 // Read reads a Linux VLAN interface.
@@ -313,9 +323,14 @@ func (r *linuxVLANResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	r.read(ctx, &state, &resp.Diagnostics)
+	found := r.read(ctx, &state, &resp.Diagnostics)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !found {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -357,9 +372,18 @@ func (r *linuxVLANResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	r.read(ctx, &plan, &resp.Diagnostics)
+	found := r.read(ctx, &plan, &resp.Diagnostics)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !found {
+		resp.Diagnostics.AddError(
+			"Linux VLAN interface not found after update",
+			fmt.Sprintf("Interface %q on node %q could not be read after update", plan.Name.ValueString(), plan.NodeName.ValueString()),
+		)
+
 		return
 	}
 
@@ -439,9 +463,18 @@ func (r *linuxVLANResource) ImportState(
 		NodeName: types.StringValue(nodeName),
 		Name:     types.StringValue(iface),
 	}
-	r.read(ctx, &state, &resp.Diagnostics)
+	found := r.read(ctx, &state, &resp.Diagnostics)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !found {
+		resp.Diagnostics.AddError(
+			"Linux VLAN interface not found",
+			fmt.Sprintf("Interface %q on node %q could not be imported", iface, nodeName),
+		)
+
 		return
 	}
 


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions. -> **No affect**
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources. -> **No affect**
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
Reference to the resources proxmox_virtual_environment_network_linux_bridge + proxmox_virtual_environment_network_linux_vlan . 

I'm currently involved in a Crossplane provider development based on this provider of Proxmox that is the best by far out there (so, thanks for this honestly, incredible work for the Proxmox community :) ). 
Crossplane, uses on its backend this Terraform provider to interact with resources in the following way: 
- Init -> - apply -refresh-only -> (if there is any drift) -> apply   (all this done automatically) and using this Terraform code for its base.  (Crossplane keeps doing this continuous refresh constantly)


So the problem I've found it's that Terraform asssigns the ID before even the resource it's created on Proxmox, making the update() and read() cycle to assume there is an existant resource (but it doesen't) so Crossplane assumes it exists the resource because there is NO drift. 

This it's an example of the error returned in crossplane + terraform cli when trying to create a proxmox_virtual_environment_network_linux_bridge  resource:

```
Error: Error updating Linux Bridge interface
Could not update Linux Bridge, unexpected error: failed to
update network interface "vmbr11" for node "pve": received
an HTTP 400 response - Reason: Parameter verification
failed. (iface: interface does not exist)

```

 This it's a very useful thing we need on the crossplane provider, so I will be really please it is taken on consideration. I have not modified the tests because I do not see any relevant change.

Thanks in advanced!!! :)

<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
