### PR TITLE
fix(vm): apply custom timeouts on update operations

### DIFF
--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -642,6 +642,45 @@ func TestAccResourceVM(t *testing.T) {
 				),
 			},
 		}},
+		{"timeout persistence across updates", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_timeout" {
+					node_name = "{{.NodeName}}"
+					started   = false
+
+					cpu {
+						cores = 1
+					}
+
+					timeout_shutdown_vm = 60
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_timeout", map[string]string{
+						"timeout_shutdown_vm": "60",
+					}),
+				),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_timeout" {
+					node_name = "{{.NodeName}}"
+					started   = false
+
+					cpu {
+						cores = 2
+					}
+
+					timeout_shutdown_vm = 60
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_timeout", map[string]string{
+						"timeout_shutdown_vm": "60",
+						"cpu.0.cores":         "2",
+					}),
+				),
+			},
+		}},
 	}
 
 	for _, tt := range tests {

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -3912,16 +3912,6 @@ func vmRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics
 	return vmReadCustom(ctx, d, m, vmID, vmConfig, vmStatus)
 }
 
-func setDefaultIfNotSet(d *schema.ResourceData, diags diag.Diagnostics, key string, value any) diag.Diagnostics {
-	if _, ok := d.GetOk(key); !ok {
-		if err := d.Set(key, value); err != nil {
-			return append(diags, diag.FromErr(err)...)
-		}
-	}
-
-	return diags
-}
-
 func setDefaultIfNotExists(d *schema.ResourceData, diags diag.Diagnostics, key string, value any) diag.Diagnostics {
 	//nolint:staticcheck
 	if _, ok := d.GetOkExists(key); !ok {
@@ -5216,14 +5206,14 @@ func vmReadCustom(
 	diags = append(diags, diag.FromErr(e)...)
 
 	diags = setDefaultIfNotExists(d, diags, mkMigrate, dvMigrate)
-	diags = setDefaultIfNotSet(d, diags, mkTimeoutClone, dvTimeoutClone)
-	diags = setDefaultIfNotSet(d, diags, mkTimeoutCreate, dvTimeoutCreate)
-	diags = setDefaultIfNotSet(d, diags, mkTimeoutMigrate, dvTimeoutMigrate)
-	diags = setDefaultIfNotSet(d, diags, mkTimeoutReboot, dvTimeoutReboot)
-	diags = setDefaultIfNotSet(d, diags, mkTimeoutShutdownVM, dvTimeoutShutdownVM)
-	diags = setDefaultIfNotSet(d, diags, mkTimeoutStartVM, dvTimeoutStartVM)
-	diags = setDefaultIfNotSet(d, diags, mkTimeoutStopVM, dvTimeoutStopVM)
-	diags = setDefaultIfNotSet(d, diags, mkTimeoutMoveDisk, dvTimeoutMoveDisk)
+	diags = setDefaultIfNotExists(d, diags, mkTimeoutClone, dvTimeoutClone)
+	diags = setDefaultIfNotExists(d, diags, mkTimeoutCreate, dvTimeoutCreate)
+	diags = setDefaultIfNotExists(d, diags, mkTimeoutMigrate, dvTimeoutMigrate)
+	diags = setDefaultIfNotExists(d, diags, mkTimeoutReboot, dvTimeoutReboot)
+	diags = setDefaultIfNotExists(d, diags, mkTimeoutShutdownVM, dvTimeoutShutdownVM)
+	diags = setDefaultIfNotExists(d, diags, mkTimeoutStartVM, dvTimeoutStartVM)
+	diags = setDefaultIfNotExists(d, diags, mkTimeoutStopVM, dvTimeoutStopVM)
+	diags = setDefaultIfNotExists(d, diags, mkTimeoutMoveDisk, dvTimeoutMoveDisk)
 	diags = setDefaultIfNotExists(d, diags, mkStopOnDestroy, dvStopOnDestroy)
 	diags = setDefaultIfNotExists(d, diags, mkPurgeOnDestroy, dvPurgeOnDestroy)
 	diags = setDefaultIfNotExists(d, diags, mkDeleteUnreferencedDisksOnDestroy, dvDeleteUnreferencedDisksOnDestroy)
@@ -5476,6 +5466,9 @@ func vmUpdatePool(
 }
 
 func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	// reset the default timeout for the update operation
+	ctx = context.WithoutCancel(ctx)
+
 	config := m.(proxmoxtf.ProviderConfiguration)
 
 	client, e := config.GetClient()


### PR DESCRIPTION
### What does this PR do?

Fixes VM timeout values (e.g. `timeout_shutdown_vm = 180`) being ignored on subsequent `terraform apply` runs. The first apply respects the configured timeout, but updates would fall back to the SDK's default 20-minute context timeout.

**Root cause:** The Terraform SDK wraps `UpdateContext` with `context.WithTimeout(ctx, 20*time.Minute)`, silently capping any custom timeout. A prior fix (commit `a57bd7e1`) added `context.WithoutCancel` to `vmCreate` and `vmDelete` to strip this wrapper, but `vmUpdate` was missed.

**Changes:**
1. Add `context.WithoutCancel(ctx)` to `vmUpdate` — matching the existing pattern in `vmCreate`/`vmDelete`
2. Switch timeout fields from `setDefaultIfNotSet` (uses `d.GetOk()`) to `setDefaultIfNotExists` (uses `d.GetOkExists()`) — fixes edge case where explicit `timeout = 0` was silently overwritten with defaults
3. Remove dead `setDefaultIfNotSet` function (zero callers after change 2)
4. Add acceptance test verifying timeout values persist across updates

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

Acceptance test output:

```
=== RUN   TestAccResourceVM/timeout_persistence_across_updates
=== PAUSE TestAccResourceVM/timeout_persistence_across_updates
=== CONT  TestAccResourceVM/timeout_persistence_across_updates
--- PASS: TestAccResourceVM/timeout_persistence_across_updates (3.15s)
```

Full checklist:

| Step | Status |
|------|--------|
| Build | PASSED |
| Go Lint | PASSED (0 issues) |
| Unit Tests | PASSED |
| Acceptance Tests | PASSED |
| Documentation | PASSED (no schema changes) |

### Community Note

- Please vote on this pull request by adding a :+1: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #1169
