### PR TITLE
fix(vm): match CPU type format with PVE

### DIFF
--- a/proxmox/nodes/vms/custom_cpu_emulation.go
+++ b/proxmox/nodes/vms/custom_cpu_emulation.go
@@ -26,15 +26,23 @@ type CustomCPUEmulation struct {
 
 // EncodeValues converts a CustomCPUEmulation struct to a URL value.
 func (r *CustomCPUEmulation) EncodeValues(key string, v *url.Values) error {
-	values := []string{
-		fmt.Sprintf("cputype=%s", r.Type),
+	hasFlags := r.Flags != nil && len(*r.Flags) > 0
+	hasHidden := r.Hidden != nil
+	hasHVVendorID := r.HVVendorID != nil
+
+	var values []string
+
+	if hasFlags || hasHidden || hasHVVendorID {
+		values = append(values, fmt.Sprintf("cputype=%s", r.Type))
+	} else {
+		values = append(values, r.Type)
 	}
 
-	if r.Flags != nil && len(*r.Flags) > 0 {
+	if hasFlags {
 		values = append(values, fmt.Sprintf("flags=%s", strings.Join(*r.Flags, ";")))
 	}
 
-	if r.Hidden != nil {
+	if hasHidden {
 		if *r.Hidden {
 			values = append(values, "hidden=1")
 		} else {
@@ -42,7 +50,7 @@ func (r *CustomCPUEmulation) EncodeValues(key string, v *url.Values) error {
 		}
 	}
 
-	if r.HVVendorID != nil {
+	if hasHVVendorID {
 		values = append(values, fmt.Sprintf("hv-vendor-id=%s", *r.HVVendorID))
 	}
 

--- a/proxmox/nodes/vms/custom_cpu_emulation_test.go
+++ b/proxmox/nodes/vms/custom_cpu_emulation_test.go
@@ -1,0 +1,266 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package vms
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
+)
+
+func TestCustomCPUEmulation_EncodeValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		emulation *CustomCPUEmulation
+		key       string
+		expected  string
+	}{
+		{
+			name: "type only - should output just type value",
+			emulation: &CustomCPUEmulation{
+				Type: "x86-64-v4",
+			},
+			key:      "cpu",
+			expected: "x86-64-v4",
+		},
+		{
+			name: "type with flags - should output cputype= format",
+			emulation: &CustomCPUEmulation{
+				Type:  "x86-64-v4",
+				Flags: &[]string{"+avx", "+sse"},
+			},
+			key:      "cpu",
+			expected: "cputype=x86-64-v4,flags=+avx;+sse",
+		},
+		{
+			name: "type with hidden - should output cputype= format",
+			emulation: &CustomCPUEmulation{
+				Type:   "x86-64-v4",
+				Hidden: types.CustomBool(true).Pointer(),
+			},
+			key:      "cpu",
+			expected: "cputype=x86-64-v4,hidden=1",
+		},
+		{
+			name: "type with hv-vendor-id - should output cputype= format",
+			emulation: &CustomCPUEmulation{
+				Type:       "x86-64-v4",
+				HVVendorID: ptr.Ptr("vendor123"),
+			},
+			key:      "cpu",
+			expected: "cputype=x86-64-v4,hv-vendor-id=vendor123",
+		},
+		{
+			name: "type with all options - should output cputype= format",
+			emulation: &CustomCPUEmulation{
+				Type:       "x86-64-v4",
+				Flags:      &[]string{"+avx"},
+				Hidden:     types.CustomBool(false).Pointer(),
+				HVVendorID: ptr.Ptr("vendor123"),
+			},
+			key:      "cpu",
+			expected: "cputype=x86-64-v4,flags=+avx,hidden=0,hv-vendor-id=vendor123",
+		},
+		{
+			name: "type only - kvm64",
+			emulation: &CustomCPUEmulation{
+				Type: "kvm64",
+			},
+			key:      "cpu",
+			expected: "kvm64",
+		},
+		{
+			name: "type only - qemu64",
+			emulation: &CustomCPUEmulation{
+				Type: "qemu64",
+			},
+			key:      "cpu",
+			expected: "qemu64",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			values := &url.Values{}
+			err := tt.emulation.EncodeValues(tt.key, values)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, values.Get(tt.key))
+		})
+	}
+}
+
+func TestCustomCPUEmulation_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		line    string
+		want    *CustomCPUEmulation
+		wantErr bool
+	}{
+		{
+			name: "type only format (GUI format)",
+			line: `"x86-64-v4"`,
+			want: &CustomCPUEmulation{
+				Type: "x86-64-v4",
+			},
+		},
+		{
+			name: "cputype= format (provider format)",
+			line: `"cputype=x86-64-v4"`,
+			want: &CustomCPUEmulation{
+				Type: "x86-64-v4",
+			},
+		},
+		{
+			name: "cputype= with flags",
+			line: `"cputype=x86-64-v4,flags=+avx;+sse"`,
+			want: &CustomCPUEmulation{
+				Type:  "x86-64-v4",
+				Flags: &[]string{"+avx", "+sse"},
+			},
+		},
+		{
+			name: "cputype= with hidden",
+			line: `"cputype=x86-64-v4,hidden=1"`,
+			want: &CustomCPUEmulation{
+				Type:   "x86-64-v4",
+				Hidden: types.CustomBool(true).Pointer(),
+			},
+		},
+		{
+			name: "cputype= with hv-vendor-id",
+			line: `"cputype=x86-64-v4,hv-vendor-id=vendor123"`,
+			want: &CustomCPUEmulation{
+				Type:       "x86-64-v4",
+				HVVendorID: ptr.Ptr("vendor123"),
+			},
+		},
+		{
+			name: "cputype= with all options",
+			line: `"cputype=x86-64-v4,flags=+avx,hidden=0,hv-vendor-id=vendor123"`,
+			want: &CustomCPUEmulation{
+				Type:       "x86-64-v4",
+				Flags:      &[]string{"+avx"},
+				Hidden:     types.CustomBool(false).Pointer(),
+				HVVendorID: ptr.Ptr("vendor123"),
+			},
+		},
+		{
+			name: "type only - kvm64",
+			line: `"kvm64"`,
+			want: &CustomCPUEmulation{
+				Type: "kvm64",
+			},
+		},
+		{
+			name: "type only - qemu64",
+			line: `"qemu64"`,
+			want: &CustomCPUEmulation{
+				Type: "qemu64",
+			},
+		},
+		{
+			name:    "invalid JSON",
+			line:    `{"cputype": "x86-64-v4"}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			line:    `""`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &CustomCPUEmulation{}
+			err := r.UnmarshalJSON([]byte(tt.line))
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want.Type, r.Type)
+
+			if tt.want.Flags != nil {
+				require.NotNil(t, r.Flags)
+				require.Equal(t, *tt.want.Flags, *r.Flags)
+			} else {
+				require.Nil(t, r.Flags)
+			}
+
+			if tt.want.Hidden != nil {
+				require.NotNil(t, r.Hidden)
+				require.Equal(t, *tt.want.Hidden, *r.Hidden)
+			} else {
+				require.Nil(t, r.Hidden)
+			}
+
+			if tt.want.HVVendorID != nil {
+				require.NotNil(t, r.HVVendorID)
+				require.Equal(t, *tt.want.HVVendorID, *r.HVVendorID)
+			} else {
+				require.Nil(t, r.HVVendorID)
+			}
+		})
+	}
+}
+
+func TestCustomCPUEmulation_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "type only format round trip",
+			input:    `"x86-64-v4"`,
+			expected: "x86-64-v4",
+		},
+		{
+			name:     "cputype= format round trip",
+			input:    `"cputype=x86-64-v4"`,
+			expected: "x86-64-v4",
+		},
+		{
+			name:     "cputype= with flags round trip",
+			input:    `"cputype=x86-64-v4,flags=+avx"`,
+			expected: "cputype=x86-64-v4,flags=+avx",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &CustomCPUEmulation{}
+			err := r.UnmarshalJSON([]byte(tt.input))
+			require.NoError(t, err)
+
+			values := &url.Values{}
+			err = r.EncodeValues("cpu", values)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expected, values.Get("cpu"))
+		})
+	}
+}


### PR DESCRIPTION
When only CPU type is set, encode it as just the type value (e.g., "x86-64-v4") instead of "cputype=x86-64-v4" to match Proxmox GUI format. This prevents false diffs when CPU type is set via GUI.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2301

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
