### PR TITLE
fix(vm): preserve disk deletions in update request

### DIFF
--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -6228,8 +6228,8 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 		rebootRequired = true
 	}
 
-	// Update the configuration now that everything has been prepared.
-	updateBody.Delete = del
+	// Merge non-disk deletions with any disk deletions already queued.
+	updateBody.Delete = append(updateBody.Delete, del...)
 
 	e = vmAPI.UpdateVM(ctx, updateBody)
 	if e != nil {


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where removing a secondary disk from a VM configuration would not actually delete the disk in Proxmox. In `vmUpdate()`, disk interface names (e.g. `scsi1`) were correctly appended to `updateBody.Delete` early in the function, but a later assignment `updateBody.Delete = del` overwrote them with only non-disk deletions. The Proxmox API never received `delete=scsi1`, so the disk remained.

The fix changes the assignment to `append(updateBody.Delete, del...)` to merge both disk and non-disk deletions.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

**Acceptance test:**

```
$ ./testacc TestAccResourceVMDiskRemoval -- -v

=== RUN   TestAccResourceVMDiskRemoval
--- PASS: TestAccResourceVMDiskRemoval (6.43s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	7.108s
```

The test creates a VM with two disks (scsi0 + scsi1), removes scsi1, then verifies via the Proxmox API that scsi1 no longer exists in the VM configuration.

**Mitmproxy verification** — `delete: scsi1` is sent in the PUT request:

```
PUT https://....:8006/api2/json/nodes/pve/qemu/100/config

    delete: scsi1
    name: test-disk-removal
    scsi0:
      file=local-lvm:vm-100-disk-0,...

 << 200 OK
```

**Existing tests still pass:**

```
$ ./testacc TestAccResourceVMDiskRemovalReuseIssue2218

ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	9.383s
```

### Community Note

- Please vote on this pull request by adding a :+1: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2596
