### PR TITLE
fix(api): improve API response error handling

### DIFF
--- a/proxmox/api/client_types.go
+++ b/proxmox/api/client_types.go
@@ -20,8 +20,9 @@ type MultiPartData struct {
 
 // ErrorResponseBody contains the body of an error response.
 type ErrorResponseBody struct {
-	Data   *string            `json:"data"`
-	Errors *map[string]string `json:"errors"`
+	Data    *string            `json:"data"`
+	Message *string            `json:"message"`
+	Errors  *map[string]string `json:"errors"`
 }
 
 // FileUploadRequest is a request for uploading a file.


### PR DESCRIPTION
PVE API may return an error response that contains additional details about the error, often in a multi-line format (`\n`-separated). The current code captures only an error from the HTTP status. 
Now we can see more details downstream in the TF errors.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [ ] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
See new unit test with an error response returning additional sdetails.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000 | Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error messages for failed API responses, now including additional details from the response body when available.

* **Bug Fixes**
  * Enhanced error handling to better parse and display error messages from server responses.

* **Tests**
  * Added and updated tests to verify improved error handling for API responses with detailed error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->