### PR TITLE
chore(core): unify Delete field type across API client structs

### DIFF
--- a/fwprovider/access/resource_realm_ldap_model.go
+++ b/fwprovider/access/resource_realm_ldap_model.go
@@ -7,8 +7,6 @@
 package access
 
 import (
-	"strings"
-
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -232,8 +230,7 @@ func (m *realmLDAPModel) toUpdateRequest(state *realmLDAPModel) *access.RealmUpd
 	}
 
 	if len(toDelete) > 0 {
-		deleteStr := strings.Join(toDelete, ",")
-		req.Delete = &deleteStr
+		req.Delete = toDelete
 	}
 
 	return req

--- a/fwprovider/cluster/acme/resource_acme_dns_plugin.go
+++ b/fwprovider/cluster/acme/resource_acme_dns_plugin.go
@@ -250,7 +250,7 @@ func (r *acmePluginResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	if len(toDelete) > 0 {
-		updateRequest.Delete = strings.Join(toDelete, ",")
+		updateRequest.Delete = toDelete
 	}
 
 	err := r.client.Update(ctx, plan.Plugin.ValueString(), updateRequest)

--- a/fwprovider/cluster/ha/resource_hagroup.go
+++ b/fwprovider/cluster/ha/resource_hagroup.go
@@ -216,7 +216,7 @@ func (r *hagroupResource) Update(ctx context.Context, req resource.UpdateRequest
 	updateRequest.Restricted.FromValue(data.Restricted)
 
 	if updateRequest.Comment == nil && !state.Comment.IsNull() {
-		updateRequest.Delete = "comment"
+		updateRequest.Delete = []string{"comment"}
 	}
 
 	err := r.client.Update(ctx, state.Group.ValueString(), updateRequest)

--- a/fwprovider/cluster/metrics/resource_metrics_server.go
+++ b/fwprovider/cluster/metrics/resource_metrics_server.go
@@ -294,7 +294,7 @@ func (r *metricsServerResource) Update(
 	attribute.CheckDelete(plan.OTelPath, state.OTelPath, &toDelete, "otel-path")
 
 	reqData := plan.toAPIRequestBody()
-	reqData.Delete = &toDelete
+	reqData.Delete = toDelete
 
 	err := r.client.UpdateServer(ctx, reqData)
 	if err != nil {

--- a/fwprovider/cluster/options/resource_options.go
+++ b/fwprovider/cluster/options/resource_options.go
@@ -846,8 +846,7 @@ func (r *clusterOptionsResource) Update(
 	attribute.CheckDelete(plan.MaxWorkers, state.MaxWorkers, &toDelete, "max_workers")
 
 	if len(toDelete) > 0 {
-		d := strings.Join(toDelete, ",")
-		body.Delete = &d
+		body.Delete = toDelete
 	}
 
 	err := r.client.Cluster().CreateUpdateOptions(ctx, body)
@@ -941,9 +940,8 @@ func (r *clusterOptionsResource) Delete(
 	}
 
 	if len(toDelete) > 0 {
-		d := strings.Join(toDelete, ",")
 		body := &cluster.OptionsRequestData{
-			Delete: &d,
+			Delete: toDelete,
 		}
 
 		err := r.client.Cluster().CreateUpdateOptions(ctx, body)

--- a/fwprovider/nodes/firewall/resource_node_firewall.go
+++ b/fwprovider/nodes/firewall/resource_node_firewall.go
@@ -401,7 +401,7 @@ func (r *nodeFirewallOptionsResource) Delete(
 	}
 
 	body := &nodefirewall.OptionsPutRequestBody{
-		Delete: &toDelete,
+		Delete: toDelete,
 	}
 
 	err := r.client.Node(nodeName).Firewall().SetNodeOptions(ctx, body)

--- a/fwprovider/nodes/network/resource_linux_bridge.go
+++ b/fwprovider/nodes/network/resource_linux_bridge.go
@@ -421,7 +421,7 @@ func (r *linuxBridgeResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	if len(toDelete) > 0 {
-		body.Delete = &toDelete
+		body.Delete = toDelete
 	}
 
 	err := r.client.Node(plan.NodeName.ValueString()).UpdateNetworkInterface(ctx, plan.Name.ValueString(), body)

--- a/fwprovider/nodes/network/resource_linux_vlan.go
+++ b/fwprovider/nodes/network/resource_linux_vlan.go
@@ -379,7 +379,7 @@ func (r *linuxVLANResource) Update(ctx context.Context, req resource.UpdateReque
 	attribute.CheckDelete(plan.Gateway6, state.Gateway6, &toDelete, "gateway6")
 
 	if len(toDelete) > 0 {
-		body.Delete = &toDelete
+		body.Delete = toDelete
 	}
 
 	err := r.client.Node(plan.NodeName.ValueString()).UpdateNetworkInterface(ctx, plan.Name.ValueString(), body)

--- a/fwprovider/nodes/resource_acme_certificate.go
+++ b/fwprovider/nodes/resource_acme_certificate.go
@@ -482,9 +482,8 @@ func (r *acmeCertificateResource) Delete(
 	}
 
 	// Clean up the ACME configuration from the node
-	toDelete := "acme,acmedomain0,acmedomain1,acmedomain2,acmedomain3,acmedomain4"
 	configUpdate := &nodes.ConfigUpdateRequestBody{
-		Delete: &toDelete,
+		Delete: []string{"acme", "acmedomain0", "acmedomain1", "acmedomain2", "acmedomain3", "acmedomain4"},
 	}
 
 	if err := nodeClient.UpdateConfig(ctx, configUpdate); err != nil {
@@ -675,8 +674,7 @@ func (r *acmeCertificateResource) configureNodeACME(
 	}
 
 	if len(toDelete) > 0 {
-		deleteValue := strings.Join(toDelete, ",")
-		configUpdate.Delete = &deleteValue
+		configUpdate.Delete = toDelete
 	}
 
 	// Update the node configuration

--- a/proxmox/access/realms_types.go
+++ b/proxmox/access/realms_types.go
@@ -95,7 +95,7 @@ type RealmUpdateRequestBody struct {
 	TFA              *string           `json:"tfa,omitempty"                   url:"tfa,omitempty"`
 	CaseSensitive    *types.CustomBool `json:"case-sensitive,omitempty"        url:"case-sensitive,omitempty,int"`
 	Domain           *string           `json:"domain,omitempty"                url:"domain,omitempty"`
-	Delete           *string           `json:"delete,omitempty"                url:"delete,omitempty"` // Comma-separated list of properties to delete
+	Delete           []string          `json:"delete,omitempty"                url:"delete,omitempty,comma"`
 }
 
 // RealmGetResponseBody contains the response for GET /access/domains/{realm}.

--- a/proxmox/cluster/acme/plugins/acme_plugins_types.go
+++ b/proxmox/cluster/acme/plugins/acme_plugins_types.go
@@ -76,7 +76,7 @@ type ACMEPluginsUpdateRequestBody struct {
 	// DNS plugin data. (base64 encoded)
 	Data *DNSPluginData `url:"data,omitempty"`
 	// A list of settings you want to delete.
-	Delete string `url:"delete,omitempty"`
+	Delete []string `url:"delete,omitempty,comma"`
 	// Flag to disable the config.
 	Disable bool `url:"disable,omitempty,int"`
 }

--- a/proxmox/cluster/ha/groups/hagroups_types.go
+++ b/proxmox/cluster/ha/groups/hagroups_types.go
@@ -68,5 +68,5 @@ type HAGroupUpdateRequestBody struct {
 	HAGroupDataBase
 
 	// A list of settings to delete
-	Delete string `url:"delete"`
+	Delete []string `url:"delete,omitempty,comma"`
 }

--- a/proxmox/cluster/metrics/server_types.go
+++ b/proxmox/cluster/metrics/server_types.go
@@ -48,5 +48,5 @@ type ServersResponseBody struct {
 type ServerRequestData struct {
 	ServerData
 
-	Delete *[]string `url:"delete,omitempty"`
+	Delete []string `url:"delete,omitempty,comma"`
 }

--- a/proxmox/cluster/options_types.go
+++ b/proxmox/cluster/options_types.go
@@ -85,15 +85,15 @@ type OptionsResponseData struct {
 type OptionsRequestData struct {
 	optionsBaseData
 
-	MaxWorkers                *int64  `json:"max_workers,omitempty"     url:"max_workers,omitempty"`
-	Delete                    *string `json:"delete,omitempty"          url:"delete,omitempty"`
-	ClusterResourceScheduling *string `json:"crs,omitempty"             url:"crs,omitempty"`
-	HASettings                *string `json:"ha,omitempty"              url:"ha,omitempty"`
-	TagStyle                  *string `json:"tag-style,omitempty"       url:"tag-style,omitempty"`
-	Migration                 *string `json:"migration,omitempty"       url:"migration,omitempty"`
-	Webauthn                  *string `json:"webauthn,omitempty"        url:"webauthn,omitempty"`
-	NextID                    *string `json:"next-id,omitempty"         url:"next-id,omitempty"`
-	Notify                    *string `json:"notify,omitempty"          url:"notify,omitempty"`
-	UserTagAccess             *string `json:"user-tag-access,omitempty" url:"user-tag-access,omitempty"`
-	RegisteredTags            *string `json:"registered-tags,omitempty" url:"registered-tags,omitempty"`
+	MaxWorkers                *int64   `json:"max_workers,omitempty"     url:"max_workers,omitempty"`
+	Delete                    []string `json:"delete,omitempty"          url:"delete,omitempty,comma"`
+	ClusterResourceScheduling *string  `json:"crs,omitempty"             url:"crs,omitempty"`
+	HASettings                *string  `json:"ha,omitempty"              url:"ha,omitempty"`
+	TagStyle                  *string  `json:"tag-style,omitempty"       url:"tag-style,omitempty"`
+	Migration                 *string  `json:"migration,omitempty"       url:"migration,omitempty"`
+	Webauthn                  *string  `json:"webauthn,omitempty"        url:"webauthn,omitempty"`
+	NextID                    *string  `json:"next-id,omitempty"         url:"next-id,omitempty"`
+	Notify                    *string  `json:"notify,omitempty"          url:"notify,omitempty"`
+	UserTagAccess             *string  `json:"user-tag-access,omitempty" url:"user-tag-access,omitempty"`
+	RegisteredTags            *string  `json:"registered-tags,omitempty" url:"registered-tags,omitempty"`
 }

--- a/proxmox/firewall/rules_types.go
+++ b/proxmox/firewall/rules_types.go
@@ -45,10 +45,10 @@ type RuleListResponseData struct {
 type RuleUpdateRequestBody struct {
 	BaseRule
 
-	Pos    *int    `json:"pos,omitempty"    url:"pos,omitempty"`
-	Action *string `json:"action,omitempty" url:"action,omitempty"`
-	Type   *string `json:"type,omitempty"   url:"type,omitempty"`
-	Group  *string `json:"group,omitempty"  url:"group,omitempty"`
-	Delete *string `json:"delete,omitempty" url:"delete,omitempty"`
-	MoveTo *int    `json:"moveto,omitempty" url:"moveto,omitempty"`
+	Pos    *int     `json:"pos,omitempty"    url:"pos,omitempty"`
+	Action *string  `json:"action,omitempty" url:"action,omitempty"`
+	Type   *string  `json:"type,omitempty"   url:"type,omitempty"`
+	Group  *string  `json:"group,omitempty"  url:"group,omitempty"`
+	Delete []string `json:"delete,omitempty" url:"delete,omitempty,comma"`
+	MoveTo *int     `json:"moveto,omitempty" url:"moveto,omitempty"`
 }

--- a/proxmox/nodes/config_types.go
+++ b/proxmox/nodes/config_types.go
@@ -58,7 +58,7 @@ type ConfigUpdateRequestBody struct {
 	ACMEDomain3 *ACMEDomainConfig `json:"acmedomain3,omitempty" url:"acmedomain3,omitempty"`
 	// ACME domain and validation plugin
 	ACMEDomain4 *ACMEDomainConfig `json:"acmedomain4,omitempty" url:"acmedomain4,omitempty"`
-	Delete      *string           `json:"delete,omitempty"      url:"delete,omitempty"`
+	Delete      []string          `json:"delete,omitempty"      url:"delete,omitempty,comma"`
 	// Description for the Node. Shown in the web-interface node notes panel. This is saved as comment inside the configuration file.
 	Description *string `json:"description,omitempty" url:"description,omitempty"`
 	// Prevent changes if current configuration file has different SHA1 digest. This can be used to prevent concurrent modifications.

--- a/proxmox/nodes/firewall/options_types.go
+++ b/proxmox/nodes/firewall/options_types.go
@@ -41,5 +41,5 @@ type OptionsGetResponseData struct {
 type OptionsPutRequestBody struct {
 	OptionsGetResponseData
 
-	Delete *[]string `url:"delete,omitempty"`
+	Delete []string `url:"delete,omitempty,comma"`
 }

--- a/proxmox/nodes/network_types.go
+++ b/proxmox/nodes/network_types.go
@@ -66,7 +66,7 @@ type NetworkInterfaceCreateUpdateRequestBody struct {
 	Comments6          *string           `json:"comments6,omitempty"             url:"comments6,omitempty"`
 	Gateway            *string           `json:"gateway,omitempty"               url:"gateway,omitempty"`
 	Gateway6           *string           `json:"gateway6,omitempty"              url:"gateway6,omitempty"`
-	Delete             *[]string         `json:"delete,omitempty"                url:"delete,omitempty"`
+	Delete             []string          `json:"delete,omitempty"                url:"delete,omitempty,comma"`
 	MTU                *int64            `json:"mtu,omitempty"                   url:"mtu,omitempty"`
 	Netmask            *string           `json:"netmask,omitempty"               url:"netmask,omitempty"`
 	Netmask6           *string           `json:"netmask6,omitempty"              url:"netmask6,omitempty"`

--- a/proxmoxtf/resource/firewall/rules.go
+++ b/proxmoxtf/resource/firewall/rules.go
@@ -488,8 +488,7 @@ func RulesUpdate(ctx context.Context, api firewall.Rule, d *schema.ResourceData)
 		}
 
 		if len(fieldsToDelete) > 0 {
-			deleteStr := strings.Join(fieldsToDelete, ",")
-			ruleBody.Delete = &deleteStr
+			ruleBody.Delete = fieldsToDelete
 		}
 
 		err := api.UpdateRule(ctx, pos, &ruleBody)


### PR DESCRIPTION
### What does this PR do?

Standardizes the `Delete` field type across all 9 API client request body structs to use `[]string` with the `url:"delete,omitempty,comma"` struct tag. Previously, `Delete` fields used a mix of `*string` (4 structs), `*[]string` (3 structs), and `string` (2 structs), each requiring different boilerplate at caller sites (`strings.Join`, pointer wrapping, address-of operators). The `comma` tag makes `go-querystring` serialize `[]string{"a","b"}` as `delete=a,b` — the comma-separated format the Proxmox API expects.

This is PR2 of #2600 (PR1 was #2601).

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

**Acceptance tests** — all affected resources pass:

```
ok   fwprovider/cluster/acme       5.082s   # TestAccResourceACMEDNSPlugin
ok   fwprovider/cluster/metrics    4.882s   # TestAccResourceMetricsServer
ok   fwprovider/cluster/options    3.999s   # TestAccResourceClusterOptions
ok   fwprovider/nodes              3.402s   # TestAccResourceACMECertificate
ok   fwprovider/nodes/firewall     4.462s   # TestAccResourceNodeFirewall
ok   fwprovider/nodes/network      9.127s   # TestAccResourceLinuxBridge, TestAccResourceLinuxVlan
ok   fwprovider/test               5.526s   # TestAccResourceFirewallRules
ok   fwprovider/access             2.360s   # TestAccRealmLDAP
```

**Mitmproxy verification** — all `delete` parameters sent as comma-separated values:

```
PUT /cluster/metrics/server/...          delete: mtu
PUT /cluster/options           (Update)  delete: keyboard,crs,ha,console,http_proxy,max_workers
PUT /cluster/options           (Delete)  delete: bwlimit,migration,next-id,notify,email_from,language,mac_prefix
PUT /cluster/acme/plugins/...            delete: disable
PUT /nodes/.../firewall/options (Delete) delete: enable,log_level_in,log_level_out,...
PUT /nodes/.../network/vmbr1412          delete: mtu,bridge_vlan_aware
PUT /nodes/.../network/vmbr1412          delete: cidr,cidr6
PUT /access/domains/...                  delete: filter,group_dn
```

### Community Note

- Please vote on this pull request by adding a :+1: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2600
