### PR TITLE
fix(storage): prevent "was absent, but now present" error for backups block

### DIFF
--- a/fwprovider/storage/model_cifs.go
+++ b/fwprovider/storage/model_cifs.go
@@ -117,16 +117,11 @@ func (m *CIFSStorageModel) fromAPI(ctx context.Context, datastore *storage.Datas
 		m.SnapshotsAsVolumeChain = types.BoolValue(*datastore.SnapshotsAsVolumeChain.PointerBool())
 	}
 
-	if datastore.MaxProtectedBackups != nil || (datastore.PruneBackups != nil && *datastore.PruneBackups != "") {
-		if m.Backups == nil {
-			m.Backups = &BackupModel{}
-		}
-
+	// only populate backups if user has configured it to avoid "was absent, but now present" error
+	if m.Backups != nil {
 		if err := m.Backups.fromAPI(datastore.MaxProtectedBackups, datastore.PruneBackups); err != nil {
 			return err
 		}
-	} else {
-		m.Backups = nil
 	}
 
 	return nil

--- a/fwprovider/storage/model_directory.go
+++ b/fwprovider/storage/model_directory.go
@@ -87,16 +87,11 @@ func (m *DirectoryStorageModel) fromAPI(ctx context.Context, datastore *storage.
 		m.Preallocation = types.StringValue(*datastore.Preallocation)
 	}
 
-	if datastore.MaxProtectedBackups != nil || (datastore.PruneBackups != nil && *datastore.PruneBackups != "") {
-		if m.Backups == nil {
-			m.Backups = &BackupModel{}
-		}
-
+	// only populate backups if user has configured it to avoid "was absent, but now present" error
+	if m.Backups != nil {
 		if err := m.Backups.fromAPI(datastore.MaxProtectedBackups, datastore.PruneBackups); err != nil {
 			return err
 		}
-	} else {
-		m.Backups = nil
 	}
 
 	return nil

--- a/fwprovider/storage/model_nfs.go
+++ b/fwprovider/storage/model_nfs.go
@@ -103,16 +103,11 @@ func (m *NFSStorageModel) fromAPI(ctx context.Context, datastore *storage.Datast
 		m.SnapshotsAsVolumeChain = types.BoolValue(*datastore.SnapshotsAsVolumeChain.PointerBool())
 	}
 
-	if datastore.MaxProtectedBackups != nil || (datastore.PruneBackups != nil && *datastore.PruneBackups != "") {
-		if m.Backups == nil {
-			m.Backups = &BackupModel{}
-		}
-
+	// only populate backups if user has configured it to avoid "was absent, but now present" error
+	if m.Backups != nil {
 		if err := m.Backups.fromAPI(datastore.MaxProtectedBackups, datastore.PruneBackups); err != nil {
 			return err
 		}
-	} else {
-		m.Backups = nil
 	}
 
 	return nil

--- a/fwprovider/storage/model_pbs.go
+++ b/fwprovider/storage/model_pbs.go
@@ -123,16 +123,11 @@ func (m *PBSStorageModel) fromAPI(ctx context.Context, datastore *storage.Datast
 		m.Shared = types.BoolValue(*datastore.Shared.PointerBool())
 	}
 
-	if datastore.MaxProtectedBackups != nil || (datastore.PruneBackups != nil && *datastore.PruneBackups != "") {
-		if m.Backups == nil {
-			m.Backups = &BackupModel{}
-		}
-
+	// only populate backups if user has configured it to avoid "was absent, but now present" error
+	if m.Backups != nil {
 		if err := m.Backups.fromAPI(datastore.MaxProtectedBackups, datastore.PruneBackups); err != nil {
 			return err
 		}
-	} else {
-		m.Backups = nil
 	}
 
 	return nil


### PR DESCRIPTION
Only populate backups from API response if user has configured it in their Terraform config. This prevents state mismatch when Proxmox returns default backup settings but user didn't specify a backups block.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

The new test was failing before the fix, now passes:
```
❯ ./testacc TestAccResourceStorageDirectoryRemoveBackups -- -v
Running single test: TestAccResourceStorageDirectoryRemoveBackups
Found test in: ./fwprovider/test/resource_storage_directory_test.go
Package: github.com/bpg/terraform-provider-proxmox/fwprovider/test

=== RUN   TestAccResourceStorageDirectoryRemoveBackups
=== PAUSE TestAccResourceStorageDirectoryRemoveBackups
=== CONT  TestAccResourceStorageDirectoryRemoveBackups
--- PASS: TestAccResourceStorageDirectoryRemoveBackups (2.23s)
PASS
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/test       2.703s
```

All existing storage tests also pass:
```
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/storage    3.474s [no tests to run]
=== RUN   TestAccResourceStorageDirectory
=== PAUSE TestAccResourceStorageDirectory
=== RUN   TestAccResourceStorageDirectoryRemoveBackups
=== PAUSE TestAccResourceStorageDirectoryRemoveBackups
=== RUN   TestAccResourceStorageNFS
=== PAUSE TestAccResourceStorageNFS
=== CONT  TestAccResourceStorageDirectory
=== CONT  TestAccResourceStorageNFS
=== CONT  TestAccResourceStorageDirectoryRemoveBackups
--- PASS: TestAccResourceStorageDirectoryRemoveBackups (3.33s)
--- PASS: TestAccResourceStorageDirectory (5.69s)
--- PASS: TestAccResourceStorageNFS (7.73s)
PASS
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2463

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
