### PR TITLE
feat(vm): Import Disk via API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,6 @@ Add the following block to your VM config:
 
 For more context, see #1639 and #1770.
 
-### Disk Images Cannot Be Imported by Non-PAM Accounts
-
-Due to limitations in the Proxmox VE API, certain actions need to be performed using SSH. This requires the use of a PAM account (standard Linux account).
-
 ### Disk Images from VMware Cannot Be Uploaded or Imported
 
 Proxmox VE does not currently support VMware disk images directly.

--- a/docs/guides/cloud-image.md
+++ b/docs/guides/cloud-image.md
@@ -32,7 +32,7 @@ resource "proxmox_virtual_environment_vm" "centos_vm" {
 
   disk {
     datastore_id = "local-lvm"
-    file_id      = proxmox_virtual_environment_download_file.centos_cloud_image.id
+    import_from  = proxmox_virtual_environment_download_file.centos_cloud_image.id
     interface    = "virtio0"
     iothread     = true
     discard      = "on"
@@ -41,11 +41,10 @@ resource "proxmox_virtual_environment_vm" "centos_vm" {
 }
 
 resource "proxmox_virtual_environment_download_file" "centos_cloud_image" {
-  content_type = "iso"
+  content_type = "import"
   datastore_id = "local"
   node_name    = "pve"
   url          = "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-latest.x86_64.qcow2"
-  file_name    = "centos8.img"
 }
 ```
 
@@ -69,7 +68,7 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 
   disk {
     datastore_id = "local-lvm"
-    file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
+    import_from  = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
     interface    = "virtio0"
     iothread     = true
     discard      = "on"
@@ -78,10 +77,12 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 }
 
 resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-  content_type = "iso"
+  content_type = "import"
   datastore_id = "local"
   node_name    = "pve"
   url          = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  # need to rename the file to *.qcow2 to indicate the actual file format for import
+  file_name = "jammy-server-cloudimg-amd64.qcow2"
 }
 ```
 
@@ -110,6 +111,7 @@ resource "proxmox_virtual_environment_vm" "debian_vm" {
   disk {
     datastore_id = "local-lvm"
     # qcow2 image downloaded from https://cloud.debian.org/images/cloud/bookworm/latest/ and renamed to *.img
+    # the image is not of import type, so provider will use SSH client to import it
     file_id   = "local:iso/debian-12-genericcloud-amd64.img"
     interface = "virtio0"
     iothread  = true

--- a/docs/guides/cloud-init.md
+++ b/docs/guides/cloud-init.md
@@ -40,7 +40,7 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 
   disk {
     datastore_id = "local-lvm"
-    file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
+    import_from  = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
     interface    = "virtio0"
     iothread     = true
     discard      = "on"
@@ -53,11 +53,12 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 }
 
 resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-  content_type = "iso"
+  content_type = "import"
   datastore_id = "local"
   node_name    = "pve"
-
-  url = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  url          = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  # need to rename the file to *.qcow2 to indicate the actual file format for import
+  file_name = "jammy-server-cloudimg-amd64.qcow2"
 }
 ```
 
@@ -130,7 +131,7 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 
   disk {
     datastore_id = "local-lvm"
-    file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
+    import_from  = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
     interface    = "virtio0"
     iothread     = true
     discard      = "on"
@@ -154,11 +155,12 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 }
 
 resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-  content_type = "iso"
+  content_type = "import"
   datastore_id = "local"
   node_name    = "pve"
-
-  url = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  url          = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  # need to rename the file to *.qcow2 to indicate the actual file format for import
+  file_name = "jammy-server-cloudimg-amd64.qcow2"
 }
 
 output "vm_ipv4_address" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -296,7 +296,9 @@ terraform plan
 
 The Proxmox provider can connect to a Proxmox node via SSH.
 This is used in the `proxmox_virtual_environment_vm` or `proxmox_virtual_environment_file` resource to execute commands on the node to perform actions that are not supported by Proxmox API.
-For example, to import VM disks, or to uploading certain type of resources, such as snippets.
+For example, to import VM disks in certain cases, or to uploading certain type of resources, such as snippets.
+
+~> Note that the SSH connection is not used when VM disk is imported using `import_from` attribute. It also is not used to _manage_ VMs or Containers, and is not required for most operations.
 
 The SSH connection configuration is provided via the optional `ssh` block in the `provider` block:
 

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -9,8 +9,6 @@ subcategory: Virtual Environment
 
 Manages a virtual machine.
 
-> This resource uses SSH access to the node. You might need to configure the [`ssh` option in the `provider` section](../index.md#node-ip-address-used-for-ssh-connection).
-
 ## Example Usage
 
 ```hcl
@@ -47,7 +45,7 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 
   disk {
     datastore_id = "local-lvm"
-    file_id      = proxmox_virtual_environment_download_file.latest_ubuntu_22_jammy_qcow2_img.id
+    import_from  = proxmox_virtual_environment_download_file.latest_ubuntu_22_jammy_qcow2_img.id
     interface    = "scsi0"
   }
 
@@ -89,10 +87,12 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 }
 
 resource "proxmox_virtual_environment_download_file" "latest_ubuntu_22_jammy_qcow2_img" {
-  content_type = "iso"
+  content_type = "import"
   datastore_id = "local"
   node_name    = "pve"
-  url          = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  url = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  # need to rename the file to *.qcow2 to indicate the actual file format for import
+  file_name = "jammy-server-cloudimg-amd64.qcow2"
 }
 
 resource "random_password" "ubuntu_vm_password" {
@@ -295,7 +295,10 @@ output "ubuntu_vm_public_key" {
         - `vmdk` - VMware Disk Image.
     - `file_id` - (Optional) The file ID for a disk image when importing a disk into VM. The ID format is
           `<datastore_id>:<content_type>/<file_name>`, for example `local:iso/centos8.img`. Can be also taken from
-          `proxmox_virtual_environment_download_file` resource.
+          `proxmox_virtual_environment_download_file` resource. *Deprecated*, use `import_from` instead.
+    - `import_from` - (Optional) The file ID for a disk image to import into VM. The image must be of `import` content type.
+       The ID format is `<datastore_id>:import/<file_name>`, for example `local:import/centos8.qcow2`. Can be also taken from
+       `proxmox_virtual_environment_download_file` resource.
     - `interface` - (Required) The disk interface for Proxmox, currently `scsi`,
         `sata` and `virtio` interfaces are supported. Append the disk index at
         the end, for example, `virtio0` for the first virtio disk, `virtio1` for

--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -231,11 +231,18 @@ resource "proxmox_virtual_environment_vm" "data_vm" {
   disk {
     datastore_id = local.datastore_id
     interface    = "scsi0"
+    size         = 8
+    import_from  = proxmox_virtual_environment_download_file.latest_debian_12_bookworm_qcow2.id
+  }
+
+  disk {
+    datastore_id = local.datastore_id
+    interface    = "scsi1"
     size         = 1
   }
   disk {
     datastore_id = local.datastore_id
-    interface    = "scsi1"
+    interface    = "scsi2"
     size         = 4
   }
 }

--- a/examples/guides/cloud-image/centos-qcow2/main.tf
+++ b/examples/guides/cloud-image/centos-qcow2/main.tf
@@ -15,7 +15,7 @@ resource "proxmox_virtual_environment_vm" "centos_vm" {
 
   disk {
     datastore_id = "local-lvm"
-    file_id      = proxmox_virtual_environment_download_file.centos_cloud_image.id
+    import_from  = proxmox_virtual_environment_download_file.centos_cloud_image.id
     interface    = "virtio0"
     iothread     = true
     discard      = "on"
@@ -24,9 +24,8 @@ resource "proxmox_virtual_environment_vm" "centos_vm" {
 }
 
 resource "proxmox_virtual_environment_download_file" "centos_cloud_image" {
-  content_type = "iso"
+  content_type = "import"
   datastore_id = "local"
   node_name    = "pve"
   url          = "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-latest.x86_64.qcow2"
-  file_name    = "centos8.img"
 }

--- a/examples/guides/cloud-image/centos-qcow2/provider.tf
+++ b/examples/guides/cloud-image/centos-qcow2/provider.tf
@@ -10,8 +10,5 @@ terraform {
 provider "proxmox" {
   endpoint  = var.virtual_environment_endpoint
   api_token = var.virtual_environment_token
-  ssh {
-    agent    = true
-    username = "terraform"
-  }
+  # SSH configuration is not required for this example
 }

--- a/examples/guides/cloud-image/debian-from-storage/main.tf
+++ b/examples/guides/cloud-image/debian-from-storage/main.tf
@@ -16,6 +16,7 @@ resource "proxmox_virtual_environment_vm" "debian_vm" {
   disk {
     datastore_id = "local-lvm"
     # qcow2 image downloaded from https://cloud.debian.org/images/cloud/bookworm/latest/ and renamed to *.img
+    # the image is not of import type, so provider will use SSH client to import it
     file_id   = "local:iso/debian-12-genericcloud-amd64.img"
     interface = "virtio0"
     iothread  = true

--- a/examples/guides/cloud-image/ubuntu-img/main.tf
+++ b/examples/guides/cloud-image/ubuntu-img/main.tf
@@ -15,7 +15,7 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 
   disk {
     datastore_id = "local-lvm"
-    file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
+    import_from  = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
     interface    = "virtio0"
     iothread     = true
     discard      = "on"
@@ -24,8 +24,10 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 }
 
 resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-  content_type = "iso"
+  content_type = "import"
   datastore_id = "local"
   node_name    = "pve"
   url          = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  # need to rename the file to *.qcow2 to indicate the actual file format for import
+  file_name = "jammy-server-cloudimg-amd64.qcow2"
 }

--- a/examples/guides/cloud-image/ubuntu-img/provider.tf
+++ b/examples/guides/cloud-image/ubuntu-img/provider.tf
@@ -10,8 +10,4 @@ terraform {
 provider "proxmox" {
   endpoint  = var.virtual_environment_endpoint
   api_token = var.virtual_environment_token
-  ssh {
-    agent    = true
-    username = "terraform"
-  }
 }

--- a/examples/guides/cloud-init/custom/main.tf
+++ b/examples/guides/cloud-init/custom/main.tf
@@ -16,7 +16,7 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 
   disk {
     datastore_id = "local-lvm"
-    file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
+    import_from  = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
     interface    = "virtio0"
     iothread     = true
     discard      = "on"
@@ -40,11 +40,12 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 }
 
 resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-  content_type = "iso"
+  content_type = "import"
   datastore_id = "local"
   node_name    = "pve"
-
   url = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  # need to rename the file to *.qcow2 to indicate the actual file format for import
+  file_name = "jammy-server-cloudimg-amd64.qcow2"
 }
 
 output "vm_ipv4_address" {

--- a/examples/guides/cloud-init/custom/main.tf
+++ b/examples/guides/cloud-init/custom/main.tf
@@ -43,7 +43,7 @@ resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
   content_type = "import"
   datastore_id = "local"
   node_name    = "pve"
-  url = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  url          = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
   # need to rename the file to *.qcow2 to indicate the actual file format for import
   file_name = "jammy-server-cloudimg-amd64.qcow2"
 }

--- a/examples/guides/cloud-init/native/main.tf
+++ b/examples/guides/cloud-init/native/main.tf
@@ -25,7 +25,7 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 
   disk {
     datastore_id = "local-lvm"
-    file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
+    import_from  = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
     interface    = "virtio0"
     iothread     = true
     discard      = "on"
@@ -38,9 +38,10 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
 }
 
 resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-  content_type = "iso"
+  content_type = "import"
   datastore_id = "local"
   node_name    = "pve"
-
   url = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  # need to rename the file to *.qcow2 to indicate the actual file format for import
+  file_name = "jammy-server-cloudimg-amd64.qcow2"
 }

--- a/examples/guides/cloud-init/native/main.tf
+++ b/examples/guides/cloud-init/native/main.tf
@@ -41,7 +41,7 @@ resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
   content_type = "import"
   datastore_id = "local"
   node_name    = "pve"
-  url = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  url          = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
   # need to rename the file to *.qcow2 to indicate the actual file format for import
   file_name = "jammy-server-cloudimg-amd64.qcow2"
 }

--- a/examples/guides/cloud-init/native/provider.tf
+++ b/examples/guides/cloud-init/native/provider.tf
@@ -10,8 +10,4 @@ terraform {
 provider "proxmox" {
   endpoint  = var.virtual_environment_endpoint
   api_token = var.virtual_environment_token
-  ssh {
-    agent    = true
-    username = "terraform"
-  }
 }

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -411,6 +411,7 @@ func (d *CustomStorageDevice) MergeWith(m CustomStorageDevice) bool {
 	updated = ptr.UpdateIfChanged(&d.Replicate, m.Replicate) || updated
 	updated = ptr.UpdateIfChanged(&d.SSD, m.SSD) || updated
 	updated = ptr.UpdateIfChanged(&d.Serial, m.Serial) || updated
+	updated = ptr.UpdateIfChanged(&d.ImportFrom, m.ImportFrom) || updated
 
 	return updated
 }

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -36,6 +36,7 @@ type CustomStorageDevice struct {
 	BurstableWriteSpeedMbps *int              `json:"mbps_wr_max,omitempty" url:"mbps_wr_max,omitempty"`
 	Cache                   *string           `json:"cache,omitempty"       url:"cache,omitempty"`
 	Discard                 *string           `json:"discard,omitempty"     url:"discard,omitempty"`
+	ImportFrom              *string           `json:"import_from,omitempty" url:"import_from,omitempty"`
 	Format                  *string           `json:"format,omitempty"      url:"format,omitempty"`
 	IopsRead                *int              `json:"iops_rd,omitempty"     url:"iops_rd,omitempty"`
 	IopsWrite               *int              `json:"iops_wr,omitempty"     url:"iops_wr,omitempty"`
@@ -203,8 +204,16 @@ func (d *CustomStorageDevice) EncodeOptions() string {
 
 // EncodeValues converts a CustomStorageDevice struct to a URL value.
 func (d *CustomStorageDevice) EncodeValues(key string, v *url.Values) error {
+	if d.ImportFrom != nil && *d.ImportFrom != "" {
+		d.FileVolume = *d.DatastoreID + ":" + "0"
+	}
+
 	values := []string{
 		fmt.Sprintf("file=%s", d.FileVolume),
+	}
+
+	if d.ImportFrom != nil && *d.ImportFrom != "" {
+		values = append(values, fmt.Sprintf("import-from=%s", *d.ImportFrom))
 	}
 
 	if d.Format != nil {
@@ -272,6 +281,9 @@ func (d *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 
 			case "file":
 				d.FileVolume = v[1]
+
+			case "import_from":
+				d.ImportFrom = &v[1]
 
 			case "format":
 				d.Format = &v[1]

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -420,6 +420,10 @@ func Read(
 			disk[mkDiskFileID] = dd.FileID
 		}
 
+		if dd.ImportFrom != nil {
+			disk[mkDiskImportFrom] = dd.ImportFrom
+		}
+
 		disk[mkDiskInterface] = di
 		disk[mkDiskSize] = dd.Size.InGigabytes()
 
@@ -598,6 +602,13 @@ func Update(
 			if !ptr.Eq(tmp.AIO, disk.AIO) {
 				rebootRequired = true
 				tmp.AIO = disk.AIO
+			}
+
+			if disk.ImportFrom != nil && *disk.ImportFrom != "" {
+				rebootRequired = true
+				tmp.DatastoreID = disk.DatastoreID
+				tmp.ImportFrom = disk.ImportFrom
+				tmp.Size = disk.Size
 			}
 
 			tmp.Backup = disk.Backup

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"regexp"
 	"slices"
 	"strings"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"golang.org/x/exp/maps"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
@@ -560,7 +560,8 @@ func Read(
 				}
 			}
 
-			diskList = utils.OrderedListFromMapByKeyValues(diskMap, maps.Keys(currentDiskMap))
+			diskList = utils.OrderedListFromMapByKeyValues(diskMap,
+				slices.AppendSeq(make([]string, 0, len(currentDiskMap)), maps.Keys(currentDiskMap)))
 		} else {
 			diskList = utils.OrderedListFromMap(diskMap)
 		}

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -178,6 +178,7 @@ func GetDiskDeviceObjects(
 		diskInterface, _ := block[mkDiskInterface].(string)
 		fileFormat, _ := block[mkDiskFileFormat].(string)
 		fileID, _ := block[mkDiskFileID].(string)
+		importfrom, _ := block[mkDiskImportFrom].(string)
 		ioThread := types.CustomBool(block[mkDiskIOThread].(bool))
 		replicate := types.CustomBool(block[mkDiskReplicate].(bool))
 		serial := block[mkDiskSerial].(string)
@@ -212,6 +213,7 @@ func GetDiskDeviceObjects(
 		diskDevice.DatastoreID = &datastoreID
 		diskDevice.Discard = &discard
 		diskDevice.FileID = &fileID
+		diskDevice.ImportFrom = &importfrom
 		diskDevice.Replicate = &replicate
 		diskDevice.Serial = &serial
 		diskDevice.Size = types.DiskSizeFromGigabytes(int64(size))

--- a/proxmoxtf/resource/vm/disk/schema.go
+++ b/proxmoxtf/resource/vm/disk/schema.go
@@ -65,6 +65,7 @@ func Schema() map[string]*schema.Schema {
 						mkDiskCache:           dvDiskCache,
 						mkDiskDatastoreID:     dvDiskDatastoreID,
 						mkDiskDiscard:         dvDiskDiscard,
+						mkDiskImportFrom:      "",
 						mkDiskFileID:          "",
 						mkDiskInterface:       dvDiskInterface,
 						mkDiskIOThread:        false,

--- a/proxmoxtf/resource/vm/disk/schema.go
+++ b/proxmoxtf/resource/vm/disk/schema.go
@@ -31,6 +31,7 @@ const (
 	mkDiskDiscard             = "discard"
 	mkDiskFileFormat          = "file_format"
 	mkDiskFileID              = "file_id"
+	mkDiskImportFrom          = "import_from"
 	mkDiskInterface           = "interface"
 	mkDiskIopsRead            = "iops_read"
 	mkDiskIopsReadBurstable   = "iops_read_burstable"
@@ -130,6 +131,14 @@ func Schema() map[string]*schema.Schema {
 						Description:      "The file id for a disk image",
 						Optional:         true,
 						ForceNew:         true,
+						Default:          "",
+						ValidateDiagFunc: validators.FileID(),
+					},
+					mkDiskImportFrom: {
+						Type:             schema.TypeString,
+						Description:      "The file id of a disk image to import from storage.",
+						Optional:         true,
+						ForceNew:         false,
 						Default:          "",
 						ValidateDiagFunc: validators.FileID(),
 					},

--- a/proxmoxtf/resource/vm/disk/schema_test.go
+++ b/proxmoxtf/resource/vm/disk/schema_test.go
@@ -20,6 +20,7 @@ func TestVMSchema(t *testing.T) {
 		mkDiskPathInDatastore,
 		mkDiskFileFormat,
 		mkDiskFileID,
+		mkDiskImportFrom,
 		mkDiskSize,
 	})
 
@@ -28,6 +29,7 @@ func TestVMSchema(t *testing.T) {
 		mkDiskPathInDatastore: schema.TypeString,
 		mkDiskFileFormat:      schema.TypeString,
 		mkDiskFileID:          schema.TypeString,
+		mkDiskImportFrom:      schema.TypeString,
 		mkDiskSize:            schema.TypeInt,
 	})
 

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -2913,12 +2913,12 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		return diags
 	}
 
-	var resizeDisks = diskDeviceObjects.Filter(func(device *vms.CustomStorageDevice) bool {
+	resizeDisks := diskDeviceObjects.Filter(func(device *vms.CustomStorageDevice) bool {
 		return device.ImportFrom != nil && *device.ImportFrom != ""
 	})
-
 	if len(resizeDisks) > 0 {
 		tflog.Info(ctx, "Resizing disks after VM creation")
+
 		for idev, device := range resizeDisks {
 			tflog.Info(ctx, fmt.Sprintf("VM %d: Resizing disk %s", vmID, idev))
 

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5927,6 +5927,11 @@ func vmUpdateDiskLocationAndSize(
 				}
 			}
 
+			// We need to resize the disk if the import source has changed.
+			if *oldDisk.ImportFrom != *diskNewEntries[oldIface].ImportFrom {
+				*oldDisk.Size = 0
+			}
+
 			if *oldDisk.Size != *diskNewEntries[oldIface].Size {
 				if *oldDisk.Size < *diskNewEntries[oldIface].Size {
 					if oldDisk.IsOwnedBy(vmID) {

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -2913,6 +2913,25 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m interface{}) 
 		return diags
 	}
 
+	var resizeDisks = diskDeviceObjects.Filter(func(device *vms.CustomStorageDevice) bool {
+		return device.ImportFrom != nil && *device.ImportFrom != ""
+	})
+
+	if len(resizeDisks) > 0 {
+		tflog.Info(ctx, "Resizing disks after VM creation")
+		for idev, device := range resizeDisks {
+			tflog.Info(ctx, fmt.Sprintf("VM %d: Resizing disk %s", vmID, idev))
+
+			err = client.Node(nodeName).VM(vmID).ResizeVMDisk(ctx, &vms.ResizeDiskRequestBody{
+				Size: *device.Size,
+				Disk: idev,
+			})
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
 	return vmCreateStart(ctx, d, m)
 }
 


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
Running an example from /examples/guides/cloud-image/ubuntu-img

```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_download_file.ubuntu_cloud_image will be created
  + resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
      + content_type        = "import"
      + datastore_id        = "local"
      + file_name           = "jammy-server-cloudimg-amd64.qcow2"
      + id                  = (known after apply)
      + node_name           = "pve"
      + overwrite           = true
      + overwrite_unmanaged = false
      + size                = (known after apply)
      + upload_timeout      = 600
      + url                 = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
      + verify              = true
    }

  # proxmox_virtual_environment_vm.ubuntu_vm will be created
  + resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "test-ubuntu"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = true
      + stop_on_destroy         = true
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "on"
          + file_format       = (known after apply)
          + import_from       = (known after apply)
          + interface         = "virtio0"
          + iothread          = true
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 20
          + ssd               = false
        }

      + initialization {
          + datastore_id         = "local-lvm"
          + meta_data_file_id    = (known after apply)
          + network_data_file_id = (known after apply)
          + type                 = (known after apply)
          + user_data_file_id    = (known after apply)
          + vendor_data_file_id  = (known after apply)

          + user_account {
              + password = (sensitive value)
              + username = "user"
            }
        }

      + network_device (known after apply)

      + vga (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Creating...
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Still creating... [10s elapsed]
proxmox_virtual_environment_download_file.ubuntu_cloud_image: Creation complete after 16s [id=local:import/jammy-server-cloudimg-amd64.qcow2]
proxmox_virtual_environment_vm.ubuntu_vm: Creating...
proxmox_virtual_environment_vm.ubuntu_vm: Creation complete after 8s [id=101]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1913 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
