### PR TITLE
fix(vm): allow vcpus hotplug without reboot

### DIFF
--- a/fwprovider/test/resource_vm_hotplug_test.go
+++ b/fwprovider/test/resource_vm_hotplug_test.go
@@ -9,10 +9,15 @@
 package test
 
 import (
+	"context"
+	"fmt"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccResourceVMHotplug(t *testing.T) {
@@ -512,6 +517,173 @@ func TestAccResourceVMHotplug(t *testing.T) {
 				},
 			},
 		}},
+		{"change CPU hotplugged vcpus on running VM without reboot", func() []resource.TestStep {
+			var capturedUptime int
+
+			return []resource.TestStep{
+				{
+					Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
+						content_type = "iso"
+						datastore_id = "local"
+						node_name    = "{{.NodeName}}"
+						url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
+						overwrite_unmanaged = true
+					}
+
+					resource "proxmox_virtual_environment_vm" "test_hotplug" {
+						node_name       = "{{.NodeName}}"
+						started         = true
+						stop_on_destroy = true
+						name            = "test-hotplug-vcpus"
+						
+						cpu {
+							cores      = 4
+							hotplugged = 2
+						}
+						memory {
+							dedicated = 2048
+						}
+						disk {
+							datastore_id = "local-lvm"
+							file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
+							interface    = "scsi0"
+							size         = 20
+						}
+						initialization {
+							ip_config {
+								ipv4 {
+									address = "dhcp"
+								}
+							}
+						}
+						network_device {
+							bridge = "vmbr0"
+						}
+					}`),
+					Check: resource.ComposeTestCheckFunc(
+						ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
+							"cpu.0.cores":      "4",
+							"cpu.0.hotplugged": "2",
+						}),
+						// capture uptime after VM is created and running
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["proxmox_virtual_environment_vm.test_hotplug"]
+							if !ok {
+								return fmt.Errorf("resource not found")
+							}
+
+							vmID, err := strconv.Atoi(rs.Primary.Attributes["vm_id"])
+							if err != nil {
+								return fmt.Errorf("failed to parse vm_id: %w", err)
+							}
+
+							// wait a bit for uptime to accumulate
+							time.Sleep(5 * time.Second)
+
+							ctx := context.Background()
+
+							status, err := te.NodeClient().VM(vmID).GetVMStatus(ctx)
+							if err != nil {
+								return fmt.Errorf("failed to get VM status: %w", err)
+							}
+
+							if status.Uptime == nil || *status.Uptime < 3 {
+								return fmt.Errorf("VM uptime too low, expected >= 3 seconds, got %v", status.Uptime)
+							}
+
+							capturedUptime = *status.Uptime
+
+							return nil
+						},
+					),
+				},
+				{
+					Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
+						content_type = "iso"
+						datastore_id = "local"
+						node_name    = "{{.NodeName}}"
+						url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
+						overwrite_unmanaged = true
+					}
+
+					resource "proxmox_virtual_environment_vm" "test_hotplug" {
+						node_name       = "{{.NodeName}}"
+						started         = true
+						stop_on_destroy = true
+						name            = "test-hotplug-vcpus"
+						
+						cpu {
+							cores      = 4
+							hotplugged = 3
+						}
+						memory {
+							dedicated = 2048
+						}
+						disk {
+							datastore_id = "local-lvm"
+							file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
+							interface    = "scsi0"
+							size         = 20
+						}
+						initialization {
+							ip_config {
+								ipv4 {
+									address = "dhcp"
+								}
+							}
+						}
+						network_device {
+							bridge = "vmbr0"
+						}
+					}`),
+					Check: resource.ComposeTestCheckFunc(
+						ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
+							"cpu.0.cores":      "4",
+							"cpu.0.hotplugged": "3",
+						}),
+						// verify VM was not rebooted by checking uptime is still high
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["proxmox_virtual_environment_vm.test_hotplug"]
+							if !ok {
+								return fmt.Errorf("resource not found")
+							}
+
+							vmID, err := strconv.Atoi(rs.Primary.Attributes["vm_id"])
+							if err != nil {
+								return fmt.Errorf("failed to parse vm_id: %w", err)
+							}
+
+							ctx := context.Background()
+
+							status, err := te.NodeClient().VM(vmID).GetVMStatus(ctx)
+							if err != nil {
+								return fmt.Errorf("failed to get VM status: %w", err)
+							}
+
+							if status.Uptime == nil {
+								return fmt.Errorf("VM uptime is nil")
+							}
+
+							// uptime should have increased (no reboot), allow some tolerance
+							if *status.Uptime < capturedUptime {
+								return fmt.Errorf("VM was rebooted: uptime before=%d, after=%d", capturedUptime, *status.Uptime)
+							}
+
+							capturedUptime = *status.Uptime
+
+							return nil
+						},
+					),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_hotplug", plancheck.ResourceActionUpdate),
+						},
+					},
+				},
+			}
+		}()},
 	}
 
 	for _, tt := range tests {

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5658,16 +5658,16 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 		oldCPUNUMA := getBoolFromBlock(oldCPUBlock, mkCPUNUMA, false)
 
 		coresOrSocketsIncreased := (cpuCores > oldCPUCores) || (cpuSockets > oldCPUSockets)
+		hotpluggedChanged := d.HasChange(mkCPU + ".0." + mkCPUHotplugged)
 		noNonHotpluggableChanges := cpuCores >= oldCPUCores && cpuSockets >= oldCPUSockets &&
 			cpuType == oldCPUType && cpuArchitecture == oldCPUArchitecture &&
 			bool(cpuNUMA) == oldCPUNUMA &&
 			!d.HasChange(mkCPU+".0."+mkCPUFlags) &&
 			!d.HasChange(mkCPU+".0."+mkCPUAffinity) &&
-			!d.HasChange(mkCPU+".0."+mkCPUHotplugged) &&
 			!d.HasChange(mkCPU+".0."+mkCPULimit) &&
 			!d.HasChange(mkCPU+".0."+mkCPUUnits)
 
-		onlyHotpluggableChange := coresOrSocketsIncreased && noNonHotpluggableChanges
+		onlyHotpluggableChange := (coresOrSocketsIncreased || hotpluggedChanged) && noNonHotpluggableChanges
 
 		if err = setCPUArchitecture(ctx, cpuArchitecture, client, updateBody); err != nil {
 			return diag.FromErr(err)


### PR DESCRIPTION
Changes to cpu.hotplugged were incorrectly classified as non-hotpluggable, causing unnecessary VM reboots. Now vcpus changes are properly recognized as hotpluggable operations alongside cores/sockets increases.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [ ] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->
The new test failed before the fix, and now passes:
```
=== RUN   TestAccResourceVMHotplug
=== RUN   TestAccResourceVMHotplug/change_CPU_hotplugged_vcpus_on_running_VM_without_reboot
=== PAUSE TestAccResourceVMHotplug/change_CPU_hotplugged_vcpus_on_running_VM_without_reboot
=== CONT  TestAccResourceVMHotplug/change_CPU_hotplugged_vcpus_on_running_VM_without_reboot
--- PASS: TestAccResourceVMHotplug (0.00s)
    --- PASS: TestAccResourceVMHotplug/change_CPU_hotplugged_vcpus_on_running_VM_without_reboot (34.04s)
PASS
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #2412 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
