### PR TITLE
fix(lxc): avoid setting domain to `" "` when null during clone

### DIFF
--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -341,6 +341,9 @@ func TestAccResourceContainer(t *testing.T) {
 				
 				initialization {
 					hostname = "test-clone"
+					dns {
+					  servers = ["1.1.1.1"]
+					}
 				}
 			}`, WithRootUser()),
 			Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
Also, fix population of new `ipv4`/`ipv6` in template containers.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
```hcl
resource "proxmox_virtual_environment_container" "debian_container" {
  node_name = "pve"

  vm_id = 999
  template = true

  initialization {
    hostname = "test-container"

    dns {
      domain = null
      servers = ["1.1.1.1"]
    }

    ip_config {
      ipv4 {
        address = "dhcp"
      }
    }
  }

  disk {
    datastore_id = "local-lvm"
    size         = 4
  }

  operating_system {
    template_file_id = "local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz"
    type             = "ubuntu"
  }

  network_interface {
    name   = "eth0"
    bridge = "vmbr0"
  }
}

resource "proxmox_virtual_environment_container" "clone" {
  node_name = "pve"

  depends_on = [proxmox_virtual_environment_container.debian_container]

  clone {
    vm_id = 999
  }

  initialization {
    hostname = "DOCKER-MON"

    ip_config {
      ipv4 {
        address = "dhcp"
      }
    }

    dns {
      servers = ["8.8.8.8"]
    }
  }
}
```
```
❯ tofu apply -auto-approve

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_container.clone will be created
  + resource "proxmox_virtual_environment_container" "clone" {
      + id             = (known after apply)
      + ipv4           = (known after apply)
      + ipv6           = (known after apply)
      + node_name      = "pve"
      + protection     = false
      + start_on_boot  = true
      + started        = true
      + template       = false
      + timeout_clone  = 1800
      + timeout_create = 1800
      + timeout_delete = 60
      + timeout_start  = 300
      + timeout_update = 1800
      + unprivileged   = false
      + vm_id          = (known after apply)

      + clone {
          + vm_id = 999
        }

      + initialization {
          + hostname = "DOCKER-MON"

          + dns {
              + servers = [
                  + "8.8.8.8",
                ]
            }

          + ip_config {
              + ipv4 {
                  + address = "dhcp"
                }
            }
        }
    }

  # proxmox_virtual_environment_container.debian_container will be created
  + resource "proxmox_virtual_environment_container" "debian_container" {
      + id             = (known after apply)
      + ipv4           = (known after apply)
      + ipv6           = (known after apply)
      + node_name      = "pve"
      + protection     = false
      + start_on_boot  = true
      + template       = true
      + timeout_clone  = 1800
      + timeout_create = 1800
      + timeout_delete = 60
      + timeout_start  = 300
      + timeout_update = 1800
      + unprivileged   = false
      + vm_id          = 999

      + disk {
          + datastore_id = "local-lvm"
          + size         = 4
        }

      + initialization {
          + hostname = "test-container"

          + dns {
              + servers = [
                  + "1.1.1.1",
                ]
            }

          + ip_config {
              + ipv4 {
                  + address = "dhcp"
                }
            }
        }

      + network_interface {
          + bridge      = "vmbr0"
          + enabled     = true
          + firewall    = false
          + mac_address = (known after apply)
          + mtu         = 0
          + name        = "eth0"
          + rate_limit  = 0
          + vlan_id     = 0
        }

      + operating_system {
          + template_file_id = "local:vztmpl/ubuntu-20.04-standard_20.04-1_amd64.tar.gz"
          + type             = "ubuntu"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_container.debian_container: Creating...
proxmox_virtual_environment_container.debian_container: Creation complete after 8s [id=999]
proxmox_virtual_environment_container.clone: Creating...
proxmox_virtual_environment_container.clone: Still creating... [10s elapsed]
proxmox_virtual_environment_container.clone: Creation complete after 10s [id=100]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
❯ tofu apply -auto-approve

proxmox_virtual_environment_container.debian_container: Refreshing state... [id=999]
proxmox_virtual_environment_container.clone: Refreshing state... [id=100]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
❯ 
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2011

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of DNS configuration for containers to avoid setting empty values.
  * Ensured network information is consistently set in the state, even if the container is not started or an error occurs.

* **Tests**
  * Updated container resource tests to include DNS server configuration in initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->