### PR TITLE
fix(network): resolve comment field inconsistency in network interface resources

### DIFF
--- a/fwprovider/nodes/network/resource_linux_bridge.go
+++ b/fwprovider/nodes/network/resource_linux_bridge.go
@@ -73,7 +73,10 @@ func (m *linuxBridgeResourceModel) exportToNetworkInterfaceCreateUpdateBody() *n
 		body.MTU = m.MTU.ValueInt64Pointer()
 	}
 
-	body.Comments = m.Comment.ValueStringPointer()
+	if !m.Comment.IsNull() && !m.Comment.IsUnknown() {
+		trimmed := strings.TrimSpace(m.Comment.ValueString())
+		body.Comments = &trimmed
+	}
 
 	var sanitizedPorts []string
 

--- a/fwprovider/nodes/network/resource_linux_vlan.go
+++ b/fwprovider/nodes/network/resource_linux_vlan.go
@@ -66,7 +66,10 @@ func (m *linuxVLANResourceModel) exportToNetworkInterfaceCreateUpdateBody() *nod
 	body.Gateway = m.Gateway.ValueStringPointer()
 	body.CIDR6 = m.Address6.ValueStringPointer()
 	body.Gateway6 = m.Gateway6.ValueStringPointer()
-	body.Comments = m.Comment.ValueStringPointer()
+	if !m.Comment.IsNull() && !m.Comment.IsUnknown() {
+		trimmed := strings.TrimSpace(m.Comment.ValueString())
+		body.Comments = &trimmed
+	}
 
 	if !m.MTU.IsUnknown() {
 		body.MTU = m.MTU.ValueInt64Pointer()


### PR DESCRIPTION
## Summary
- Fix inconsistency where comment fields in `network_linux_vlan` and `network_linux_bridge` resources were trimmed on read but not on write
- Resolves "Provider produced inconsistent result after apply" errors when comment fields contain leading/trailing whitespace

## Root Cause
The issue occurred because:
- `exportToNetworkInterfaceCreateUpdateBody()` sent comments as-is to the Proxmox API
- `importFromNetworkInterfaceList()` applied `strings.TrimSpace()` when reading back from the API

This mismatch caused Terraform to detect state drift between plan and apply operations.

## Solution
Apply consistent trimming by using `strings.TrimSpace()` before sending comments to the API, ensuring the sent value matches what will be read back.

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Code is properly formatted (`make fmt`)
- [x] Follows conventional commit format
- [x] DCO sign-off included

## Files Changed
- `fwprovider/nodes/network/resource_linux_vlan.go`
- `fwprovider/nodes/network/resource_linux_bridge.go`

Fixes #2038

🤖 Generated with [Claude Code](https://claude.ai/code)