### PR TITLE
fix(network): update reload timeout and retry

### DIFF
--- a/proxmox/nodes/network.go
+++ b/proxmox/nodes/network.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	networkReloadTimeout = 10 * time.Second
+	networkReloadTimeout = 100 * time.Second
 )
 
 // reloadLock is used to prevent concurrent network reloads.
@@ -76,8 +76,9 @@ func (c *Client) ReloadNetworkConfiguration(ctx context.Context) error {
 
 	err := retry.New(
 		retry.Context(ctx),
-		retry.Delay(1*time.Second),
+		retry.Delay(10*time.Second),
 		retry.Attempts(3),
+		retry.DelayType(retry.BackOffDelay),
 		retry.RetryIf(func(err error) bool {
 			return strings.Contains(err.Error(), "exit code 89")
 		}),


### PR DESCRIPTION
This fixes an issue where running the network reload could cause the provider to timeout.

If `ifreload -a` takes more than 1 second on your proxmox then this provider will time out when trying to create network vlans or bridges in a `for_each` or `count`.

This updates the timeout to 100 seconds and the backoff delay between retries to 10 seconds.
It's a quick fix so if there are better ways to resolve the issue I'm open to making those changes.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests for any new or updated resources / data sources.
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).


### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #2509 





<!---
BEGIN_COMMIT_OVERRIDE
fix(network): update reload timeout and retry (#2510)
END_COMMIT_OVERRIDE
--->