### PR TITLE
fix(vm): clean up orphaned re-import code and clarify `import_from` as create-only

### DIFF
--- a/proxmoxtf/resource/vm/disk/schema.go
+++ b/proxmoxtf/resource/vm/disk/schema.go
@@ -140,8 +140,9 @@ func Schema() map[string]*schema.Schema {
 						ValidateDiagFunc: validators.FileID(),
 					},
 					mkDiskImportFrom: {
-						Type:             schema.TypeString,
-						Description:      "The file id of a disk image to import from storage.",
+						Type: schema.TypeString,
+						Description: "The file id of a disk image to import from storage." +
+							" Only used during initial creation; changes after creation are ignored.",
 						Optional:         true,
 						ForceNew:         false,
 						Default:          "",

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -6440,11 +6440,6 @@ func vmUpdateDiskLocationAndSize(
 				}
 			}
 
-			// We need to resize the disk if the import source has changed.
-			if *oldDisk.ImportFrom != *diskNewEntries[oldIface].ImportFrom {
-				*oldDisk.Size = 0
-			}
-
 			if *oldDisk.Size != *diskNewEntries[oldIface].Size {
 				if *oldDisk.Size < *diskNewEntries[oldIface].Size {
 					if oldDisk.IsOwnedBy(vmID) {


### PR DESCRIPTION
### What does this PR do?

After the revert of disk re-import logic in PR #2401 (v0.89.0), two cleanup items were left behind:

1. **Removed orphaned code** in `vmUpdateDiskLocationAndSize` (`vm.go`) that compared `ImportFrom` values and reset disk size to zero. This code had no practical effect because `disk.Update()` no longer passes `ImportFrom` through, but was confusing and could mask future bugs.

2. **Updated `import_from` schema description** to clarify that it is only used during initial disk creation and changes after creation are silently ignored.

Context: Discussion #2403 — decision to keep `import_from` as create-only, aligning with how every major Terraform provider (AWS, Azure, GCP, vSphere) treats disk image sources as immutable.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

Dead code removal and description text update — no behavior changes.

```
$ make build
go build -o "./build/terraform-provider-proxmox_v0.95.0"

$ make lint
golangci-lint run --fix
0 issues.

$ make test
ok  	.../proxmoxtf/resource/vm       0.479s
ok  	.../proxmoxtf/resource/vm/disk  0.840s
```

### Community Note

- Please vote on this pull request by adding a reaction to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2567
