### PR TITLE
fix(vm): regression: disk re-ordering on re-apply

### DIFF
--- a/fwprovider/test/resource_vm_disks_test.go
+++ b/fwprovider/test/resource_vm_disks_test.go
@@ -246,6 +246,202 @@ func TestAccResourceVMDisks(t *testing.T) {
 				RefreshState: true,
 			},
 		}},
+		{"disk ordering consistency", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_disk_ordering" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name 	  = "test-disk-ordering"
+					
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "virtio2"
+						size         = 8
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi1"
+						size         = 15
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "sata0"
+						size         = 12
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi0"
+						size         = 10
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "virtio0"
+						size         = 20
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi3"
+						size         = 5
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "virtio1"
+						size         = 18
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi2"
+						size         = 25
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_disk_ordering", map[string]string{
+					"disk.0.interface": "virtio2",
+					"disk.0.size":      "8",
+					"disk.1.interface": "scsi1",
+					"disk.1.size":      "15",
+					"disk.2.interface": "sata0",
+					"disk.2.size":      "12",
+					"disk.3.interface": "scsi0",
+					"disk.3.size":      "10",
+					"disk.4.interface": "virtio0",
+					"disk.4.size":      "20",
+					"disk.5.interface": "scsi3",
+					"disk.5.size":      "5",
+					"disk.6.interface": "virtio1",
+					"disk.6.size":      "18",
+					"disk.7.interface": "scsi2",
+					"disk.7.size":      "25",
+				}),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_disk_ordering" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name 	  = "test-disk-ordering"
+					
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "virtio2"
+						size         = 8
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi1"
+						size         = 15
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "sata0"
+						size         = 12
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi0"
+						size         = 10
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "virtio0"
+						size         = 20
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi3"
+						size         = 5
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "virtio1"
+						size         = 18
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi2"
+						size         = 25
+					}
+				}`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_disk_ordering", map[string]string{
+					"disk.0.interface": "virtio2",
+					"disk.0.size":      "8",
+					"disk.1.interface": "scsi1",
+					"disk.1.size":      "15",
+					"disk.2.interface": "sata0",
+					"disk.2.size":      "12",
+					"disk.3.interface": "scsi0",
+					"disk.3.size":      "10",
+					"disk.4.interface": "virtio0",
+					"disk.4.size":      "20",
+					"disk.5.interface": "scsi3",
+					"disk.5.size":      "5",
+					"disk.6.interface": "virtio1",
+					"disk.6.size":      "18",
+					"disk.7.interface": "scsi2",
+					"disk.7.size":      "25",
+				}),
+			},
+			{
+				// Third apply to ensure consistency across multiple applies
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_disk_ordering" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name 	  = "test-disk-ordering"
+					
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "virtio2"
+						size         = 8
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi1"
+						size         = 15
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "sata0"
+						size         = 12
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi0"
+						size         = 10
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "virtio0"
+						size         = 20
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi3"
+						size         = 5
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "virtio1"
+						size         = 18
+					}
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi2"
+						size         = 25
+					}
+				}`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		}},
 		{"adding disks", []resource.TestStep{
 			{
 				Config: te.RenderConfig(`

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"regexp"
 	"slices"
 	"strings"
@@ -560,11 +559,8 @@ func Read(
 				}
 			}
 
-			// Sort keys to ensure deterministic ordering
-			currentKeys := slices.Collect(maps.Keys(currentDiskMap))
-			slices.SortFunc(currentKeys, utils.CompareWithPrefix)
-
-			diskList = utils.OrderedListFromMapByKeyValues(diskMap, currentKeys)
+			disks := utils.ListResourcesAttributeValue(currentDiskList, mkDiskInterface)
+			diskList = utils.OrderedListFromMapByKeyValues(diskMap, disks)
 		} else {
 			diskList = utils.OrderedListFromMap(diskMap)
 		}

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -560,8 +560,11 @@ func Read(
 				}
 			}
 
-			diskList = utils.OrderedListFromMapByKeyValues(diskMap,
-				slices.AppendSeq(make([]string, 0, len(currentDiskMap)), maps.Keys(currentDiskMap)))
+			// Sort keys to ensure deterministic ordering
+			currentKeys := slices.Collect(maps.Keys(currentDiskMap))
+			slices.SortFunc(currentKeys, utils.CompareWithPrefix)
+
+			diskList = utils.OrderedListFromMapByKeyValues(diskMap, currentKeys)
 		} else {
 			diskList = utils.OrderedListFromMap(diskMap)
 		}

--- a/proxmoxtf/resource/vm/disk/disk_test.go
+++ b/proxmoxtf/resource/vm/disk/disk_test.go
@@ -76,12 +76,9 @@ func TestDiskOrderingDeterministic(t *testing.T) {
 		ctx := context.Background()
 		vmID := 100 // Test VM ID
 
-		var client proxmox.Client = nil // We avoid API calls by setting Format
+		var client proxmox.Client = nil
 
-		nodeName := "test-node"
-		isClone := false
-
-		diags := Read(ctx, resourceData, diskDeviceObjects, vmID, client, nodeName, isClone)
+		diags := Read(ctx, resourceData, diskDeviceObjects, vmID, client, "test-node", false)
 		require.Empty(t, diags, "Read should not return any diagnostics")
 
 		// Get the resulting disk list
@@ -167,10 +164,7 @@ func TestDiskOrderingVariousInterfaces(t *testing.T) {
 
 		var client proxmox.Client = nil
 
-		nodeName := "test-node"
-		isClone := false
-
-		diags := Read(ctx, resourceData, diskDeviceObjects, vmID, client, nodeName, isClone)
+		diags := Read(ctx, resourceData, diskDeviceObjects, vmID, client, "test-node", false)
 		require.Empty(t, diags)
 
 		diskList := resourceData.Get(MkDisk).([]interface{})

--- a/proxmoxtf/resource/vm/disk/disk_test.go
+++ b/proxmoxtf/resource/vm/disk/disk_test.go
@@ -1,0 +1,195 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package disk
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
+)
+
+// TestDiskOrderingDeterministic tests that disk ordering is deterministic
+// when reading VM disk configuration. This test addresses the issue where
+// disk interfaces (scsi0, scsi1, etc.) would randomly reorder on each
+// terraform apply due to Go's non-deterministic map iteration.
+func TestDiskOrderingDeterministic(t *testing.T) {
+	t.Parallel()
+
+	// Create test schema
+	diskSchema := Schema()
+
+	// Create resource data with multiple disks in a specific order that could be affected by map iteration
+	currentDiskList := []interface{}{
+		map[string]interface{}{
+			mkDiskInterface:   "scsi1", // Intentionally put scsi1 first
+			mkDiskDatastoreID: "local",
+			mkDiskSize:        150,
+			mkDiskSpeed:       []interface{}{},
+		},
+		map[string]interface{}{
+			mkDiskInterface:   "scsi0", // Then scsi0 second
+			mkDiskDatastoreID: "local",
+			mkDiskSize:        50,
+			mkDiskSpeed:       []interface{}{},
+		},
+	}
+
+	// Mock VM disk data from API that matches the currentDiskList
+	// Set Format to avoid API calls in the Read function
+	qcow2Format := "qcow2"
+	diskDeviceObjects := vms.CustomStorageDevices{
+		"scsi0": &vms.CustomStorageDevice{
+			FileVolume: "local:50",
+			Size:       types.DiskSizeFromGigabytes(50),
+			Format:     &qcow2Format,
+		},
+		"scsi1": &vms.CustomStorageDevice{
+			FileVolume: "local:150",
+			Size:       types.DiskSizeFromGigabytes(150),
+			Format:     &qcow2Format,
+		},
+	}
+
+	// Run the ordering logic multiple times to ensure deterministic results
+	const iterations = 10
+
+	results := make([][]interface{}, 0, iterations)
+
+	for range iterations {
+		// Create a new resource data for each iteration
+		resourceData := schema.TestResourceDataRaw(t, diskSchema, map[string]interface{}{
+			MkDisk: currentDiskList,
+		})
+
+		// Call the Read function which contains our fixed ordering logic
+		ctx := context.Background()
+		vmID := 100 // Test VM ID
+
+		var client proxmox.Client = nil // We avoid API calls by setting Format
+
+		nodeName := "test-node"
+		isClone := false
+
+		diags := Read(ctx, resourceData, diskDeviceObjects, vmID, client, nodeName, isClone)
+		require.Empty(t, diags, "Read should not return any diagnostics")
+
+		// Get the resulting disk list
+		diskList := resourceData.Get(MkDisk).([]interface{})
+		results = append(results, diskList)
+	}
+
+	// Verify all results are identical (deterministic ordering)
+	expectedResult := results[0]
+	for i, result := range results {
+		require.True(t, reflect.DeepEqual(expectedResult, result),
+			"Disk ordering should be deterministic across multiple calls. Iteration %d differs from first result", i)
+	}
+
+	// Verify the specific ordering - should be scsi0, then scsi1 (numerical order)
+	require.Len(t, expectedResult, 2, "Should have 2 disks")
+
+	disk0 := expectedResult[0].(map[string]interface{})
+	disk1 := expectedResult[1].(map[string]interface{})
+
+	require.Equal(t, "scsi0", disk0[mkDiskInterface], "First disk should be scsi0")
+	require.Equal(t, 50, disk0[mkDiskSize], "First disk should have size 50")
+
+	require.Equal(t, "scsi1", disk1[mkDiskInterface], "Second disk should be scsi1")
+	require.Equal(t, 150, disk1[mkDiskSize], "Second disk should have size 150")
+}
+
+// TestDiskOrderingVariousInterfaces tests deterministic ordering with various disk interfaces.
+func TestDiskOrderingVariousInterfaces(t *testing.T) {
+	t.Parallel()
+
+	diskSchema := Schema()
+
+	// Test with various interface types in random order
+	currentDiskList := []interface{}{
+		map[string]interface{}{
+			mkDiskInterface:   "virtio2",
+			mkDiskDatastoreID: "local",
+			mkDiskSize:        30,
+			mkDiskSpeed:       []interface{}{},
+		},
+		map[string]interface{}{
+			mkDiskInterface:   "scsi0",
+			mkDiskDatastoreID: "local",
+			mkDiskSize:        10,
+			mkDiskSpeed:       []interface{}{},
+		},
+		map[string]interface{}{
+			mkDiskInterface:   "sata1",
+			mkDiskDatastoreID: "local",
+			mkDiskSize:        20,
+			mkDiskSpeed:       []interface{}{},
+		},
+		map[string]interface{}{
+			mkDiskInterface:   "virtio0",
+			mkDiskDatastoreID: "local",
+			mkDiskSize:        40,
+			mkDiskSpeed:       []interface{}{},
+		},
+	}
+
+	qcow2Format := "qcow2"
+	diskDeviceObjects := vms.CustomStorageDevices{
+		"scsi0":   &vms.CustomStorageDevice{FileVolume: "local:10", Size: types.DiskSizeFromGigabytes(10), Format: &qcow2Format},
+		"sata1":   &vms.CustomStorageDevice{FileVolume: "local:20", Size: types.DiskSizeFromGigabytes(20), Format: &qcow2Format},
+		"virtio2": &vms.CustomStorageDevice{FileVolume: "local:30", Size: types.DiskSizeFromGigabytes(30), Format: &qcow2Format},
+		"virtio0": &vms.CustomStorageDevice{FileVolume: "local:40", Size: types.DiskSizeFromGigabytes(40), Format: &qcow2Format},
+	}
+
+	// Test multiple iterations
+	const iterations = 5
+
+	results := make([][]interface{}, 0, iterations)
+
+	for range iterations {
+		resourceData := schema.TestResourceDataRaw(t, diskSchema, map[string]interface{}{
+			MkDisk: currentDiskList,
+		})
+
+		ctx := context.Background()
+		vmID := 100
+
+		var client proxmox.Client = nil
+
+		nodeName := "test-node"
+		isClone := false
+
+		diags := Read(ctx, resourceData, diskDeviceObjects, vmID, client, nodeName, isClone)
+		require.Empty(t, diags)
+
+		diskList := resourceData.Get(MkDisk).([]interface{})
+		results = append(results, diskList)
+	}
+
+	// Verify deterministic ordering
+	expectedResult := results[0]
+	for i, result := range results {
+		require.True(t, reflect.DeepEqual(expectedResult, result),
+			"Disk ordering should be deterministic for various interfaces. Iteration %d differs", i)
+	}
+
+	// Verify logical ordering: sata1, scsi0, virtio0, virtio2
+	require.Len(t, expectedResult, 4)
+
+	expectedOrder := []string{"sata1", "scsi0", "virtio0", "virtio2"}
+	for i, expectedInterface := range expectedOrder {
+		disk := expectedResult[i].(map[string]interface{})
+		require.Equal(t, expectedInterface, disk[mkDiskInterface],
+			"Disk at position %d should be %s", i, expectedInterface)
+	}
+}

--- a/utils/maps.go
+++ b/utils/maps.go
@@ -26,7 +26,7 @@ func OrderedListFromMap(inputMap map[string]interface{}) []interface{} {
 		i++
 	}
 
-	slices.SortFunc(keyList, compareWithPrefix)
+	slices.SortFunc(keyList, CompareWithPrefix)
 
 	return OrderedListFromMapByKeyValues(inputMap, keyList)
 }
@@ -36,7 +36,7 @@ func OrderedListFromMap(inputMap map[string]interface{}) []interface{} {
 // - If numbers are equal, falls back to string comparison (preserving digit formatting).
 // - If numeric parsing fails, falls back to string comparison.
 // - If prefixes differ, compares the whole values as strings.
-func compareWithPrefix(a, b string) int {
+func CompareWithPrefix(a, b string) int {
 	prefix := commonPrefix(a, b)
 
 	if prefix != "" {

--- a/utils/maps_test.go
+++ b/utils/maps_test.go
@@ -114,7 +114,7 @@ func TestCompareWithPrefix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equalf(t, tt.want, compareWithPrefix(tt.args.a, tt.args.b), "compareWithPrefix(%v, %v)", tt.args.a, tt.args.b)
+			assert.Equalf(t, tt.want, CompareWithPrefix(tt.args.a, tt.args.b), "CompareWithPrefix(%v, %v)", tt.args.a, tt.args.b)
 		})
 	}
 }


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
This resource apply and re-apply without any issues:
```hcl
resource "proxmox_virtual_environment_vm" "test_disk_ordering" {
  node_name = "pve"
  started   = false
  name 	  = "test-disk-ordering"

  disk {
    datastore_id = "local-lvm"
    interface    = "virtio2"
    size         = 8
  }
  disk {
    datastore_id = "local-lvm"
    interface    = "scsi1"
    size         = 15
  }
  disk {
    datastore_id = "local-lvm"
    interface    = "sata0"
    size         = 12
  }
  disk {
    datastore_id = "local-lvm"
    interface    = "scsi0"
    size         = 10
  }
  disk {
    datastore_id = "local-lvm"
    interface    = "virtio0"
    size         = 20
  }
  disk {
    datastore_id = "local-lvm"
    interface    = "scsi3"
    size         = 5
  }
  disk {
    datastore_id = "local-lvm"
    interface    = "virtio1"
    size         = 18
  }
  disk {
    datastore_id = "local-lvm"
    interface    = "scsi2"
    size         = 25
  }
}
```
```
❯ tofu apply -auto-approve

OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

OpenTofu will perform the following actions:

  # proxmox_virtual_environment_vm.test_disk_ordering will be created
  + resource "proxmox_virtual_environment_vm" "test_disk_ordering" {
      + acpi                    = true
      + bios                    = "seabios"
      + id                      = (known after apply)
      + ipv4_addresses          = (known after apply)
      + ipv6_addresses          = (known after apply)
      + keyboard_layout         = "en-us"
      + mac_addresses           = (known after apply)
      + migrate                 = false
      + name                    = "test-disk-ordering"
      + network_interface_names = (known after apply)
      + node_name               = "pve"
      + on_boot                 = true
      + protection              = false
      + reboot                  = false
      + reboot_after_update     = true
      + scsi_hardware           = "virtio-scsi-pci"
      + started                 = false
      + stop_on_destroy         = false
      + tablet_device           = true
      + template                = false
      + timeout_clone           = 1800
      + timeout_create          = 1800
      + timeout_migrate         = 1800
      + timeout_move_disk       = 1800
      + timeout_reboot          = 1800
      + timeout_shutdown_vm     = 1800
      + timeout_start_vm        = 1800
      + timeout_stop_vm         = 300
      + vm_id                   = (known after apply)

      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "ignore"
          + file_format       = (known after apply)
          + interface         = "virtio2"
          + iothread          = false
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 8
          + ssd               = false
        }
      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "ignore"
          + file_format       = (known after apply)
          + interface         = "scsi1"
          + iothread          = false
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 15
          + ssd               = false
        }
      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "ignore"
          + file_format       = (known after apply)
          + interface         = "sata0"
          + iothread          = false
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 12
          + ssd               = false
        }
      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "ignore"
          + file_format       = (known after apply)
          + interface         = "scsi0"
          + iothread          = false
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 10
          + ssd               = false
        }
      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "ignore"
          + file_format       = (known after apply)
          + interface         = "virtio0"
          + iothread          = false
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 20
          + ssd               = false
        }
      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "ignore"
          + file_format       = (known after apply)
          + interface         = "scsi3"
          + iothread          = false
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 5
          + ssd               = false
        }
      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "ignore"
          + file_format       = (known after apply)
          + interface         = "virtio1"
          + iothread          = false
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 18
          + ssd               = false
        }
      + disk {
          + aio               = "io_uring"
          + backup            = true
          + cache             = "none"
          + datastore_id      = "local-lvm"
          + discard           = "ignore"
          + file_format       = (known after apply)
          + interface         = "scsi2"
          + iothread          = false
          + path_in_datastore = (known after apply)
          + replicate         = true
          + size              = 25
          + ssd               = false
        }

      + network_device (known after apply)

      + vga (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
proxmox_virtual_environment_vm.test_disk_ordering: Creating...
proxmox_virtual_environment_vm.test_disk_ordering: Creation complete after 4s [id=105]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
❯ tofu apply -auto-approve
proxmox_virtual_environment_vm.test_disk_ordering: Refreshing state... [id=105]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
❯ tofu apply -auto-approve
proxmox_virtual_environment_vm.test_disk_ordering: Refreshing state... [id=105]

No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2059

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Ensured deterministic VM disk ordering across plans and applies, preventing unexpected reordering and reducing spurious changes in diffs.

- Tests
  - Added comprehensive acceptance and unit tests to validate stable disk ordering across multiple applies and different disk interfaces, improving reliability and preventing regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->