### PR TITLE
fix(firewall): update rules with position awareness

### DIFF
--- a/proxmoxtf/resource/firewall/rules_test.go
+++ b/proxmoxtf/resource/firewall/rules_test.go
@@ -9,7 +9,6 @@ package firewall
 import (
 	"context"
 	"fmt"
-	"sort"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -70,131 +69,6 @@ func TestRuleSchema(t *testing.T) {
 		mkRuleSource:  schema.TypeString,
 		mkRuleSPort:   schema.TypeString,
 	})
-}
-
-// TestRulesReadDriftDetection tests drift detection when rules are manually deleted.
-func TestRulesReadDriftDetection(t *testing.T) {
-	t.Parallel()
-
-	mockAPI := &mockFirewallRuleAPI{
-		rules: map[int]*firewall.RuleGetResponseData{
-			0: {
-				Action: "ACCEPT",
-				Type:   "in",
-				BaseRule: firewall.BaseRule{
-					Comment: stringPtr("Allow HTTP"),
-					DPort:   stringPtr("80"),
-					Proto:   stringPtr("tcp"),
-				},
-			},
-			2: {
-				Action: "ACCEPT",
-				Type:   "in",
-				BaseRule: firewall.BaseRule{
-					Comment: stringPtr("Allow HTTPS"),
-					DPort:   stringPtr("443"),
-					Proto:   stringPtr("tcp"),
-				},
-			},
-		},
-		rulesID: "test-rules-id",
-	}
-
-	// Create ResourceData with the rules schema
-	rulesResource := Rules()
-	d := rulesResource.TestResourceData()
-	err := d.Set(MkRule, []any{
-		map[string]any{
-			mkRulePos:     0,
-			mkRuleAction:  "ACCEPT",
-			mkRuleType:    "in",
-			mkRuleComment: "Allow HTTP",
-			mkRuleDPort:   "80",
-			mkRuleProto:   "tcp",
-		},
-		map[string]any{
-			mkRulePos:     1,
-			mkRuleAction:  "ACCEPT",
-			mkRuleType:    "in",
-			mkRuleComment: "Allow SSH",
-			mkRuleDPort:   "22",
-			mkRuleProto:   "tcp",
-		},
-		map[string]any{
-			mkRulePos:     2,
-			mkRuleAction:  "ACCEPT",
-			mkRuleType:    "in",
-			mkRuleComment: "Allow HTTPS",
-			mkRuleDPort:   "443",
-			mkRuleProto:   "tcp",
-		},
-	})
-	require.NoError(t, err)
-
-	diags := RulesRead(context.Background(), mockAPI, d)
-	require.False(t, diags.HasError(), "RulesRead should not return errors")
-
-	rules := d.Get(MkRule).([]any)
-	require.Len(t, rules, 2, "Should have 2 rules after drift detection")
-
-	rule0 := rules[0].(map[string]any)
-	require.Equal(t, "Allow HTTP", rule0[mkRuleComment])
-	require.Equal(t, "80", rule0[mkRuleDPort])
-
-	rule1 := rules[1].(map[string]any)
-	require.Equal(t, "Allow HTTPS", rule1[mkRuleComment])
-	require.Equal(t, "443", rule1[mkRuleDPort])
-}
-
-// mockFirewallRuleAPI is a mock implementation for testing.
-type mockFirewallRuleAPI struct {
-	rules   map[int]*firewall.RuleGetResponseData
-	rulesID string
-}
-
-func (m *mockFirewallRuleAPI) GetRulesID() string {
-	return m.rulesID
-}
-
-func (m *mockFirewallRuleAPI) CreateRule(_ context.Context, _ *firewall.RuleCreateRequestBody) error {
-	return nil
-}
-
-func (m *mockFirewallRuleAPI) GetRule(_ context.Context, pos int) (*firewall.RuleGetResponseData, error) {
-	rule, exists := m.rules[pos]
-	if !exists {
-		return nil, fmt.Errorf("500 no rule at position %d", pos)
-	}
-
-	return rule, nil
-}
-
-func (m *mockFirewallRuleAPI) ListRules(_ context.Context) ([]*firewall.RuleListResponseData, error) {
-	keys := make([]int, 0, len(m.rules))
-	for k := range m.rules {
-		keys = append(keys, k)
-	}
-
-	sort.Ints(keys)
-
-	result := make([]*firewall.RuleListResponseData, 0, len(m.rules))
-	for _, pos := range keys {
-		result = append(result, &firewall.RuleListResponseData{Pos: pos})
-	}
-
-	return result, nil
-}
-
-func (m *mockFirewallRuleAPI) UpdateRule(_ context.Context, _ int, _ *firewall.RuleUpdateRequestBody) error {
-	return nil
-}
-
-func (m *mockFirewallRuleAPI) DeleteRule(_ context.Context, _ int) error {
-	return nil
-}
-
-func stringPtr(s string) *string {
-	return &s
 }
 
 // TestMapToBaseRuleWithEmptyValues tests empty value handling for issue #1504.
@@ -267,6 +141,119 @@ func TestMapToBaseRuleWithNonEmptyValues(t *testing.T) {
 	require.Equal(t, "tcp", *baseRule.Proto)
 	require.Equal(t, "192.168.1.0/24", *baseRule.Source)
 	require.Equal(t, "8080", *baseRule.SPort)
+}
+
+// deleteTestMockAPI is a minimal mock for testing RulesDelete error handling.
+// RulesDelete's skip-missing logic (ErrNoRuleAtPosition → continue) is only reachable
+// via a race condition (rule disappears between Read and Delete), so it cannot be
+// tested with acceptance tests.
+type deleteTestMockAPI struct {
+	getRuleErrors map[int]error
+	deletedPos    []int
+}
+
+func (m *deleteTestMockAPI) GetRulesID() string { return "test" }
+
+func (m *deleteTestMockAPI) ListRules(context.Context) ([]*firewall.RuleListResponseData, error) {
+	return nil, nil
+}
+
+func (m *deleteTestMockAPI) CreateRule(context.Context, *firewall.RuleCreateRequestBody) error {
+	return nil
+}
+
+func (m *deleteTestMockAPI) UpdateRule(context.Context, int, *firewall.RuleUpdateRequestBody) error {
+	return nil
+}
+
+func (m *deleteTestMockAPI) GetRule(_ context.Context, pos int) (*firewall.RuleGetResponseData, error) {
+	if err, ok := m.getRuleErrors[pos]; ok {
+		return nil, err
+	}
+
+	return &firewall.RuleGetResponseData{Action: "ACCEPT", Type: "in"}, nil
+}
+
+func (m *deleteTestMockAPI) DeleteRule(_ context.Context, pos int) error {
+	m.deletedPos = append(m.deletedPos, pos)
+	return nil
+}
+
+func newDeleteTestState(t *testing.T, rules []map[string]any) *schema.ResourceData {
+	t.Helper()
+
+	d := Rules().TestResourceData()
+
+	ruleList := make([]any, len(rules))
+	for i, r := range rules {
+		ruleList[i] = r
+	}
+
+	err := d.Set(MkRule, ruleList)
+	require.NoError(t, err)
+
+	return d
+}
+
+func ruleState(pos int, comment string) map[string]any {
+	return map[string]any{
+		mkRulePos:       pos,
+		mkRuleAction:    "ACCEPT",
+		mkRuleType:      "in",
+		mkRuleComment:   comment,
+		mkRuleDPort:     "",
+		mkRuleProto:     "",
+		mkSecurityGroup: "",
+		mkRuleDest:      "",
+		mkRuleSource:    "",
+		mkRuleSPort:     "",
+		mkRuleEnabled:   true,
+		mkRuleIFace:     "",
+		mkRuleLog:       "",
+		mkRuleMacro:     "",
+	}
+}
+
+// TestRulesDeleteSkipsMissingRules verifies that RulesDelete skips rules
+// that no longer exist (ErrNoRuleAtPosition) instead of failing.
+func TestRulesDeleteSkipsMissingRules(t *testing.T) {
+	t.Parallel()
+
+	mock := &deleteTestMockAPI{
+		getRuleErrors: map[int]error{
+			1: fmt.Errorf("error retrieving firewall rule 1: %w", firewall.ErrNoRuleAtPosition),
+		},
+	}
+
+	d := newDeleteTestState(t, []map[string]any{
+		ruleState(0, "Allow HTTP"),
+		ruleState(1, "Allow SSH"),
+	})
+
+	diags := RulesDelete(context.Background(), mock, d)
+	require.False(t, diags.HasError(), "RulesDelete should not error for missing rules")
+	require.Equal(t, []int{0}, mock.deletedPos, "Only existing rule should be deleted")
+}
+
+// TestRulesDeletePropagatesAPIErrors verifies that RulesDelete propagates
+// real API errors (non-ErrNoRuleAtPosition) instead of silently ignoring them.
+func TestRulesDeletePropagatesAPIErrors(t *testing.T) {
+	t.Parallel()
+
+	mock := &deleteTestMockAPI{
+		getRuleErrors: map[int]error{
+			1: fmt.Errorf("500 connection refused"),
+		},
+	}
+
+	d := newDeleteTestState(t, []map[string]any{
+		ruleState(0, "Allow HTTP"),
+		ruleState(1, "Allow SSH"),
+	})
+
+	diags := RulesDelete(context.Background(), mock, d)
+	require.True(t, diags.HasError(), "RulesDelete should propagate non-missing-rule API errors")
+	require.Empty(t, mock.deletedPos, "No rules should be deleted when earlier position errors")
 }
 
 // TestComputeRuleSignature tests the signature computation for rules.


### PR DESCRIPTION
### What does this PR do?

Uses a position aware algorithm to update firewall rules to properly account for shifts when updating firewall rules. Refactors the logic around updating firewall rules to work in 4 phases in order to avoid gaps/lockout at apply-time. The algorithm tracks rules through building rule signatures based on identity fields. Also look at [this comment](https://github.com/bpg/terraform-provider-proxmox/issues/2575#issuecomment-3895874538) in the related issue.


### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits). (Not applicable here i believe?)
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->
<details>
<summary> make test </summary>

```
go test ./...
?   	github.com/bpg/terraform-provider-proxmox	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/access	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/attribute	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/acme	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/ha	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/hardwaremapping	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/metrics	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/options	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/sdn/applier	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/sdn/fabric	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/sdn/fabric_node	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/sdn/subnet	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/sdn/vnet	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/sdn/zone	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/config	[no test files]
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes	(cached)
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/apt	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/clonedvm	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/datastores	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/firewall	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/network	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/vm	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/vm/cdrom	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/vm/cpu	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/vm/memory	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/vm/rng	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/vm/vga	[no test files]
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/pools	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/storage	(cached)
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/test	[no test files]
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/types	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/types/hardwaremapping	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/types/nodes/apt	(cached)
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/types/stringset	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/fwprovider/validators	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/access	[no test files]
ok  	github.com/bpg/terraform-provider-proxmox/proxmox/api	(cached)
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/acme	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/acme/account	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/acme/plugins	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/firewall	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/ha	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/ha/groups	[no test files]
ok  	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/ha/resources	(cached)
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/mapping	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/metrics	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/sdn	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/sdn/applier	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/sdn/fabric_nodes	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/sdn/fabrics	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/sdn/subnets	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/sdn/vnets	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/cluster/sdn/zones	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/firewall	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr	[no test files]
ok  	github.com/bpg/terraform-provider-proxmox/proxmox/nodes	(cached)
?   	github.com/bpg/terraform-provider-proxmox/proxmox/nodes/apt	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/nodes/apt/repositories	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/nodes/containers	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/nodes/containers/firewall	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/nodes/firewall	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/nodes/storage	[no test files]
ok  	github.com/bpg/terraform-provider-proxmox/proxmox/nodes/tasks	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms	(cached)
?   	github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms/firewall	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/pools	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmox/ssh	[no test files]
ok  	github.com/bpg/terraform-provider-proxmox/proxmox/storage	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmox/types	(cached)
?   	github.com/bpg/terraform-provider-proxmox/proxmox/types/hardwaremapping	[no test files]
ok  	github.com/bpg/terraform-provider-proxmox/proxmox/types/nodes/apt/repositories	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmox/version	(cached)
?   	github.com/bpg/terraform-provider-proxmox/proxmoxtf	[no test files]
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/datasource	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/provider	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/cluster/firewall	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/container	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/firewall	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/pool	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/validators	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/disk	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/network	(cached)
?   	github.com/bpg/terraform-provider-proxmox/proxmoxtf/structure	[no test files]
?   	github.com/bpg/terraform-provider-proxmox/proxmoxtf/test	[no test files]
ok  	github.com/bpg/terraform-provider-proxmox/utils	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/utils/ip	(cached)
```

</details>

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2575 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
