### PR TITLE
fix(file)!: restore upstream URL change detection in `download_file`

### DIFF
--- a/docs/resources/virtual_environment_download_file.md
+++ b/docs/resources/virtual_environment_download_file.md
@@ -102,7 +102,7 @@ resource "proxmox_virtual_environment_download_file" "latest_ubuntu_22_jammy_lxc
 - `checksum_algorithm` (String) The algorithm to calculate the checksum of the file. Must be `md5` | `sha1` | `sha224` | `sha256` | `sha384` | `sha512`.
 - `decompression_algorithm` (String) Decompress the downloaded file using the specified compression algorithm. Must be one of `gz` | `lzo` | `zst` | `bz2`.
 - `file_name` (String) The file name. If not provided, it is calculated using `url`. PVE will raise 'wrong file extension' error for some popular extensions file `.raw` or `.qcow2` on PVE versions prior to 8.4. Workaround is to use e.g. `.img` instead.
-- `overwrite` (Boolean) By default `true`. If `true` and file size has changed in the datastore, it will be replaced. If `false`, there will be no check.
+- `overwrite` (Boolean) By default `true`. If `true`, the file will be replaced when either: (1) the file size in the datastore has changed outside of Terraform, or (2) the file size reported by the URL differs from the downloaded file (detecting upstream updates like new cloud image versions). If `false`, no size checks are performed and the file is never automatically replaced.
 - `overwrite_unmanaged` (Boolean) If `true` and a file with the same name already exists in the datastore, it will be deleted and the new file will be downloaded. If `false` and the file already exists, an error will be returned.
 - `upload_timeout` (Number) The file download timeout seconds. Default is 600 (10min).
 - `verify` (Boolean) By default `true`. If `false`, no SSL/TLS certificates will be verified.

--- a/fwprovider/nodes/resource_download_file_upstream_test.go
+++ b/fwprovider/nodes/resource_download_file_upstream_test.go
@@ -1,0 +1,244 @@
+//go:build acceptance || all
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package nodes_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/bpg/terraform-provider-proxmox/fwprovider/test"
+)
+
+// TestAccResourceDownloadFileUpstreamChange tests that when the upstream URL
+// reports a different Content-Length than the local file, replacement is triggered.
+//
+// This test uses a controllable HTTP server running on the test machine.
+//
+// REQUIREMENTS:
+// Set PROXMOX_VE_ACC_TEST_FILE_SERVER_IP to the IP that Proxmox can use to reach
+// the test machine. For example:
+//
+//	export PROXMOX_VE_ACC_TEST_FILE_SERVER_IP=192.168.1.100
+//
+// The test machine must:
+//   - Have the specified IP reachable from Proxmox
+//   - Allow incoming connections on a random high port
+//
+// This test is skipped if PROXMOX_VE_ACC_TEST_FILE_SERVER_IP is not set.
+func TestAccResourceDownloadFileUpstreamChange(t *testing.T) {
+	fileServer := test.NewTestFileServer(t)
+	if fileServer == nil {
+		t.Skip("PROXMOX_VE_ACC_TEST_FILE_SERVER_IP not set - skipping upstream change test")
+	}
+
+	te := test.InitEnvironment(t)
+
+	// set initial content (15 bytes)
+	fileServer.SetContent([]byte("initial content"))
+	fileServer.SetFilename("upstream_test.iso")
+
+	te.AddTemplateVars(map[string]interface{}{
+		"FileURL": fileServer.FileURL(),
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Download file - local size matches URL size (15 bytes)
+				Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_download_file" "upstream_test" {
+						content_type        = "iso"
+						node_name           = "{{.NodeName}}"
+						datastore_id        = "{{.DatastoreID}}"
+						url                 = "{{.FileURL}}"
+						file_name           = "upstream_change_test.iso"
+						overwrite           = true
+						overwrite_unmanaged = true
+						verify              = false
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_virtual_environment_download_file.upstream_test", map[string]string{
+						"size":      "15",
+						"overwrite": "true",
+					}),
+				),
+			},
+			{
+				// Step 2: Change server's Content-Length to simulate upstream update
+				// Local file is still 15 bytes, but URL now reports 100 bytes
+				PreConfig: func() {
+					// simulate upstream releasing a new version with different size
+					fileServer.SetReportedSize(100)
+					t.Log("Changed server to report Content-Length: 100 (was 15)")
+				},
+				Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_download_file" "upstream_test" {
+						content_type        = "iso"
+						node_name           = "{{.NodeName}}"
+						datastore_id        = "{{.DatastoreID}}"
+						url                 = "{{.FileURL}}"
+						file_name           = "upstream_change_test.iso"
+						overwrite           = true
+						overwrite_unmanaged = true
+						verify              = false
+					}`),
+				// with overwrite=true, size mismatch should trigger replacement
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"proxmox_virtual_environment_download_file.upstream_test",
+							plancheck.ResourceActionDestroyBeforeCreate,
+						),
+					},
+				},
+				// after apply, size should be 100 (the new reported size from URL)
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_virtual_environment_download_file.upstream_test", map[string]string{
+						"size": "100",
+					}),
+				),
+			},
+		},
+	})
+}
+
+// TestAccResourceDownloadFileUpstreamChangeIgnored tests that with overwrite=false,
+// upstream size changes are NOT detected (no replacement triggered).
+func TestAccResourceDownloadFileUpstreamChangeIgnored(t *testing.T) {
+	fileServer := test.NewTestFileServer(t)
+	if fileServer == nil {
+		t.Skip("PROXMOX_VE_ACC_TEST_FILE_SERVER_IP not set - skipping test")
+	}
+
+	te := test.InitEnvironment(t)
+
+	fileServer.SetContent([]byte("initial content"))
+	fileServer.SetFilename("no_upstream_check.iso")
+
+	te.AddTemplateVars(map[string]interface{}{
+		"FileURL": fileServer.FileURL(),
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Download file with overwrite=false
+				Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_download_file" "no_check" {
+						content_type        = "iso"
+						node_name           = "{{.NodeName}}"
+						datastore_id        = "{{.DatastoreID}}"
+						url                 = "{{.FileURL}}"
+						file_name           = "no_upstream_check.iso"
+						overwrite           = false
+						overwrite_unmanaged = true
+						verify              = false
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_virtual_environment_download_file.no_check", map[string]string{
+						"size":      "15",
+						"overwrite": "false",
+					}),
+				),
+			},
+			{
+				// Step 2: Change server's Content-Length
+				// With overwrite=false, this should be IGNORED
+				PreConfig: func() {
+					fileServer.SetReportedSize(200)
+					t.Log("Changed server to report Content-Length: 200 - but overwrite=false, so should be ignored")
+				},
+				Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_download_file" "no_check" {
+						content_type        = "iso"
+						node_name           = "{{.NodeName}}"
+						datastore_id        = "{{.DatastoreID}}"
+						url                 = "{{.FileURL}}"
+						file_name           = "no_upstream_check.iso"
+						overwrite           = false
+						overwrite_unmanaged = true
+						verify              = false
+					}`),
+				// with overwrite=false, URL is not checked - expect empty plan
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccResourceDownloadFileUpstreamNoChange tests that when URL size matches
+// local file size, no replacement is triggered (steady state).
+func TestAccResourceDownloadFileUpstreamNoChange(t *testing.T) {
+	fileServer := test.NewTestFileServer(t)
+	if fileServer == nil {
+		t.Skip("PROXMOX_VE_ACC_TEST_FILE_SERVER_IP not set - skipping test")
+	}
+
+	te := test.InitEnvironment(t)
+
+	fileServer.SetContent([]byte("stable content"))
+	fileServer.SetFilename("stable.iso")
+
+	te.AddTemplateVars(map[string]interface{}{
+		"FileURL": fileServer.FileURL(),
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Download file
+				Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_download_file" "stable" {
+						content_type        = "iso"
+						node_name           = "{{.NodeName}}"
+						datastore_id        = "{{.DatastoreID}}"
+						url                 = "{{.FileURL}}"
+						file_name           = "stable_test.iso"
+						overwrite           = true
+						overwrite_unmanaged = true
+						verify              = false
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_virtual_environment_download_file.stable", map[string]string{
+						"size": "14",
+					}),
+				),
+			},
+			{
+				// Step 2: Same config, no changes - should be empty plan
+				// URL is checked (overwrite=true) but sizes match
+				Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_download_file" "stable" {
+						content_type        = "iso"
+						node_name           = "{{.NodeName}}"
+						datastore_id        = "{{.DatastoreID}}"
+						url                 = "{{.FileURL}}"
+						file_name           = "stable_test.iso"
+						overwrite           = true
+						overwrite_unmanaged = true
+						verify              = false
+					}`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}

--- a/fwprovider/nodes/resource_oci_image.go
+++ b/fwprovider/nodes/resource_oci_image.go
@@ -46,7 +46,6 @@ const ociSizeRequiresReplaceDescription = "Triggers resource force replacement i
 
 type ociSizeRequiresReplaceModifier struct{}
 
-//nolint:dupl // shared plan modifier logic reused across resources
 func (r ociSizeRequiresReplaceModifier) PlanModifyInt64(
 	ctx context.Context,
 	req planmodifier.Int64Request,

--- a/fwprovider/test/datasource_file_test.go
+++ b/fwprovider/test/datasource_file_test.go
@@ -11,6 +11,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -22,25 +23,25 @@ import (
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/storage"
 )
 
-func TestAccDatasourceFile(t *testing.T) {
-	t.Parallel()
+// fallback URLs for when TestFileServer is not available.
+const (
+	fallbackISOURL    = "https://boot.netboot.xyz/ipxe/netboot.xyz.iso"
+	fallbackVZTmplURL = "http://download.proxmox.com/images/system/alpine-3.19-default_20240207_amd64.tar.xz"
+)
 
+func TestAccDatasourceFile(t *testing.T) {
 	te := InitEnvironment(t)
 
-	fileName := gofakeit.Word() + "-test-file.yaml"
+	// Upload snippet via SSH (DownloadFileByURL doesn't support snippets content type)
+	snippetFile := CreateTempFile(t, "datasource-test-*.yaml", "test: yaml\nkey: value\n")
+	uploadSnippetFile(t, snippetFile.Name())
+
+	// Use the actual filename from the created temp file
+	fileName := filepath.Base(snippetFile.Name())
 
 	te.AddTemplateVars(map[string]interface{}{
 		"TestFileName": fileName,
 	})
-
-	err := te.NodeStorageClient().DownloadFileByURL(context.Background(), &storage.DownloadURLPostRequestBody{
-		Content:  ptr.Ptr("snippets"),
-		FileName: ptr.Ptr(fileName),
-		Node:     ptr.Ptr(te.NodeName),
-		Storage:  ptr.Ptr("local"),
-		URL:      ptr.Ptr("https://raw.githubusercontent.com/yaml/yaml-test-suite/main/src/229Q.yaml"),
-	})
-	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		e := te.NodeStorageClient().DeleteDatastoreFile(context.Background(), fmt.Sprintf("snippets/%s", fileName))
@@ -99,8 +100,6 @@ func TestAccDatasourceFileImport(t *testing.T) {
 }
 
 func TestAccDatasourceFileNotFound(t *testing.T) {
-	t.Parallel()
-
 	te := InitEnvironment(t)
 
 	nonExistentFileName := "non-existent-" + gofakeit.Word() + ".txt"
@@ -139,23 +138,40 @@ func TestAccDatasourceFileContentTypeFiltering(t *testing.T) {
 		"ISOFileName":    isoFileName,
 	})
 
-	// Upload a vztmpl file (container template)
+	// Try to use local test server for ISO, fall back to external URLs if not configured
+	fileServer := NewTestFileServer(t)
+
+	var isoURL, vztmplURL string
+
+	if fileServer != nil {
+		isoContent := []byte("fake ISO content for testing")
+		isoURL = fileServer.AddFile("/test.iso", "test.iso", isoContent)
+		// vztmpl still needs external URL as it requires specific archive format
+		vztmplURL = fallbackVZTmplURL
+		t.Logf("Using local test file server at %s (vztmpl uses external URL)", fileServer.URL())
+	} else {
+		isoURL = fallbackISOURL
+		vztmplURL = fallbackVZTmplURL
+		t.Log("PROXMOX_VE_ACC_TEST_FILE_SERVER_IP not set - using external URLs")
+	}
+
+	// Upload a vztmpl file (container template) - must be a real archive format
 	err := te.NodeStorageClient().DownloadFileByURL(context.Background(), &storage.DownloadURLPostRequestBody{
 		Content:  ptr.Ptr("vztmpl"),
 		FileName: ptr.Ptr(vztmplFileName),
 		Node:     ptr.Ptr(te.NodeName),
 		Storage:  ptr.Ptr("local"),
-		URL:      ptr.Ptr("http://download.proxmox.com/images/system/alpine-3.19-default_20240207_amd64.tar.xz"),
+		URL:      ptr.Ptr(vztmplURL),
 	})
 	require.NoError(t, err)
 
-	// Upload an ISO file (small test ISO)
+	// Upload an ISO file
 	err = te.NodeStorageClient().DownloadFileByURL(context.Background(), &storage.DownloadURLPostRequestBody{
 		Content:  ptr.Ptr("iso"),
 		FileName: ptr.Ptr(isoFileName),
 		Node:     ptr.Ptr(te.NodeName),
 		Storage:  ptr.Ptr("local"),
-		URL:      ptr.Ptr("https://boot.netboot.xyz/ipxe/netboot.xyz.iso"),
+		URL:      ptr.Ptr(isoURL),
 	})
 	require.NoError(t, err)
 
@@ -220,13 +236,27 @@ func TestAccDatasourceFileContentTypeMismatch(t *testing.T) {
 		"ISOFileName": isoFileName,
 	})
 
+	// Try to use local test server, fall back to external URL if not configured
+	fileServer := NewTestFileServer(t)
+
+	var isoURL string
+
+	if fileServer != nil {
+		isoContent := []byte("fake ISO content for mismatch testing")
+		isoURL = fileServer.AddFile("/mismatch.iso", "mismatch.iso", isoContent)
+		t.Logf("Using local test file server at %s", fileServer.URL())
+	} else {
+		isoURL = fallbackISOURL
+		t.Log("PROXMOX_VE_ACC_TEST_FILE_SERVER_IP not set - using external URLs")
+	}
+
 	// Upload an ISO file
 	err := te.NodeStorageClient().DownloadFileByURL(context.Background(), &storage.DownloadURLPostRequestBody{
 		Content:  ptr.Ptr("iso"),
 		FileName: ptr.Ptr(isoFileName),
 		Node:     ptr.Ptr(te.NodeName),
 		Storage:  ptr.Ptr("local"),
-		URL:      ptr.Ptr("https://boot.netboot.xyz/ipxe/netboot.xyz.iso"),
+		URL:      ptr.Ptr(isoURL),
 	})
 	require.NoError(t, err)
 

--- a/fwprovider/test/test_http_server.go
+++ b/fwprovider/test/test_http_server.go
@@ -1,0 +1,254 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bpg/terraform-provider-proxmox/utils"
+)
+
+// testFile represents a file served by TestFileServer.
+type testFile struct {
+	content      []byte
+	reportedSize int64 // if > 0, overrides Content-Length
+	filename     string
+}
+
+// TestFileServer is a controllable HTTP server for testing file downloads.
+// It can serve multiple files at different paths, each with configurable content
+// and Content-Length headers. This allows tests to simulate upstream file changes
+// (e.g., new cloud image releases) without depending on external services.
+//
+// The server binds to 0.0.0.0 to be accessible from Proxmox. Set the environment
+// variable PROXMOX_VE_ACC_TEST_FILE_SERVER_IP to the IP address that Proxmox
+// should use to reach this server.
+type TestFileServer struct {
+	t        *testing.T
+	server   *http.Server
+	listener net.Listener
+	mu       sync.RWMutex
+
+	// externalIP is the IP that Proxmox will use to reach this server
+	externalIP string
+	// port is the port the server is listening on
+	port int
+
+	// files maps URL path -> file content
+	files map[string]*testFile
+}
+
+// NewTestFileServer creates a new test file server.
+// The server starts serving immediately on a random available port, bound to 0.0.0.0.
+//
+// Set PROXMOX_VE_ACC_TEST_FILE_SERVER_IP to the IP that Proxmox can use to reach
+// this machine. For example, if your test machine is 192.168.1.100, set:
+//
+//	export PROXMOX_VE_ACC_TEST_FILE_SERVER_IP=192.168.1.100
+//
+// Returns nil if the environment variable is not set (test should be skipped).
+func NewTestFileServer(t *testing.T) *TestFileServer {
+	t.Helper()
+
+	externalIP := utils.GetAnyStringEnv("PROXMOX_VE_ACC_TEST_FILE_SERVER_IP")
+	if externalIP == "" {
+		return nil
+	}
+
+	s := &TestFileServer{
+		t:          t,
+		externalIP: externalIP,
+		files:      make(map[string]*testFile),
+	}
+
+	// add a default file for backwards compatibility
+	s.files["/file"] = &testFile{
+		content:  []byte("initial content"),
+		filename: "test_file.iso",
+	}
+
+	lc := net.ListenConfig{}
+
+	// bind to all interfaces so Proxmox can reach us
+	listener, err := lc.Listen(context.Background(), "tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatalf("Failed to create listener: %v", err)
+	}
+
+	s.listener = listener
+	s.port = listener.Addr().(*net.TCPAddr).Port
+	s.server = &http.Server{
+		Handler:           s,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		if err := s.server.Serve(listener); err != http.ErrServerClosed {
+			t.Logf("HTTP server error: %v", err)
+		}
+	}()
+
+	t.Cleanup(func() {
+		s.Close()
+	})
+
+	t.Logf("Test file server started at %s (internal: %s)", s.URL(), s.listener.Addr().String())
+
+	return s
+}
+
+// ServeHTTP implements http.Handler to serve files from the files map.
+func (s *TestFileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	file, ok := s.files[r.URL.Path]
+	s.mu.RUnlock()
+
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	content := file.content
+	reportedSize := file.reportedSize
+	filename := file.filename
+
+	// determine the size to report in Content-Length
+	size := int64(len(content))
+	if reportedSize > 0 {
+		size = reportedSize
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+
+	if filename != "" {
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+	}
+
+	// for HEAD requests (used by Proxmox query-url-metadata), don't send body
+	if r.Method == http.MethodHead {
+		return
+	}
+
+	// if reportedSize is larger than actual content, pad with zeros
+	if reportedSize > int64(len(content)) {
+		padded := make([]byte, reportedSize)
+		copy(padded, content)
+		content = padded
+	}
+
+	if _, err := w.Write(content); err != nil {
+		s.t.Logf("Failed to write content: %v", err)
+	}
+}
+
+// URL returns the base URL that Proxmox should use to download files.
+func (s *TestFileServer) URL() string {
+	return "http://" + net.JoinHostPort(s.externalIP, strconv.Itoa(s.port))
+}
+
+// FileURL returns the URL to download the default test file at /file.
+func (s *TestFileServer) FileURL() string {
+	return s.URL() + "/file"
+}
+
+// AddFile adds a file to be served at the given path.
+// The path should start with "/" (e.g., "/fake_file.iso").
+// Returns the full URL to access the file.
+func (s *TestFileServer) AddFile(path, filename string, content []byte) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.files[path] = &testFile{
+		content:  content,
+		filename: filename,
+	}
+
+	return s.URL() + path
+}
+
+// SetContent sets the content for the default file at /file.
+func (s *TestFileServer) SetContent(content []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if f, ok := s.files["/file"]; ok {
+		f.content = content
+		f.reportedSize = 0
+	}
+}
+
+// SetReportedSize sets the Content-Length header for the default file at /file.
+func (s *TestFileServer) SetReportedSize(size int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if f, ok := s.files["/file"]; ok {
+		f.reportedSize = size
+	}
+}
+
+// SetFilename sets the filename for the default file at /file.
+func (s *TestFileServer) SetFilename(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if f, ok := s.files["/file"]; ok {
+		f.filename = name
+	}
+}
+
+// SetFileReportedSize sets the Content-Length header for a specific file path.
+func (s *TestFileServer) SetFileReportedSize(path string, size int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if f, ok := s.files[path]; ok {
+		f.reportedSize = size
+	}
+}
+
+// GetActualSize returns the actual content length of the default file.
+func (s *TestFileServer) GetActualSize() int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if f, ok := s.files["/file"]; ok {
+		return int64(len(f.content))
+	}
+
+	return 0
+}
+
+// GetFileSHA256 returns the SHA256 checksum of a file's content.
+func (s *TestFileServer) GetFileSHA256(path string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if f, ok := s.files[path]; ok {
+		hash := sha256.Sum256(f.content)
+		return hex.EncodeToString(hash[:])
+	}
+
+	return ""
+}
+
+// Close shuts down the test server.
+func (s *TestFileServer) Close() {
+	if s.server != nil {
+		s.server.Close()
+	}
+}


### PR DESCRIPTION
Restore the original behaviour of the `overwrite` attribute which was accidentally removed in PR #1989. When `overwrite=true` (default), the resource now detects upstream file changes by comparing the URL's `Content-Length` with the local file size.

Changes:
- Restore URL metadata check in Read() when overwrite=true
- Restore url_size comparison in plan modifier
- Update overwrite attribute description

Test infrastructure:
- Add TestFileServer for controllable HTTP endpoint testing
- Add acceptance tests for upstream change detection
- Update existing tests to use local server (with external fallback)
- Fix broken TestAccDatasourceFile (snippets require SSH upload)

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have added / updated documentation in `/docs` for any user-facing features or additions.
- [x] I have added / updated acceptance tests in `/fwprovider/tests` for any new or updated resources / data sources.
- [x] I have ran `make example` to verify that the change works as expected.

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.
--->

<!--
*IF* your code contains breaking changes make sure to add `!` to the end of commit type, e.g.:
```
    feat(vm)!: add support for new feature 
```
Also, uncomment the section just below, and add a description of the breaking change. 
--->

#### ⚠ BREAKING CHANGES
With `overwrite=true` (default), the resource now checks the upstream URL's `Content-Length` during every refresh. This restores the original behavior from v0.33.0 that was accidentally removed in v0.78.2. Users who want to disable upstream checking should set `overwrite=false`.



### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

### Acceptance Tests

**download_file resource (existing tests):**
```
TestAccResourceDownloadFile/missing_url                    PASS (0.43s)
TestAccResourceDownloadFile/download_qcow2_file_to_iso     PASS (2.31s)
TestAccResourceDownloadFile/download_qcow2_file_to_import  PASS (1.86s)
TestAccResourceDownloadFile/download_&_update_iso_file     PASS (3.54s)
TestAccResourceDownloadFile/override_file                  PASS (7.15s)
```

**Upstream change detection (new tests):**
```
TestAccResourceDownloadFileUpstreamChange        PASS (2.18s)
TestAccResourceDownloadFileUpstreamChangeIgnored PASS (1.32s)
TestAccResourceDownloadFileUpstreamNoChange      PASS (2.59s)
```

**File resource/datasource tests:**
```
TestAccResourceFile                         PASS (15.04s)
TestAccDatasourceFile                       PASS (2.18s)
TestAccDatasourceFileNotFound               PASS (0.44s)
TestAccDatasourceFileImport                 PASS (0.47s)
TestAccDatasourceFileContentTypeFiltering   PASS (3.53s)
TestAccDatasourceFileContentTypeMismatch    PASS (0.63s)
```

### Regression Verification

Without fix:
```
TestAccResourceDownloadFileUpstreamChange: FAIL
  expected DestroyBeforeCreate, got action(s): [no-op]
```

With fix:
```
TestAccResourceDownloadFileUpstreamChange: PASS
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2470
Relates #1989

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
