### PR TITLE
feat(provider): add support for ssh `agent_forwarding`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -436,6 +436,8 @@ In the example below, we create a user `terraform` and assign the `sudo` privile
 
   You should be able to connect to the target node and see the output containing `APIVER <number>` on the screen without being prompted for your password.
 
+Alteratively if `pam_ssh_agent_auth` is configured on the target node the SSH Config option `agent_forwarding` may be used to forward the SSH Agent that was used for the connection to the remote server. This can allow `sudo` with out a password which validates public ssh key configured for `pam_ssh_agent_auth`.
+
 ### Node IP address used for SSH connection
 
 In order to make the SSH connection, the provider needs to be able to resolve the target node name to an IP.
@@ -528,6 +530,7 @@ In addition to [generic provider arguments](https://developer.hashicorp.com/terr
     - `password` - (Optional) The password to use for the SSH connection. Defaults to the password used for the Proxmox API connection. Can also be sourced from `PROXMOX_VE_SSH_PASSWORD`.
     - `agent` - (Optional) Whether to use the SSH agent for the SSH authentication. Defaults to `false`. Can also be sourced from `PROXMOX_VE_SSH_AGENT`.
     - `agent_socket` - (Optional) The path to the SSH agent socket. Defaults to the value of the `SSH_AUTH_SOCK` environment variable. Can also be sourced from `PROXMOX_VE_SSH_AUTH_SOCK`.
+    - `agent_forwarding` - (Optional) Whether to enable SSH agent forwarding. Defaults to the value of the `PROXMOX_VE_SSH_AGENT_FORWARDING` environment variable, or `false` if not set.
     - `private_key` - (Optional) The private key to use for the SSH connection. Can also be sourced from `PROXMOX_VE_SSH_PRIVATE_KEY`. The private key must be in PEM format.
     - `socks5_server` - (Optional) The address of the SOCKS5 proxy server to use for the SSH connection. Can also be sourced from `PROXMOX_VE_SSH_SOCKS5_SERVER`.
     - `socks5_username` - (Optional) The username to use for the SOCKS5 proxy server. Can also be sourced from `PROXMOX_VE_SSH_SOCKS5_USERNAME`.

--- a/fwprovider/nodes/resource_download_file_test.go
+++ b/fwprovider/nodes/resource_download_file_test.go
@@ -280,10 +280,11 @@ func uploadIsoFile(t *testing.T, fileName string) {
 	sshUsername := utils.GetAnyStringEnv("PROXMOX_VE_SSH_USERNAME")
 	sshPassword := utils.GetAnyStringEnv("PROXMOX_VE_SSH_PASSWORD")
 	sshAgentSocket := utils.GetAnyStringEnv("SSH_AUTH_SOCK", "PROXMOX_VE_SSH_AUTH_SOCK")
+	sshAgentForwarding := utils.GetAnyBoolEnv("PROXMOX_VE_SSH_AGENT_FORWARDING")
 	sshPrivateKey := utils.GetAnyStringEnv("PROXMOX_VE_SSH_PRIVATE_KEY")
 	sshPort := utils.GetAnyIntEnv("PROXMOX_VE_ACC_NODE_SSH_PORT")
 	sshClient, err := ssh.NewClient(
-		sshUsername, sshPassword, sshAgent, sshAgentSocket, sshPrivateKey,
+		sshUsername, sshPassword, sshAgent, sshAgentSocket, sshAgentForwarding, sshPrivateKey,
 		"", "", "",
 		&nodeResolver{
 			node: ssh.ProxmoxNode{

--- a/fwprovider/test/resource_file_test.go
+++ b/fwprovider/test/resource_file_test.go
@@ -254,10 +254,11 @@ func uploadSnippetFile(t *testing.T, fileName string) {
 	sshUsername := utils.GetAnyStringEnv("PROXMOX_VE_SSH_USERNAME")
 	sshPassword := utils.GetAnyStringEnv("PROXMOX_VE_SSH_PASSWORD")
 	sshAgentSocket := utils.GetAnyStringEnv("SSH_AUTH_SOCK", "PROXMOX_VE_SSH_AUTH_SOCK")
+	sshAgentForwarding := utils.GetAnyBoolEnv("PROXMOX_VE_SSH_AGENT_FORWARDING")
 	sshPrivateKey := utils.GetAnyStringEnv("PROXMOX_VE_SSH_PRIVATE_KEY")
 	sshPort := utils.GetAnyIntEnv("PROXMOX_VE_ACC_NODE_SSH_PORT")
 	sshClient, err := ssh.NewClient(
-		sshUsername, sshPassword, sshAgent, sshAgentSocket, sshPrivateKey,
+		sshUsername, sshPassword, sshAgent, sshAgentSocket, sshAgentForwarding, sshPrivateKey,
 		"", "", "",
 		&nodeResolver{
 			node: ssh.ProxmoxNode{

--- a/proxmox/ssh/client.go
+++ b/proxmox/ssh/client.go
@@ -188,12 +188,12 @@ func (c *client) openSession(ctx context.Context, sshClient *ssh.Client) (*ssh.S
 	}
 
 	return sshSession, closer, nil
-
 }
 
 func (c *client) executeCommands(ctx context.Context, sshClient *ssh.Client, commands []string) ([]byte, error) {
 	sshSession, closer, err := c.openSession(ctx, sshClient)
 	defer closer()
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to open SSH session: %w", err)
 	}
@@ -393,6 +393,7 @@ func (c *client) uploadFile(
 ) error {
 	sshSession, closer, err := c.openSession(ctx, sshClient)
 	defer closer()
+
 	if err != nil {
 		return fmt.Errorf("failed to open SSH session: %w", err)
 	}

--- a/proxmox/ssh/client.go
+++ b/proxmox/ssh/client.go
@@ -32,14 +32,8 @@ import (
 
 const (
 	// TrySudo is a shell function that tries to execute a command with sudo if the user has sudo permissions.
-	TrySudo = `try_sudo(){ 
-		if [ "$(sudo whoami 2>/dev/null)" = "root" ] || 
-			 [ $(sudo -n pvesm apiinfo 2>&1 | grep "APIVER" | wc -l) -gt 0 ]; then 
-			sudo $1
-		else 
-			$1
-		fi 
-	}`
+	//nolint:lll
+	TrySudo = `try_sudo(){ if [ "$(sudo whoami 2>/dev/null)" = "root" ] || [ $(sudo -n pvesm apiinfo 2>&1 | grep "APIVER" | wc -l) -gt 0 ]; then sudo $1; else $1; fi }`
 )
 
 // NewErrUserHasNoPermission creates a new error indicating that the SSH user does not have required permissions.

--- a/proxmoxtf/provider/provider.go
+++ b/proxmoxtf/provider/provider.go
@@ -127,6 +127,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	sshPassword := utils.GetAnyStringEnv("PROXMOX_VE_SSH_PASSWORD", "PM_VE_SSH_PASSWORD")
 	sshAgent := utils.GetAnyBoolEnv("PROXMOX_VE_SSH_AGENT", "PM_VE_SSH_AGENT")
 	sshAgentSocket := utils.GetAnyStringEnv("SSH_AUTH_SOCK", "PROXMOX_VE_SSH_AUTH_SOCK", "PM_VE_SSH_AUTH_SOCK")
+	sshAgentForwarding := utils.GetAnyBoolEnv("PROXMOX_VE_SSH_AGENT_FORWARDING", "PM_VE_SSH_AGENT_FORWARDING")
 	sshPrivateKey := utils.GetAnyStringEnv("PROXMOX_VE_SSH_PRIVATE_KEY")
 	sshSocks5Server := utils.GetAnyStringEnv("PROXMOX_VE_SSH_SOCKS5_SERVER")
 	sshSocks5Username := utils.GetAnyStringEnv("PROXMOX_VE_SSH_SOCKS5_USERNAME")
@@ -160,6 +161,10 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	if v, ok := sshConf[mkProviderSSHAgentSocket]; !ok || v.(string) == "" {
 		sshConf[mkProviderSSHAgentSocket] = sshAgentSocket
+	}
+
+	if _, ok := sshConf[mkProviderSSHAgentForwarding]; !ok {
+		sshConf[mkProviderSSHAgentForwarding] = sshAgentForwarding
 	}
 
 	if v, ok := sshConf[mkProviderSSHPrivateKey]; !ok || v.(string) == "" {
@@ -196,6 +201,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		sshConf[mkProviderSSHPassword].(string),
 		sshConf[mkProviderSSHAgent].(bool),
 		sshConf[mkProviderSSHAgentSocket].(string),
+		sshConf[mkProviderSSHAgentForwarding].(bool),
 		sshConf[mkProviderSSHPrivateKey].(string),
 		sshConf[mkProviderSSHSocks5Server].(string),
 		sshConf[mkProviderSSHSocks5Username].(string),

--- a/proxmoxtf/provider/schema.go
+++ b/proxmoxtf/provider/schema.go
@@ -32,6 +32,7 @@ const (
 	mkProviderSSHPassword         = "password"
 	mkProviderSSHAgent            = "agent"
 	mkProviderSSHAgentSocket      = "agent_socket"
+	mkProviderSSHAgentForwarding  = "agent_forwarding"
 	mkProviderSSHPrivateKey       = "private_key"
 	mkProviderSSHSocks5Server     = "socks5_server"
 	mkProviderSSHSocks5Username   = "socks5_username"
@@ -163,6 +164,23 @@ func createSchema() map[string]*schema.Schema {
 							nil,
 						),
 						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					mkProviderSSHAgentForwarding: {
+						Type:     schema.TypeBool,
+						Optional: true,
+						Description: "Whether to enable SSH agent forwarding. Defaults to the value of the " +
+							"`PROXMOX_VE_SSH_AGENT_FORWARDING` environment variable, or `false` if not set.",
+						DefaultFunc: func() (interface{}, error) {
+							for _, k := range []string{"PROXMOX_VE_SSH_AGENT_FORWARDING", "PM_VE_SSH_AGENT_FORWARDING"} {
+								v := os.Getenv(k)
+
+								if v == "true" || v == "1" {
+									return true, nil
+								}
+							}
+
+							return false, nil
+						},
 					},
 					mkProviderSSHPrivateKey: {
 						Type:      schema.TypeString,


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

This PR adds support for ssh agent forwarding using the Go ssh agent forwarding std lib. I found that with `pam_ssh_agent_auth` the `try_sudo` check with `sudo -n`  would not work unless sudo was run once first (presumably starting a session). To work around this I added an additional check to see if sudo worked with out restriction with `sudo whoami` then falling back to the previous behavior if it failed. 

To properly test this the [pam_ssh_agetnt_auth](https://manpages.debian.org/testing/libpam-ssh-agent-auth/pam_ssh_agent_auth.8.en.html) would need to be set up on the PVE node. I have validated this works with my setup, and also validated there were no regressions with the existing documentation regarding the sudoers file. 

If there is an ideal way to add tests for this let me know, but it was not otherwise clear how this would best be tested. 

Below is the minimum required config to trigger this change. 

```hcl
provider "proxmox" {
  endpoint  = var.virtual_environment_endpoint
  api_token = var.virtual_environment_token

  insecure = true

  ssh {
    agent            = true
    agent_forwarding = true
    username         = "ops"
    node {
      name    = "pve-02"
      address = "pve-02"
    }
  }
}

resource "proxmox_virtual_environment_file" "example_snippet" {
  content_type = "snippets"
  datastore_id = "snippets"
  node_name    = "pve-02"

  source_raw {
    data = <<-EOF
    #cloud-config
    hostname: test-ubuntu
    timezone: America/Los_Angeles
    EOF

    file_name = "example.yaml"
  }
}
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2019 
<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
