### PR TITLE
feat(lxc): add `path_in_datastore` computed attribute for cross-resource refs

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -77,6 +77,13 @@ resource "proxmox_virtual_environment_container" "ubuntu_container" {
     path   = "/mnt/data"
   }
 
+  # To reference a mount point volume from another resource, use path_in_datastore:
+  # mount_point {
+  #   volume = other_container.mount_point[0].path_in_datastore
+  #   size   = "10G"
+  #   path   = "/mnt/shared"
+  # }
+
   startup {
     order      = "3"
     up_delay   = "60"
@@ -148,6 +155,8 @@ output "ubuntu_container_public_key" {
         to `4`). When set to 0 a directory or zfs/btrfs subvolume will be created.
         Requires `datastore_id` to be set.
     - `mount_options` (Optional) List of extra mount options.
+    - `path_in_datastore` (Computed) The in-datastore path to the disk image.
+        Use this attribute for cross-resource references.
 - `environment_variables` - (Optional) A map of runtime environment variables for the container init process.
 - `initialization` - (Optional) The initialization configuration.
     - `dns` - (Optional) The DNS configuration.
@@ -195,6 +204,8 @@ output "ubuntu_container_public_key" {
         Can be specified with a unit suffix (e.g. `10G`).
     - `volume` (Required) Volume, device or directory to mount into the
         container.
+    - `path_in_datastore` (Computed) The in-datastore path to the mount point volume.
+        Use this attribute for cross-resource references instead of `volume`.
 - `device_passthrough` - (Optional) Device to pass through to the container (multiple blocks supported).
     - `deny_write` - (Optional) Deny the container to write to the device (defaults to `false`).
     - `gid` - (Optional) Group ID to be assigned to the device node.

--- a/proxmoxtf/resource/container/container_test.go
+++ b/proxmoxtf/resource/container/container_test.go
@@ -118,7 +118,8 @@ func TestContainerSchema(t *testing.T) {
 	})
 
 	test.AssertValueTypes(t, diskSchema, map[string]schema.ValueType{
-		mkDiskDatastoreID: schema.TypeString,
+		mkDiskDatastoreID:     schema.TypeString,
+		mkDiskPathInDatastore: schema.TypeString,
 	})
 
 	featuresSchema := test.AssertNestedSchemaExistence(t, s, mkFeatures)
@@ -284,16 +285,17 @@ func TestContainerSchema(t *testing.T) {
 	})
 
 	test.AssertValueTypes(t, mountPointSchema, map[string]schema.ValueType{
-		mkMountPointACL:          schema.TypeBool,
-		mkMountPointBackup:       schema.TypeBool,
-		mkMountPointMountOptions: schema.TypeList,
-		mkMountPointPath:         schema.TypeString,
-		mkMountPointQuota:        schema.TypeBool,
-		mkMountPointReadOnly:     schema.TypeBool,
-		mkMountPointReplicate:    schema.TypeBool,
-		mkMountPointShared:       schema.TypeBool,
-		mkMountPointSize:         schema.TypeString,
-		mkMountPointVolume:       schema.TypeString,
+		mkMountPointACL:             schema.TypeBool,
+		mkMountPointBackup:          schema.TypeBool,
+		mkMountPointMountOptions:    schema.TypeList,
+		mkMountPointPath:            schema.TypeString,
+		mkMountPointQuota:           schema.TypeBool,
+		mkMountPointReadOnly:        schema.TypeBool,
+		mkMountPointReplicate:       schema.TypeBool,
+		mkMountPointShared:          schema.TypeBool,
+		mkMountPointSize:            schema.TypeString,
+		mkMountPointVolume:          schema.TypeString,
+		mkMountPointPathInDatastore: schema.TypeString,
 	})
 
 	networkInterfaceSchema := test.AssertNestedSchemaExistence(


### PR DESCRIPTION
Add computed path_in_datastore attribute to mount_point and disk blocks to enable cross-resource volume references without "inconsistent final plan" errors

- mount_point.path_in_datastore: full volume path after creation
- disk.path_in_datastore: root disk volume path (consistent with VM schema)

users can now reference volumes between containers:
```
  volume = other_container.mount_point[0].path_in_datastore
```

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests for any new or updated resources / data sources.
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2492

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
