### PR TITLE
fix(vm): prevent initialization drift when cloning VM with user_account

### DIFF
--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -4757,7 +4757,27 @@ func vmReadCustom(
 
 	//nolint:gocritic
 	if len(clone) > 0 {
-		if len(currentInitialization) > 0 {
+		if len(currentInitialization) > 0 && currentInitialization[0] != nil {
+			currentInitializationBlock := currentInitialization[0].(map[string]any)
+
+			// for cloned VMs, only include initialization sub-blocks if the user specified them in config
+			// this prevents drift when the template has settings the user didn't define
+
+			currentInitializationUserAccount := currentInitializationBlock[mkInitializationUserAccount].([]any)
+			if len(currentInitializationUserAccount) == 0 {
+				delete(initialization, mkInitializationUserAccount)
+			}
+
+			currentInitializationDNS := currentInitializationBlock[mkInitializationDNS].([]any)
+			if len(currentInitializationDNS) == 0 {
+				delete(initialization, mkInitializationDNS)
+			}
+
+			currentInitializationIPConfig := currentInitializationBlock[mkInitializationIPConfig].([]any)
+			if len(currentInitializationIPConfig) == 0 {
+				delete(initialization, mkInitializationIPConfig)
+			}
+
 			if len(initialization) > 0 {
 				err := d.Set(mkInitialization, []any{initialization})
 				diags = append(diags, diag.FromErr(err)...)


### PR DESCRIPTION
When cloning a VM from a template with user_account settings, the cloned VM would show drift on subsequent applies if user_account wasn't in the clone's config. Now only initialization sub-blocks explicitly defined in the user's config are preserved in state for cloned VMs.

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests for any new or updated resources / data sources.
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

#### Acceptance Test Results

| Test | Status |
|------|--------|
| TestAccResourceVMClone/clone_with_network_device | PASS |
| TestAccResourceVMClone/clone_cpu.architecture_as_root | PASS |
| TestAccResourceVMClone/clone_machine_type | PASS |
| TestAccResourceVMClone/clone_no_vga_block | PASS |
| TestAccResourceVMClone/clone_with_network_devices | PASS |
| TestAccResourceVMClone/clone_initialization_datastore_does_not_exist | PASS |
| TestAccResourceVMClone/clone_hotplug_inherited | PASS |
| TestAccResourceVMClone/clone_hotplug_override | PASS |
| TestAccResourceVMClone/clone_user_account_drift | PASS |
| TestAccResourceContainerClone | PASS |

#### Test Coverage

| Scenario | Covered |
|----------|---------|
| Template with user_account, clone with only ip_config | ✓ |
| Re-apply shows no drift | ✓ |
| user_account not inherited from template | ✓ |
| Existing clone tests still pass | ✓ |
| Container clone not affected | ✓ |

## How to Reproduce and Verify

1. Create a template VM with `initialization.user_account`:
   ```hcl
   resource "proxmox_virtual_environment_vm" "template" {
     node_name = "pve"
     started   = false
     template  = true
     initialization {
       user_account {
         username = "testuser"
         keys     = ["ssh-ed25519 AAAAC3... testkey"]
       }
     }
   }
   ```

2. Clone it with only `ip_config`:
   ```hcl
   resource "proxmox_virtual_environment_vm" "clone" {
     node_name = "pve"
     started   = false
     clone {
       vm_id = proxmox_virtual_environment_vm.template.vm_id
     }
     initialization {
       ip_config {
         ipv4 { address = "dhcp" }
       }
     }
   }
   ```

3. Before fix: Second apply would show changes to delete `user_account`
4. After fix: Second apply shows no changes (no drift)

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2374

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
