### PR TITLE
fix(vm): require reboot for CPU core or socket changes

### DIFF
--- a/fwprovider/test/resource_vm_hotplug_test.go
+++ b/fwprovider/test/resource_vm_hotplug_test.go
@@ -18,535 +18,67 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/storage"
 )
+
+// downloadCloudImage downloads a cloud image with a unique filename for use in VM tests.
+// The image is automatically cleaned up after the test completes.
+// Returns the file ID in format "local:iso/filename".
+func downloadCloudImage(t *testing.T, te *Environment) string {
+	t.Helper()
+
+	imageFileName := fmt.Sprintf("%d-ubuntu-24.04-minimal-cloudimg-amd64.img", time.Now().UnixMicro())
+
+	err := te.NodeStorageClient().DownloadFileByURL(context.Background(), &storage.DownloadURLPostRequestBody{
+		Content:  ptr.Ptr("iso"),
+		FileName: ptr.Ptr(imageFileName),
+		Node:     ptr.Ptr(te.NodeName),
+		Storage:  ptr.Ptr("local"),
+		URL:      ptr.Ptr(te.CloudImagesServer + "/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		// Best effort cleanup - ignore errors as the file may already be deleted
+		_ = te.NodeStorageClient().DeleteDatastoreFile(context.Background(), fmt.Sprintf("iso/%s", imageFileName))
+	})
+
+	return fmt.Sprintf("local:iso/%s", imageFileName)
+}
 
 func TestAccResourceVMHotplug(t *testing.T) {
 	te := InitEnvironment(t)
+	imageFileID := downloadCloudImage(t, te)
 
-	tests := []struct {
-		name  string
-		steps []resource.TestStep
-	}{
-		{"add disk to running VM", []resource.TestStep{
-			{
-				Config: te.RenderConfig(`
-				resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-					content_type = "iso"
-					datastore_id = "local"
-					node_name    = "{{.NodeName}}"
-					url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
-					overwrite_unmanaged = true
-				}
+	t.Run("add disk to running VM", func(t *testing.T) {
+		t.Parallel()
 
-				resource "proxmox_virtual_environment_vm" "test_hotplug" {
-					node_name       = "{{.NodeName}}"
-					started         = true
-					stop_on_destroy = true
-					name            = "test-hotplug-disk"
-					
-					cpu {
-						cores = 2
-					}
-					memory {
-						dedicated = 2048
-					}
-					disk {
-						datastore_id = "local-lvm"
-						file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
-						interface    = "scsi0"
-						size         = 20
-					}
-					initialization {
-						ip_config {
-							ipv4 {
-								address = "dhcp"
-							}
-						}
-					}
-					network_device {
-						bridge = "vmbr0"
-					}
-				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
-						"disk.#": "1",
-					}),
-				),
-			},
-			{
-				Config: te.RenderConfig(`
-				resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-					content_type = "iso"
-					datastore_id = "local"
-					node_name    = "{{.NodeName}}"
-					url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
-					overwrite_unmanaged = true
-				}
+		te := InitEnvironment(t)
+		te.AddTemplateVars(map[string]any{"ImageFileID": imageFileID})
 
-				resource "proxmox_virtual_environment_vm" "test_hotplug" {
-					node_name       = "{{.NodeName}}"
-					started         = true
-					stop_on_destroy = true
-					name            = "test-hotplug-disk"
-					
-					cpu {
-						cores = 2
-					}
-					memory {
-						dedicated = 2048
-					}
-					disk {
-						datastore_id = "local-lvm"
-						file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
-						interface    = "scsi0"
-						size         = 20
-					}
-					disk {
-						datastore_id = "local-lvm"
-						interface    = "scsi1"
-						size         = 4
-					}
-					initialization {
-						ip_config {
-							ipv4 {
-								address = "dhcp"
-							}
-						}
-					}
-					network_device {
-						bridge = "vmbr0"
-					}
-				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
-						"disk.#": "2",
-					}),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_hotplug", plancheck.ResourceActionUpdate),
-					},
-				},
-			},
-		}},
-		{"add network device to running VM", []resource.TestStep{
-			{
-				Config: te.RenderConfig(`
-				resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-					content_type = "iso"
-					datastore_id = "local"
-					node_name    = "{{.NodeName}}"
-					url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
-					overwrite_unmanaged = true
-				}
-
-				resource "proxmox_virtual_environment_vm" "test_hotplug" {
-					node_name = "{{.NodeName}}"
-					started   = true
-					name      = "test-hotplug-network"
-					
-					cpu {
-						cores = 2
-					}
-					memory {
-						dedicated = 2048
-					}
-					disk {
-						datastore_id = "local-lvm"
-						file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
-						interface    = "scsi0"
-						size         = 20
-					}
-					initialization {
-						ip_config {
-							ipv4 {
-								address = "dhcp"
-							}
-						}
-					}
-					network_device {
-						bridge = "vmbr0"
-					}
-				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
-						"network_device.#": "1",
-					}),
-				),
-			},
-			{
-				Config: te.RenderConfig(`
-				resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-					content_type = "iso"
-					datastore_id = "local"
-					node_name    = "{{.NodeName}}"
-					url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
-					overwrite_unmanaged = true
-				}
-
-				resource "proxmox_virtual_environment_vm" "test_hotplug" {
-					node_name = "{{.NodeName}}"
-					started   = true
-					name      = "test-hotplug-network"
-					
-					cpu {
-						cores = 2
-					}
-					memory {
-						dedicated = 2048
-					}
-					disk {
-						datastore_id = "local-lvm"
-						file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
-						interface    = "scsi0"
-						size         = 20
-					}
-					initialization {
-						ip_config {
-							ipv4 {
-								address = "dhcp"
-							}
-						}
-					}
-					network_device {
-						bridge = "vmbr0"
-					}
-					network_device {
-						bridge = "vmbr0"
-						model  = "virtio"
-					}
-				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
-						"network_device.#": "2",
-					}),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_hotplug", plancheck.ResourceActionUpdate),
-					},
-				},
-			},
-		}},
-		{"increase memory on running VM", []resource.TestStep{
-			{
-				Config: te.RenderConfig(`
-				resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-					content_type = "iso"
-					datastore_id = "local"
-					node_name    = "{{.NodeName}}"
-					url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
-					overwrite_unmanaged = true
-				}
-
-				resource "proxmox_virtual_environment_vm" "test_hotplug" {
-					node_name = "{{.NodeName}}"
-					started   = true
-					name      = "test-hotplug-memory"
-					
-					cpu {
-						cores = 2
-					}
-					memory {
-						dedicated = 2048
-					}
-					disk {
-						datastore_id = "local-lvm"
-						file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
-						interface    = "scsi0"
-						size         = 20
-					}
-					initialization {
-						ip_config {
-							ipv4 {
-								address = "dhcp"
-							}
-						}
-					}
-					network_device {
-						bridge = "vmbr0"
-					}
-				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
-						"memory.0.dedicated": "2048",
-					}),
-				),
-			},
-			{
-				Config: te.RenderConfig(`
-				resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-					content_type = "iso"
-					datastore_id = "local"
-					node_name    = "{{.NodeName}}"
-					url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
-					overwrite_unmanaged = true
-				}
-
-				resource "proxmox_virtual_environment_vm" "test_hotplug" {
-					node_name = "{{.NodeName}}"
-					started   = true
-					name      = "test-hotplug-memory"
-					
-					cpu {
-						cores = 2
-					}
-					memory {
-						dedicated = 4096
-					}
-					disk {
-						datastore_id = "local-lvm"
-						file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
-						interface    = "scsi0"
-						size         = 20
-					}
-					initialization {
-						ip_config {
-							ipv4 {
-								address = "dhcp"
-							}
-						}
-					}
-					network_device {
-						bridge = "vmbr0"
-					}
-				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
-						"memory.0.dedicated": "4096",
-					}),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_hotplug", plancheck.ResourceActionUpdate),
-					},
-				},
-			},
-		}},
-		{"increase CPU cores on running VM", []resource.TestStep{
-			{
-				Config: te.RenderConfig(`
-				resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-					content_type = "iso"
-					datastore_id = "local"
-					node_name    = "{{.NodeName}}"
-					url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
-					overwrite_unmanaged = true
-				}
-
-				resource "proxmox_virtual_environment_vm" "test_hotplug" {
-					node_name = "{{.NodeName}}"
-					started   = true
-					name      = "test-hotplug-cpu"
-					
-					cpu {
-						cores = 2
-					}
-					memory {
-						dedicated = 2048
-					}
-					disk {
-						datastore_id = "local-lvm"
-						file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
-						interface    = "scsi0"
-						size         = 20
-					}
-					initialization {
-						ip_config {
-							ipv4 {
-								address = "dhcp"
-							}
-						}
-					}
-					network_device {
-						bridge = "vmbr0"
-					}
-				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
-						"cpu.0.cores": "2",
-					}),
-				),
-			},
-			{
-				Config: te.RenderConfig(`
-				resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-					content_type = "iso"
-					datastore_id = "local"
-					node_name    = "{{.NodeName}}"
-					url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
-					overwrite_unmanaged = true
-				}
-
-				resource "proxmox_virtual_environment_vm" "test_hotplug" {
-					node_name = "{{.NodeName}}"
-					started   = true
-					name      = "test-hotplug-cpu"
-					
-					cpu {
-						cores = 4
-					}
-					memory {
-						dedicated = 2048
-					}
-					disk {
-						datastore_id = "local-lvm"
-						file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
-						interface    = "scsi0"
-						size         = 20
-					}
-					initialization {
-						ip_config {
-							ipv4 {
-								address = "dhcp"
-							}
-						}
-					}
-					network_device {
-						bridge = "vmbr0"
-					}
-				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
-						"cpu.0.cores": "4",
-					}),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_hotplug", plancheck.ResourceActionUpdate),
-					},
-				},
-			},
-		}},
-		{"change disk properties on running VM", []resource.TestStep{
-			{
-				Config: te.RenderConfig(`
-				resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-					content_type = "iso"
-					datastore_id = "local"
-					node_name    = "{{.NodeName}}"
-					url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
-					overwrite_unmanaged = true
-				}
-
-				resource "proxmox_virtual_environment_vm" "test_hotplug" {
-					node_name = "{{.NodeName}}"
-					started   = true
-					name      = "test-hotplug-disk-props"
-					
-					cpu {
-						cores = 2
-					}
-					memory {
-						dedicated = 2048
-					}
-					disk {
-						datastore_id = "local-lvm"
-						file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
-						interface    = "scsi0"
-						size         = 20
-						cache        = "none"
-					}
-					initialization {
-						ip_config {
-							ipv4 {
-								address = "dhcp"
-							}
-						}
-					}
-					network_device {
-						bridge = "vmbr0"
-					}
-				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
-						"disk.0.cache": "none",
-					}),
-				),
-			},
-			{
-				Config: te.RenderConfig(`
-				resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-					content_type = "iso"
-					datastore_id = "local"
-					node_name    = "{{.NodeName}}"
-					url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
-					overwrite_unmanaged = true
-				}
-
-				resource "proxmox_virtual_environment_vm" "test_hotplug" {
-					node_name = "{{.NodeName}}"
-					started   = true
-					name      = "test-hotplug-disk-props"
-					
-					cpu {
-						cores = 2
-					}
-					memory {
-						dedicated = 2048
-					}
-					disk {
-						datastore_id = "local-lvm"
-						file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
-						interface    = "scsi0"
-						size         = 20
-						cache        = "writeback"
-						discard      = "on"
-					}
-					initialization {
-						ip_config {
-							ipv4 {
-								address = "dhcp"
-							}
-						}
-					}
-					network_device {
-						bridge = "vmbr0"
-					}
-				}`),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
-						"disk.0.cache":   "writeback",
-						"disk.0.discard": "on",
-					}),
-				),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_hotplug", plancheck.ResourceActionUpdate),
-					},
-				},
-			},
-		}},
-		{"change CPU hotplugged vcpus on running VM without reboot", func() []resource.TestStep {
-			var capturedUptime int
-
-			return []resource.TestStep{
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: te.AccProviders,
+			Steps: []resource.TestStep{
 				{
 					Config: te.RenderConfig(`
-					resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-						content_type = "iso"
-						datastore_id = "local"
-						node_name    = "{{.NodeName}}"
-						url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
-						overwrite_unmanaged = true
-					}
-
 					resource "proxmox_virtual_environment_vm" "test_hotplug" {
 						node_name       = "{{.NodeName}}"
 						started         = true
 						stop_on_destroy = true
-						name            = "test-hotplug-vcpus"
-						
+						name            = "test-hotplug-disk"
+
 						cpu {
-							cores      = 4
-							hotplugged = 2
+							cores = 2
 						}
 						memory {
 							dedicated = 2048
 						}
 						disk {
 							datastore_id = "local-lvm"
-							file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
+							file_id      = "{{.ImageFileID}}"
 							interface    = "scsi0"
 							size         = 20
 						}
@@ -563,10 +95,292 @@ func TestAccResourceVMHotplug(t *testing.T) {
 					}`),
 					Check: resource.ComposeTestCheckFunc(
 						ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
-							"cpu.0.cores":      "4",
-							"cpu.0.hotplugged": "2",
+							"disk.#": "1",
 						}),
-						// capture uptime after VM is created and running
+					),
+				},
+				{
+					Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_vm" "test_hotplug" {
+						node_name       = "{{.NodeName}}"
+						started         = true
+						stop_on_destroy = true
+						name            = "test-hotplug-disk"
+
+						cpu {
+							cores = 2
+						}
+						memory {
+							dedicated = 2048
+						}
+						disk {
+							datastore_id = "local-lvm"
+							file_id      = "{{.ImageFileID}}"
+							interface    = "scsi0"
+							size         = 20
+						}
+						disk {
+							datastore_id = "local-lvm"
+							interface    = "scsi1"
+							size         = 4
+						}
+						initialization {
+							ip_config {
+								ipv4 {
+									address = "dhcp"
+								}
+							}
+						}
+						network_device {
+							bridge = "vmbr0"
+						}
+					}`),
+					Check: resource.ComposeTestCheckFunc(
+						ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
+							"disk.#": "2",
+						}),
+					),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_hotplug", plancheck.ResourceActionUpdate),
+						},
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("add network device to running VM", func(t *testing.T) {
+		t.Parallel()
+
+		te := InitEnvironment(t)
+		te.AddTemplateVars(map[string]any{"ImageFileID": imageFileID})
+
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: te.AccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_vm" "test_hotplug" {
+						node_name = "{{.NodeName}}"
+						started   = true
+						name      = "test-hotplug-network"
+
+						cpu {
+							cores = 2
+						}
+						memory {
+							dedicated = 2048
+						}
+						disk {
+							datastore_id = "local-lvm"
+							file_id      = "{{.ImageFileID}}"
+							interface    = "scsi0"
+							size         = 20
+						}
+						initialization {
+							ip_config {
+								ipv4 {
+									address = "dhcp"
+								}
+							}
+						}
+						network_device {
+							bridge = "vmbr0"
+						}
+					}`),
+					Check: resource.ComposeTestCheckFunc(
+						ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
+							"network_device.#": "1",
+						}),
+					),
+				},
+				{
+					Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_vm" "test_hotplug" {
+						node_name = "{{.NodeName}}"
+						started   = true
+						name      = "test-hotplug-network"
+
+						cpu {
+							cores = 2
+						}
+						memory {
+							dedicated = 2048
+						}
+						disk {
+							datastore_id = "local-lvm"
+							file_id      = "{{.ImageFileID}}"
+							interface    = "scsi0"
+							size         = 20
+						}
+						initialization {
+							ip_config {
+								ipv4 {
+									address = "dhcp"
+								}
+							}
+						}
+						network_device {
+							bridge = "vmbr0"
+						}
+						network_device {
+							bridge = "vmbr0"
+							model  = "virtio"
+						}
+					}`),
+					Check: resource.ComposeTestCheckFunc(
+						ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
+							"network_device.#": "2",
+						}),
+					),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_hotplug", plancheck.ResourceActionUpdate),
+						},
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("increase memory on running VM", func(t *testing.T) {
+		t.Parallel()
+
+		te := InitEnvironment(t)
+		te.AddTemplateVars(map[string]any{"ImageFileID": imageFileID})
+
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: te.AccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_vm" "test_hotplug" {
+						node_name = "{{.NodeName}}"
+						started   = true
+						name      = "test-hotplug-memory"
+
+						cpu {
+							cores = 2
+						}
+						memory {
+							dedicated = 2048
+						}
+						disk {
+							datastore_id = "local-lvm"
+							file_id      = "{{.ImageFileID}}"
+							interface    = "scsi0"
+							size         = 20
+						}
+						initialization {
+							ip_config {
+								ipv4 {
+									address = "dhcp"
+								}
+							}
+						}
+						network_device {
+							bridge = "vmbr0"
+						}
+					}`),
+					Check: resource.ComposeTestCheckFunc(
+						ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
+							"memory.0.dedicated": "2048",
+						}),
+					),
+				},
+				{
+					Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_vm" "test_hotplug" {
+						node_name = "{{.NodeName}}"
+						started   = true
+						name      = "test-hotplug-memory"
+
+						cpu {
+							cores = 2
+						}
+						memory {
+							dedicated = 4096
+						}
+						disk {
+							datastore_id = "local-lvm"
+							file_id      = "{{.ImageFileID}}"
+							interface    = "scsi0"
+							size         = 20
+						}
+						initialization {
+							ip_config {
+								ipv4 {
+									address = "dhcp"
+								}
+							}
+						}
+						network_device {
+							bridge = "vmbr0"
+						}
+					}`),
+					Check: resource.ComposeTestCheckFunc(
+						ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
+							"memory.0.dedicated": "4096",
+						}),
+					),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_hotplug", plancheck.ResourceActionUpdate),
+						},
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("change CPU cores requires reboot", func(t *testing.T) {
+		t.Parallel()
+
+		te := InitEnvironment(t)
+		te.AddTemplateVars(map[string]any{"ImageFileID": imageFileID})
+
+		var capturedUptime int
+
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: te.AccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_vm" "test_hotplug" {
+						node_name           = "{{.NodeName}}"
+						started             = true
+						stop_on_destroy     = true
+						reboot_after_update = true
+						name                = "test-reboot-cores"
+
+						cpu {
+							cores = 2
+						}
+						memory {
+							dedicated = 2048
+						}
+						disk {
+							datastore_id = "local-lvm"
+							file_id      = "{{.ImageFileID}}"
+							interface    = "scsi0"
+							size         = 20
+						}
+						initialization {
+							ip_config {
+								ipv4 {
+									address = "dhcp"
+								}
+							}
+						}
+						network_device {
+							bridge = "vmbr0"
+						}
+					}`),
+					Check: resource.ComposeTestCheckFunc(
+						ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
+							"cpu.0.cores": "2",
+						}),
 						func(s *terraform.State) error {
 							rs, ok := s.RootModule().Resources["proxmox_virtual_environment_vm.test_hotplug"]
 							if !ok {
@@ -600,20 +414,167 @@ func TestAccResourceVMHotplug(t *testing.T) {
 				},
 				{
 					Config: te.RenderConfig(`
-					resource "proxmox_virtual_environment_download_file" "ubuntu_cloud_image" {
-						content_type = "iso"
-						datastore_id = "local"
-						node_name    = "{{.NodeName}}"
-						url = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
-						overwrite_unmanaged = true
-					}
+					resource "proxmox_virtual_environment_vm" "test_hotplug" {
+						node_name           = "{{.NodeName}}"
+						started             = true
+						stop_on_destroy     = true
+						reboot_after_update = true
+						name                = "test-reboot-cores"
 
+						cpu {
+							cores = 4
+						}
+						memory {
+							dedicated = 2048
+						}
+						disk {
+							datastore_id = "local-lvm"
+							file_id      = "{{.ImageFileID}}"
+							interface    = "scsi0"
+							size         = 20
+						}
+						initialization {
+							ip_config {
+								ipv4 {
+									address = "dhcp"
+								}
+							}
+						}
+						network_device {
+							bridge = "vmbr0"
+						}
+					}`),
+					Check: resource.ComposeTestCheckFunc(
+						ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
+							"cpu.0.cores": "4",
+						}),
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["proxmox_virtual_environment_vm.test_hotplug"]
+							if !ok {
+								return fmt.Errorf("resource not found")
+							}
+
+							vmID, err := strconv.Atoi(rs.Primary.Attributes["vm_id"])
+							if err != nil {
+								return fmt.Errorf("failed to parse vm_id: %w", err)
+							}
+
+							ctx := context.Background()
+
+							status, err := te.NodeClient().VM(vmID).GetVMStatus(ctx)
+							if err != nil {
+								return fmt.Errorf("failed to get VM status: %w", err)
+							}
+
+							if status.Uptime == nil {
+								return fmt.Errorf("VM uptime is nil")
+							}
+
+							// uptime should be reset (reboot happened) - new uptime should be less than captured
+							if *status.Uptime >= capturedUptime {
+								return fmt.Errorf("VM was NOT rebooted: uptime before=%d, after=%d (expected reboot)", capturedUptime, *status.Uptime)
+							}
+
+							return nil
+						},
+					),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_hotplug", plancheck.ResourceActionUpdate),
+						},
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("change CPU hotplugged vcpus without reboot", func(t *testing.T) {
+		t.Parallel()
+
+		te := InitEnvironment(t)
+		te.AddTemplateVars(map[string]any{"ImageFileID": imageFileID})
+
+		var capturedUptime int
+
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: te.AccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: te.RenderConfig(`
 					resource "proxmox_virtual_environment_vm" "test_hotplug" {
 						node_name       = "{{.NodeName}}"
 						started         = true
 						stop_on_destroy = true
 						name            = "test-hotplug-vcpus"
-						
+
+						cpu {
+							cores      = 4
+							hotplugged = 2
+						}
+						memory {
+							dedicated = 2048
+						}
+						disk {
+							datastore_id = "local-lvm"
+							file_id      = "{{.ImageFileID}}"
+							interface    = "scsi0"
+							size         = 20
+						}
+						initialization {
+							ip_config {
+								ipv4 {
+									address = "dhcp"
+								}
+							}
+						}
+						network_device {
+							bridge = "vmbr0"
+						}
+					}`),
+					Check: resource.ComposeTestCheckFunc(
+						ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
+							"cpu.0.cores":      "4",
+							"cpu.0.hotplugged": "2",
+						}),
+						func(s *terraform.State) error {
+							rs, ok := s.RootModule().Resources["proxmox_virtual_environment_vm.test_hotplug"]
+							if !ok {
+								return fmt.Errorf("resource not found")
+							}
+
+							vmID, err := strconv.Atoi(rs.Primary.Attributes["vm_id"])
+							if err != nil {
+								return fmt.Errorf("failed to parse vm_id: %w", err)
+							}
+
+							// wait a bit for uptime to accumulate
+							time.Sleep(5 * time.Second)
+
+							ctx := context.Background()
+
+							status, err := te.NodeClient().VM(vmID).GetVMStatus(ctx)
+							if err != nil {
+								return fmt.Errorf("failed to get VM status: %w", err)
+							}
+
+							if status.Uptime == nil || *status.Uptime < 3 {
+								return fmt.Errorf("VM uptime too low, expected >= 3 seconds, got %v", status.Uptime)
+							}
+
+							capturedUptime = *status.Uptime
+
+							return nil
+						},
+					),
+				},
+				{
+					Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_vm" "test_hotplug" {
+						node_name       = "{{.NodeName}}"
+						started         = true
+						stop_on_destroy = true
+						name            = "test-hotplug-vcpus"
+
 						cpu {
 							cores      = 4
 							hotplugged = 3
@@ -623,7 +584,7 @@ func TestAccResourceVMHotplug(t *testing.T) {
 						}
 						disk {
 							datastore_id = "local-lvm"
-							file_id      = proxmox_virtual_environment_download_file.ubuntu_cloud_image.id
+							file_id      = "{{.ImageFileID}}"
 							interface    = "scsi0"
 							size         = 20
 						}
@@ -643,7 +604,6 @@ func TestAccResourceVMHotplug(t *testing.T) {
 							"cpu.0.cores":      "4",
 							"cpu.0.hotplugged": "3",
 						}),
-						// verify VM was not rebooted by checking uptime is still high
 						func(s *terraform.State) error {
 							rs, ok := s.RootModule().Resources["proxmox_virtual_environment_vm.test_hotplug"]
 							if !ok {
@@ -671,8 +631,6 @@ func TestAccResourceVMHotplug(t *testing.T) {
 								return fmt.Errorf("VM was rebooted: uptime before=%d, after=%d", capturedUptime, *status.Uptime)
 							}
 
-							capturedUptime = *status.Uptime
-
 							return nil
 						},
 					),
@@ -682,18 +640,101 @@ func TestAccResourceVMHotplug(t *testing.T) {
 						},
 					},
 				},
-			}
-		}()},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			resource.Test(t, resource.TestCase{
-				ProtoV6ProviderFactories: te.AccProviders,
-				Steps:                    tt.steps,
-			})
+			},
 		})
-	}
+	})
+
+	t.Run("change disk properties on running VM", func(t *testing.T) {
+		t.Parallel()
+
+		te := InitEnvironment(t)
+		te.AddTemplateVars(map[string]any{"ImageFileID": imageFileID})
+
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: te.AccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_vm" "test_hotplug" {
+						node_name = "{{.NodeName}}"
+						started   = true
+						name      = "test-hotplug-disk-props"
+
+						cpu {
+							cores = 2
+						}
+						memory {
+							dedicated = 2048
+						}
+						disk {
+							datastore_id = "local-lvm"
+							file_id      = "{{.ImageFileID}}"
+							interface    = "scsi0"
+							size         = 20
+							cache        = "none"
+						}
+						initialization {
+							ip_config {
+								ipv4 {
+									address = "dhcp"
+								}
+							}
+						}
+						network_device {
+							bridge = "vmbr0"
+						}
+					}`),
+					Check: resource.ComposeTestCheckFunc(
+						ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
+							"disk.0.cache": "none",
+						}),
+					),
+				},
+				{
+					Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_vm" "test_hotplug" {
+						node_name = "{{.NodeName}}"
+						started   = true
+						name      = "test-hotplug-disk-props"
+
+						cpu {
+							cores = 2
+						}
+						memory {
+							dedicated = 2048
+						}
+						disk {
+							datastore_id = "local-lvm"
+							file_id      = "{{.ImageFileID}}"
+							interface    = "scsi0"
+							size         = 20
+							cache        = "writeback"
+							discard      = "on"
+						}
+						initialization {
+							ip_config {
+								ipv4 {
+									address = "dhcp"
+								}
+							}
+						}
+						network_device {
+							bridge = "vmbr0"
+						}
+					}`),
+					Check: resource.ComposeTestCheckFunc(
+						ResourceAttributes("proxmox_virtual_environment_vm.test_hotplug", map[string]string{
+							"disk.0.cache":   "writeback",
+							"disk.0.discard": "on",
+						}),
+					),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_hotplug", plancheck.ResourceActionUpdate),
+						},
+					},
+				},
+			},
+		})
+	})
 }


### PR DESCRIPTION
CPU cores and sockets cannot be hotplugged in Proxmox - only vcpus (the hotplugged attribute) can change without reboot. The previous logic incorrectly treated core/socket increases as hotpluggable.

Also refactors hotplug tests to use pre-downloaded cloud image with unique filename, fixing parallel test isolation issues.

Fixes #2516

### Contributor's Note
<!--- 
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests for any new or updated resources / data sources.
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!--- 
Please add screenshots, logs, or other relevant information that demonstrates the change works as expected.
--->

#### Acceptance Tests

| Test | Verifies | Status |
|------|----------|--------|
| `change CPU cores requires reboot` | Uptime resets when cores change (reboot happened) | PASS |
| `change CPU hotplugged vcpus without reboot` | Uptime continues when vcpus change (no reboot) | PASS |
| `add disk to running VM` | Disk hotplug works | PASS |
| `add network device to running VM` | Network hotplug works | PASS |
| `increase memory on running VM` | Memory hotplug works | PASS |
| `change disk properties on running VM` | Disk property changes work | PASS |

#### Test Output

```
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	36.796s
```


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
