### PR TITLE
fix(vm): do not re-import existing disks during update

### DIFF
--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -631,12 +631,8 @@ func Update(
 				tmp.AIO = disk.AIO
 			}
 
-			if disk.ImportFrom != nil && *disk.ImportFrom != "" {
-				shutdownBeforeUpdate = true
-				tmp.DatastoreID = disk.DatastoreID
-				tmp.ImportFrom = disk.ImportFrom
-				tmp.Size = disk.Size
-			}
+			// Never re-import existing disks - import_from is only for initial disk creation.
+			// See https://github.com/bpg/terraform-provider-proxmox/issues/2385
 
 			tmp.Backup = disk.Backup
 			tmp.BurstableReadSpeedMbps = disk.BurstableReadSpeedMbps
@@ -658,5 +654,7 @@ func Update(
 		}
 	}
 
+	// shutdownBeforeUpdate is always false now, as we're not updating a boot disk that was imported.
+	// but let's keep this api / flag in place for future use.
 	return shutdownBeforeUpdate, rebootRequired, nil
 }


### PR DESCRIPTION
The `import_from` attribute should only be used during initial disk creation, not during updates. 

This reverts the re-import logic introduced in v0.88.0 and restores the behaviour from v0.87.0 where `import_from` is only used for initial disk creation.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2385

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
