### PR TITLE
fix(api): detect TFA requirement and return clear error message

### DIFF
--- a/proxmox/api/ticket_auth_types.go
+++ b/proxmox/api/ticket_auth_types.go
@@ -31,6 +31,7 @@ type AuthenticationResponseData struct {
 	ClusterName         *string                             `json:"clustername,omitempty"`
 	CSRFPreventionToken *string                             `json:"CSRFPreventionToken,omitempty"`
 	Capabilities        *AuthenticationResponseCapabilities `json:"cap,omitempty"`
+	NeedTFA             *int                                `json:"NeedTFA,omitempty"`
 	Ticket              *string                             `json:"ticket,omitempty"`
 	Username            string                              `json:"username"`
 }

--- a/proxmox/api/user_auth.go
+++ b/proxmox/api/user_auth.go
@@ -116,6 +116,13 @@ func (t *userAuthenticator) authenticate(ctx context.Context) (*AuthenticationRe
 		return nil, errors.New("the server did not include the username in the authentication response")
 	}
 
+	if resBody.Data.NeedTFA != nil && *resBody.Data.NeedTFA == 1 {
+		return nil, errors.New(
+			"two-factor authentication is required for this account; " +
+				"please provide the 'otp' parameter in the provider configuration",
+		)
+	}
+
 	t.authData = resBody.Data
 
 	return resBody.Data, nil

--- a/proxmox/api/user_auth_test.go
+++ b/proxmox/api/user_auth_test.go
@@ -1,0 +1,90 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package api
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserAuthenticator_TFARequired(t *testing.T) {
+	t.Parallel()
+
+	// TFA response mock based on actual Proxmox API behavior
+	tfaResponse := `{
+		"data": {
+			"NeedTFA": 1,
+			"ticket": "PVE:!tfa!{totp:true}:12345678::testticket",
+			"CSRFPreventionToken": "test-csrf-token",
+			"username": "root@pam"
+		}
+	}`
+
+	conn := &Connection{
+		endpoint: "http://localhost",
+		httpClient: newTestClient(func(_ *http.Request) *http.Response {
+			return &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(tfaResponse)),
+			}
+		}),
+	}
+
+	auth := NewUserAuthenticator(UserCredentials{
+		Username: "root@pam",
+		Password: "test",
+	}, conn)
+
+	err := auth.AuthenticateRequest(t.Context(), &http.Request{
+		Method: http.MethodGet,
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "two-factor authentication is required")
+	require.Contains(t, err.Error(), "otp")
+}
+
+func TestUserAuthenticator_Success(t *testing.T) {
+	t.Parallel()
+
+	successResponse := `{
+		"data": {
+			"ticket": "PVE:root@pam:12345678::validticket",
+			"CSRFPreventionToken": "test-csrf-token",
+			"username": "root@pam"
+		}
+	}`
+
+	conn := &Connection{
+		endpoint: "http://localhost",
+		httpClient: newTestClient(func(_ *http.Request) *http.Response {
+			return &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(successResponse)),
+			}
+		}),
+	}
+
+	auth := NewUserAuthenticator(UserCredentials{
+		Username: "root@pam",
+		Password: "test",
+	}, conn)
+
+	req := &http.Request{
+		Method: http.MethodGet,
+		Header: make(http.Header),
+	}
+	err := auth.AuthenticateRequest(t.Context(), req)
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests for any new or updated resources / data sources.
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #2420

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
