### PR TITLE
fix(lxc): apply start_on_boot and features on clone and update

### DIFF
--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -1247,6 +1247,13 @@ func containerCreateClone(ctx context.Context, d *schema.ResourceData, m any) di
 	startOnBoot := types.CustomBool(d.Get(mkStartOnBoot).(bool))
 	updateBody.StartOnBoot = &startOnBoot
 
+	features, err := containerGetFeatures(Container(), d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	updateBody.Features = features
+
 	protection := types.CustomBool(d.Get(mkProtection).(bool))
 	updateBody.Protection = &protection
 
@@ -3580,6 +3587,11 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 	if d.HasChange(mkProtection) {
 		protection := types.CustomBool(d.Get(mkProtection).(bool))
 		updateBody.Protection = &protection
+	}
+
+	if d.HasChange(mkStartOnBoot) {
+		startOnBoot := types.CustomBool(d.Get(mkStartOnBoot).(bool))
+		updateBody.StartOnBoot = &startOnBoot
 	}
 
 	if d.HasChange(mkTags) {


### PR DESCRIPTION
### What does this PR do?

Fixes two remaining bugs from #794 where container configuration was not fully applied:

1. **`start_on_boot` not applied on update** — `containerUpdate()` was missing a `d.HasChange(mkStartOnBoot)` check, so toggling `start_on_boot` on an existing container had no effect on the Proxmox API.
2. **`features` not applied on clone** — `containerCreateClone()` did not call `containerGetFeatures()` in the post-clone update body, so `features` (nesting, keyctl, fuse) specified in Terraform config were silently ignored on cloned containers.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

#### Acceptance test

```bash
./testacc TestAccResourceContainerCloneStartOnBoot -- -v
```

```
=== RUN   TestAccResourceContainerCloneStartOnBoot
=== PAUSE TestAccResourceContainerCloneStartOnBoot
=== CONT  TestAccResourceContainerCloneStartOnBoot
--- PASS: TestAccResourceContainerCloneStartOnBoot (19.94s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	20.464s
```

The test verifies:
- Step 1: Clone a container with `start_on_boot = true` and `features { nesting = true }`, then assert both are set in Proxmox via the API.
- Step 2: Update `start_on_boot` to `false` on the cloned container, then assert it is updated in Proxmox via the API.

#### Mitmproxy verification

**Post-clone PUT** — `features` and `onboot` sent correctly:

```
PUT /api2/json/nodes/pve/lxc/{id}/config

    features: nesting=1
    hostname: test-clone
    net0: bridge=vmbr0,firewall=0,hwaddr=BC:24:11:E5:15:6A,name=vmbr0
    onboot: '1'
    protection: '0'

 << 200 OK
```

**Update PUT** — `onboot` change applied:

```
PUT /api2/json/nodes/pve/lxc/{id}/config

    onboot: '0'

 << 200 OK
```

### Community Note

- Please vote on this pull request by adding a :+1: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #794
