### PR TITLE
fix(lxc, vm): add retries for LXC operations, unify retry logic into shared package

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,10 +1,12 @@
 {
     "MD007": false,
+    "MD010": { "code_blocks": false },
     "MD013": false,
     "MD025": false,
     "MD028": false,
     "MD029": false,
     "MD033": false,
+    "MD036": false,
     "MD041": false,
     "MD059": false
 }

--- a/proxmox/nodes/containers/containers.go
+++ b/proxmox/nodes/containers/containers.go
@@ -26,6 +26,10 @@ var errContainerAlreadyRunning = errors.New("container is already running")
 // that should be retried. It matches HTTP 5xx server errors, "got no worker upid"
 // (PVE worker start failures), and "got timeout" errors.
 func isRetryableContainerError(err error) bool {
+	if err == nil {
+		return false
+	}
+
 	var httpErr *api.HTTPError
 	if errors.As(err, &httpErr) {
 		return httpErr.Code >= http.StatusInternalServerError

--- a/proxmox/nodes/containers/containers_test.go
+++ b/proxmox/nodes/containers/containers_test.go
@@ -1,0 +1,334 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package containers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
+)
+
+// testUPID is a valid Proxmox UPID for use in tests.
+// Format: UPID:<node>:<pid_hex>:<pstart_hex>:<starttime_hex>:<type>:<id>:<user@realm>:.
+const testUPID = "UPID:pve:00001234:00005678:AABBCCDD:vzcreate:100:root@pam:"
+
+type requestCaptures struct {
+	mu  sync.Mutex
+	req []capturedRequest
+}
+
+type capturedRequest struct {
+	Method string
+	Path   string
+}
+
+func (c *requestCaptures) add(method, path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.req = append(c.req, capturedRequest{Method: method, Path: path})
+}
+
+func (c *requestCaptures) countPOST(pathSuffix string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	n := 0
+
+	for _, r := range c.req {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.Path, pathSuffix) {
+			n++
+		}
+	}
+
+	return n
+}
+
+func newTestServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewTLSServer(handler)
+}
+
+func newTestClient(t *testing.T, endpoint string) *Client {
+	t.Helper()
+
+	conn, err := api.NewConnection(endpoint, true, "")
+	require.NoError(t, err)
+
+	creds, err := api.NewCredentials("", "", "", "user@pve!token=test", "", "")
+	require.NoError(t, err)
+
+	c, err := api.NewClient(creds, conn)
+	require.NoError(t, err)
+
+	return &Client{Client: c, VMID: 100}
+}
+
+// writeJSON writes a JSON response in test handlers. Panics on error since
+// we're in a test context and can't use require (which would fail in goroutine).
+func writeJSON(w http.ResponseWriter, v any) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		panic(err)
+	}
+}
+
+// taskCompletedHandler returns a handler that responds with a completed task status.
+func taskCompletedHandler(captures *requestCaptures) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		captures.add(r.Method, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{
+			"data": map[string]any{
+				"status":     "stopped",
+				"exitstatus": "OK",
+			},
+		})
+	}
+}
+
+func TestIsRetryableContainerError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		err     error
+		want    bool
+		comment string
+	}{
+		{
+			name:    "HTTP 500 Internal Server Error",
+			err:     &api.HTTPError{Code: http.StatusInternalServerError, Message: "Internal Server Error"},
+			want:    true,
+			comment: "HTTP 500 should be retried (API overload)",
+		},
+		{
+			name:    "HTTP 503 Service Unavailable",
+			err:     &api.HTTPError{Code: http.StatusServiceUnavailable, Message: "Service Unavailable"},
+			want:    true,
+			comment: "HTTP 503 should be retried (API overload)",
+		},
+		{
+			name:    "HTTP 400 Bad Request",
+			err:     &api.HTTPError{Code: http.StatusBadRequest, Message: "Bad Request"},
+			want:    false,
+			comment: "HTTP 400 should not be retried (client error)",
+		},
+		{
+			name:    "HTTP 403 Forbidden",
+			err:     &api.HTTPError{Code: http.StatusForbidden, Message: "Forbidden"},
+			want:    false,
+			comment: "HTTP 403 should not be retried (auth error)",
+		},
+		{
+			name:    "HTTP 404 Not Found",
+			err:     &api.HTTPError{Code: http.StatusNotFound, Message: "Not Found"},
+			want:    false,
+			comment: "HTTP 404 should not be retried (resource does not exist)",
+		},
+		{
+			name:    "got no worker upid error",
+			err:     fmt.Errorf("got no worker upid - start worker failed"),
+			want:    true,
+			comment: "PVE worker start failure should be retried",
+		},
+		{
+			name:    "got timeout error",
+			err:     fmt.Errorf("got timeout"),
+			want:    true,
+			comment: "timeout errors should be retried",
+		},
+		{
+			name:    "wrapped got no worker upid error",
+			err:     fmt.Errorf("error creating container: %w", fmt.Errorf("got no worker upid")),
+			want:    true,
+			comment: "wrapped PVE worker start failure should be retried",
+		},
+		{
+			name:    "wrapped got timeout error",
+			err:     fmt.Errorf("error waiting for task: %w", fmt.Errorf("got timeout")),
+			want:    true,
+			comment: "wrapped timeout errors should be retried",
+		},
+		{
+			name:    "generic error",
+			err:     errors.New("something went wrong"),
+			want:    false,
+			comment: "generic errors should not be retried",
+		},
+		{
+			name:    "nil error",
+			err:     nil,
+			want:    false,
+			comment: "nil error should not be retried",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.err == nil {
+				// isRetryableContainerError is only called by retry-go when err != nil,
+				// so we skip the nil case at runtime
+				return
+			}
+
+			got := isRetryableContainerError(tt.err)
+			assert.Equal(t, tt.want, got, tt.comment)
+		})
+	}
+}
+
+// TestCreateContainerRetries verifies that CreateContainer retries on HTTP 500
+// errors and eventually succeeds. The mock server returns 500 on the first POST
+// to the create endpoint, then succeeds on the second attempt with a valid UPID,
+// and returns a completed task status on the status poll.
+func TestCreateContainerRetries(t *testing.T) {
+	t.Parallel()
+
+	captures := &requestCaptures{}
+	var createCount int
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api2/json/lxc", func(w http.ResponseWriter, r *http.Request) {
+		captures.add(r.Method, r.URL.Path)
+
+		createCount++
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if createCount == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			writeJSON(w, map[string]any{"data": nil})
+
+			return
+		}
+
+		writeJSON(w, map[string]any{"data": testUPID})
+	})
+	mux.HandleFunc("GET /api2/json/nodes/", taskCompletedHandler(captures))
+
+	server := newTestServer(t, mux)
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+
+	err := client.CreateContainer(t.Context(), &CreateRequestBody{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, captures.countPOST("/lxc"),
+		"expected exactly 2 POST calls (1 failure + 1 success), proving retry occurred")
+}
+
+// TestCreateContainerNoRetryOn400 verifies that CreateContainer does NOT retry
+// on HTTP 400 errors. The mock server always returns 400, and we assert that
+// only 1 call was made (no retry).
+func TestCreateContainerNoRetryOn400(t *testing.T) {
+	t.Parallel()
+
+	captures := &requestCaptures{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api2/json/lxc", func(w http.ResponseWriter, r *http.Request) {
+		captures.add(r.Method, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]any{
+			"errors": map[string]string{"ostemplate": "value does not exist"},
+		})
+	})
+
+	server := newTestServer(t, mux)
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+
+	err := client.CreateContainer(t.Context(), &CreateRequestBody{})
+	require.Error(t, err)
+
+	assert.Equal(t, 1, captures.countPOST("/lxc"),
+		"expected exactly 1 POST call (no retry on 400)")
+}
+
+// TestCloneContainerRetries verifies that CloneContainer retries on HTTP 500
+// errors and eventually succeeds.
+func TestCloneContainerRetries(t *testing.T) {
+	t.Parallel()
+
+	captures := &requestCaptures{}
+	var cloneCount int
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api2/json/lxc/100/clone", func(w http.ResponseWriter, r *http.Request) {
+		captures.add(r.Method, r.URL.Path)
+
+		cloneCount++
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if cloneCount == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			writeJSON(w, map[string]any{"data": nil})
+
+			return
+		}
+
+		writeJSON(w, map[string]any{"data": testUPID})
+	})
+	mux.HandleFunc("GET /api2/json/nodes/", taskCompletedHandler(captures))
+
+	server := newTestServer(t, mux)
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+
+	err := client.CloneContainer(t.Context(), &CloneRequestBody{})
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, captures.countPOST("/clone"),
+		"expected exactly 2 POST calls (1 failure + 1 success), proving retry occurred")
+}
+
+// TestCloneContainerNoRetryOn400 verifies that CloneContainer does NOT retry
+// on HTTP 400 errors.
+func TestCloneContainerNoRetryOn400(t *testing.T) {
+	t.Parallel()
+
+	captures := &requestCaptures{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api2/json/lxc/100/clone", func(w http.ResponseWriter, r *http.Request) {
+		captures.add(r.Method, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		writeJSON(w, map[string]any{
+			"errors": map[string]string{"vmid": "VM 999 does not exist"},
+		})
+	})
+
+	server := newTestServer(t, mux)
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+
+	err := client.CloneContainer(t.Context(), &CloneRequestBody{})
+	require.Error(t, err)
+
+	assert.Equal(t, 1, captures.countPOST("/clone"),
+		"expected exactly 1 POST call (no retry on 400)")
+}

--- a/proxmox/nodes/containers/containers_test.go
+++ b/proxmox/nodes/containers/containers_test.go
@@ -182,12 +182,6 @@ func TestIsRetryableContainerError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if tt.err == nil {
-				// isRetryableContainerError is only called by retry-go when err != nil,
-				// so we skip the nil case at runtime
-				return
-			}
-
 			got := isRetryableContainerError(tt.err)
 			assert.Equal(t, tt.want, got, tt.comment)
 		})

--- a/proxmox/nodes/containers/containers_types.go
+++ b/proxmox/nodes/containers/containers_types.go
@@ -183,7 +183,9 @@ type TaskSubmittedResponseBody struct {
 type (
 	CreateResponseBody   = TaskSubmittedResponseBody
 	CloneResponseBody    = TaskSubmittedResponseBody
+	DeleteResponseBody   = TaskSubmittedResponseBody
 	RebootResponseBody   = TaskSubmittedResponseBody
+	ResizeResponseBody   = TaskSubmittedResponseBody
 	ShutdownResponseBody = TaskSubmittedResponseBody
 )
 

--- a/proxmox/nodes/vms/vms.go
+++ b/proxmox/nodes/vms/vms.go
@@ -16,50 +16,50 @@ import (
 	"strings"
 	"time"
 
-	"github.com/avast/retry-go/v5"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/tasks"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/retry"
 	"github.com/bpg/terraform-provider-proxmox/utils/ip"
 )
 
 // CloneVM clones a virtual machine.
 func (c *Client) CloneVM(ctx context.Context, retries int, d *CloneRequestBody) error {
-	var err error
-
-	resBody := &MoveDiskResponseBody{}
-
 	// just a guard in case someone sets retries to zero unknowingly
 	if retries <= 0 {
 		retries = 1
 	}
 
-	err = retry.New(
-		retry.Context(ctx),
-		retry.Attempts(uint(retries)),
-		retry.Delay(10*time.Second),
-		retry.LastErrorOnly(false),
-	).Do(
-		func() error {
-			err = c.DoRequest(ctx, http.MethodPost, c.ExpandPath("clone"), d, resBody)
-			if err != nil {
-				return fmt.Errorf("error cloning VM: %w", err)
-			}
+	op := retry.NewTaskOperation("VM clone",
+		retry.WithAttempts(uint(retries)),
+		retry.WithBaseDelay(10*time.Second),
+		retry.WithRetryIf(retry.IsTransientAPIError),
+		retry.WithAlreadyDoneCheck(retry.ErrorContains("already exists")),
+	)
 
-			if resBody.Data == nil {
-				return api.ErrNoDataObjectInResponse
-			}
-
-			// ignoring warnings as per https://www.mail-archive.com/pve-devel@lists.proxmox.com/msg17724.html
-			return c.Tasks().WaitForTask(ctx, *resBody.Data, tasks.WithIgnoreWarnings())
+	return op.DoTask(ctx,
+		func() (*string, error) { return c.CloneVMAsync(ctx, d) },
+		func(ctx context.Context, taskID string) error {
+			return c.Tasks().WaitForTask(ctx, taskID, tasks.WithIgnoreWarnings())
 		},
 	)
+}
+
+// CloneVMAsync clones a virtual machine asynchronously.
+func (c *Client) CloneVMAsync(ctx context.Context, d *CloneRequestBody) (*string, error) {
+	resBody := &CloneResponseBody{}
+
+	err := c.DoRequest(ctx, http.MethodPost, c.ExpandPath("clone"), d, resBody)
 	if err != nil {
-		return fmt.Errorf("error waiting for VM clone: %w", err)
+		return nil, fmt.Errorf("error cloning VM: %w", err)
 	}
 
-	return nil
+	if resBody.Data == nil {
+		return nil, api.ErrNoDataObjectInResponse
+	}
+
+	return resBody.Data, nil
 }
 
 // ConvertToTemplate converts a virtual machine to a template using proper endpoint.
@@ -83,53 +83,22 @@ func (c *Client) ConvertToTemplate(ctx context.Context) error {
 
 // CreateVM creates a virtual machine.
 func (c *Client) CreateVM(ctx context.Context, d *CreateRequestBody) error {
-	taskID, err := c.CreateVMAsync(ctx, d)
-	if err != nil {
-		return err
-	}
+	op := retry.NewTaskOperation("VM create",
+		retry.WithRetryIf(retry.ErrorContains("got no worker upid")),
+		retry.WithAlreadyDoneCheck(retry.ErrorContains("already exists")),
+	)
 
-	err = c.Tasks().WaitForTask(ctx, *taskID)
-	if err != nil {
-		return fmt.Errorf("error waiting for VM creation: %w", err)
-	}
-
-	return nil
+	return op.DoTask(ctx,
+		func() (*string, error) { return c.CreateVMAsync(ctx, d) },
+		func(ctx context.Context, taskID string) error { return c.Tasks().WaitForTask(ctx, taskID) },
+	)
 }
 
-// CreateVMAsync creates a virtual machine asynchronously. Returns ID of the started task.
+// CreateVMAsync creates a virtual machine asynchronously.
 func (c *Client) CreateVMAsync(ctx context.Context, d *CreateRequestBody) (*string, error) {
 	resBody := &CreateResponseBody{}
-	retrying := false
 
-	// retry the request if we get an error that the VM already exists
-	// but only if we're retrying. If this error is returned by the first
-	// request, we'll just return the error (i.e. can't "override" the VM).
-	err := retry.New(
-		retry.Context(ctx),
-		retry.Attempts(3),
-		retry.Delay(1*time.Second),
-		retry.LastErrorOnly(false),
-		retry.OnRetry(func(n uint, err error) {
-			tflog.Warn(ctx, "retrying VM creation", map[string]any{
-				"attempt": n,
-				"error":   err.Error(),
-			})
-
-			retrying = true
-		}),
-		retry.RetryIf(func(err error) bool {
-			return strings.Contains(err.Error(), "got no worker upid")
-		}),
-	).Do(
-		func() error {
-			err := c.DoRequest(ctx, http.MethodPost, c.basePath(), d, resBody)
-			if err != nil && retrying && strings.Contains(err.Error(), "already exists") {
-				return nil
-			}
-
-			return err
-		},
-	)
+	err := c.DoRequest(ctx, http.MethodPost, c.basePath(), d, resBody)
 	if err != nil {
 		return nil, fmt.Errorf("error creating VM: %w", err)
 	}
@@ -143,24 +112,6 @@ func (c *Client) CreateVMAsync(ctx context.Context, d *CreateRequestBody) (*stri
 
 // DeleteVM deletes a virtual machine.
 func (c *Client) DeleteVM(ctx context.Context, purge bool, destroyUnreferencedDisks bool) error {
-	taskID, err := c.DeleteVMAsync(ctx, purge, destroyUnreferencedDisks)
-	if err != nil {
-		return err
-	}
-
-	err = c.Tasks().WaitForTask(ctx, *taskID)
-	if err != nil {
-		return fmt.Errorf("error waiting for VM deletion: %w", err)
-	}
-
-	return nil
-}
-
-// DeleteVMAsync deletes a virtual machine asynchronously. Returns ID of the started task.
-func (c *Client) DeleteVMAsync(ctx context.Context, purge bool, destroyUnreferencedDisks bool) (*string, error) {
-	// PVE may return a 500 error "got no worker upid - start worker failed", so we retry few times.
-	resBody := &DeleteResponseBody{}
-
 	purgeValue := 0
 	if purge {
 		purgeValue = 1
@@ -171,25 +122,30 @@ func (c *Client) DeleteVMAsync(ctx context.Context, purge bool, destroyUnreferen
 		destroyUnreferencedDisksValue = 1
 	}
 
-	err := retry.New(
-		retry.Context(ctx),
-		retry.Attempts(3),
-		retry.Delay(1*time.Second),
-		retry.LastErrorOnly(true),
-		retry.RetryIf(func(err error) bool {
+	op := retry.NewTaskOperation("VM delete",
+		retry.WithRetryIf(func(err error) bool {
 			return !errors.Is(err, api.ErrResourceDoesNotExist)
 		}),
-	).Do(
-		func() error {
-			path := fmt.Sprintf("?destroy-unreferenced-disks=%d&purge=%d", destroyUnreferencedDisksValue, purgeValue)
-			return c.DoRequest(ctx, http.MethodDelete, c.ExpandPath(path), nil, resBody)
-		},
 	)
-	if err != nil {
-		return nil, fmt.Errorf("error deleting VM: %w", err)
-	}
 
-	return resBody.TaskID, nil
+	return op.DoTask(ctx,
+		func() (*string, error) {
+			resBody := &DeleteResponseBody{}
+			path := fmt.Sprintf("?destroy-unreferenced-disks=%d&purge=%d", destroyUnreferencedDisksValue, purgeValue)
+
+			err := c.DoRequest(ctx, http.MethodDelete, c.ExpandPath(path), nil, resBody)
+			if err != nil {
+				return nil, fmt.Errorf("error deleting VM: %w", err)
+			}
+
+			if resBody.TaskID == nil {
+				return nil, api.ErrNoDataObjectInResponse
+			}
+
+			return resBody.TaskID, nil
+		},
+		func(ctx context.Context, taskID string) error { return c.Tasks().WaitForTask(ctx, taskID) },
+	)
 }
 
 // GetVM retrieves a virtual machine.
@@ -385,34 +341,25 @@ func (c *Client) RebootVMAsync(ctx context.Context, d *RebootRequestBody) (*stri
 
 // ResizeVMDisk resizes a virtual machine disk.
 func (c *Client) ResizeVMDisk(ctx context.Context, d *ResizeDiskRequestBody) error {
-	err := retry.New(
-		retry.Context(ctx),
-		retry.Attempts(5),
-		retry.Delay(1*time.Second),
-		retry.DelayType(retry.BackOffDelay),
-		retry.LastErrorOnly(false),
-		retry.RetryIf(func(err error) bool {
-			errStr := err.Error()
-			// retry on "got timeout" or "does not exist" errors.
-			// the "does not exist" error can happen on NFS storage when a disk
-			// was just moved and the storage needs time to sync.
-			return strings.Contains(errStr, "got timeout") || strings.Contains(errStr, "does not exist")
+	// Retry wraps the entire operation (dispatch + wait) because "does not exist"
+	// errors can come from WaitForTask on NFS storage when a disk was just moved
+	// and the storage needs time to sync.
+	op := retry.NewAPICallOperation("VM disk resize",
+		retry.WithAttempts(5),
+		retry.WithRetryIf(func(err error) bool {
+			return strings.Contains(err.Error(), "got timeout") ||
+				strings.Contains(err.Error(), "does not exist")
 		}),
-	).Do(
-		func() error {
-			taskID, err := c.ResizeVMDiskAsync(ctx, d)
-			if err != nil {
-				return err
-			}
-
-			return c.Tasks().WaitForTask(ctx, *taskID)
-		},
 	)
-	if err != nil {
-		return fmt.Errorf("error waiting for VM disk resize: %w", err)
-	}
 
-	return nil
+	return op.Do(ctx, func() error {
+		taskID, err := c.ResizeVMDiskAsync(ctx, d)
+		if err != nil {
+			return err
+		}
+
+		return c.Tasks().WaitForTask(ctx, *taskID)
+	})
 }
 
 // ResizeVMDiskAsync resizes a virtual machine disk asynchronously.
@@ -499,25 +446,18 @@ func (c *Client) StartVMAsync(ctx context.Context, timeoutSec int) (*string, err
 	}
 	resBody := &StartResponseBody{}
 
-	// PVE may return a 500 error "got no worker upid - start worker failed", so we retry few times.
-	err := retry.New(
-		retry.Context(ctx),
-		retry.Attempts(3),
-		retry.Delay(1*time.Second),
-		retry.LastErrorOnly(true),
-		retry.RetryIf(func(err error) bool {
-			return strings.Contains(err.Error(), "got no worker upid")
-		}),
-	).Do(
-		func() error {
-			err := c.DoRequest(ctx, http.MethodPost, c.ExpandPath("status/start"), reqBody, resBody)
-			if err != nil && strings.Contains(err.Error(), "already running") {
-				return nil
-			}
-
-			return err
-		},
+	op := retry.NewAPICallOperation("VM start",
+		retry.WithRetryIf(retry.ErrorContains("got no worker upid")),
 	)
+
+	err := op.Do(ctx, func() error {
+		err := c.DoRequest(ctx, http.MethodPost, c.ExpandPath("status/start"), reqBody, resBody)
+		if err != nil && strings.Contains(err.Error(), "already running") {
+			return nil
+		}
+
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error starting VM: %w", err)
 	}
@@ -562,24 +502,13 @@ func (c *Client) StopVMAsync(ctx context.Context) (*string, error) {
 
 // UpdateVM updates a virtual machine.
 func (c *Client) UpdateVM(ctx context.Context, d *UpdateRequestBody) error {
-	err := retry.New(
-		retry.Context(ctx),
-		retry.Attempts(3),
-		retry.Delay(1*time.Second),
-		retry.LastErrorOnly(true),
-		retry.RetryIf(func(err error) bool {
-			return strings.Contains(err.Error(), "got timeout")
-		}),
-	).Do(
-		func() error {
-			return c.DoRequest(ctx, http.MethodPut, c.ExpandPath("config"), d, nil)
-		},
+	op := retry.NewAPICallOperation("VM config update",
+		retry.WithRetryIf(retry.ErrorContains("got timeout")),
 	)
-	if err != nil {
-		return fmt.Errorf("error updating VM: %w", err)
-	}
 
-	return nil
+	return op.Do(ctx, func() error {
+		return c.DoRequest(ctx, http.MethodPut, c.ExpandPath("config"), d, nil)
+	})
 }
 
 // UpdateVMAsync updates a virtual machine asynchronously.
@@ -649,73 +578,68 @@ func (c *Client) WaitForNetworkInterfacesFromVMAgent(
 		}
 	}()
 
-	data, err := retry.NewWithData[*GetQEMUNetworkInterfacesResponseData](
-		retry.Context(ctxWithTimeout),
-		retry.RetryIf(func(err error) bool {
-			if isAgentNotReadyError(err) {
-				return true
-			}
-
-			return errors.Is(err, errNoIPsYet)
+	op := retry.NewPollOperation("VM network interfaces",
+		retry.WithRetryIf(func(err error) bool {
+			return isAgentNotReadyError(err) || errors.Is(err, errNoIPsYet)
 		}),
-		retry.LastErrorOnly(true),
-		retry.UntilSucceeded(),
-		retry.DelayType(retry.FixedDelay),
-		retry.Delay(time.Second),
-	).Do(
-		func() (*GetQEMUNetworkInterfacesResponseData, error) {
-			data, err := c.GetVMNetworkInterfacesFromAgent(ctx)
-			if err != nil {
-				var httpError *api.HTTPError
-				if errors.As(err, &httpError) {
-					if httpError.Code == http.StatusForbidden {
-						return nil, err
-					}
-
-					if isAgentNotReadyError(err) {
-						return nil, errNoIPsYet
-					}
-				}
-
-				return nil, errNoIPsYet
-			}
-
-			if data == nil || data.Result == nil {
-				return nil, errNoIPsYet
-			}
-
-			hasIPv4, hasIPv6 := c.checkIPAddresses(*data.Result)
-
-			if waitForIPConfig == nil {
-				// backward compatibility: wait for any valid global unicast address
-				if !hasIPv4 && !hasIPv6 {
-					return nil, errNoIPsYet
-				}
-
-				return data, nil
-			}
-
-			requiredIPv4 := waitForIPConfig.IPv4
-			requiredIPv6 := waitForIPConfig.IPv6
-
-			// if no specific requirements, wait for any IP (backward compatibility)
-			if !requiredIPv4 && !requiredIPv6 {
-				if !hasIPv4 && !hasIPv6 {
-					return nil, errNoIPsYet
-				}
-
-				return data, nil
-			}
-
-			// check if all required IP types are available
-			if (requiredIPv4 && !hasIPv4) || (requiredIPv6 && !hasIPv6) {
-				return nil, errNoIPsYet
-			}
-
-			// all required IP types are available
-			return data, nil
-		},
 	)
+
+	var result *GetQEMUNetworkInterfacesResponseData
+
+	err := op.DoPoll(ctxWithTimeout, func() error {
+		data, err := c.GetVMNetworkInterfacesFromAgent(ctx)
+		if err != nil {
+			var httpError *api.HTTPError
+			if errors.As(err, &httpError) {
+				if httpError.Code == http.StatusForbidden {
+					return err
+				}
+
+				if isAgentNotReadyError(err) {
+					return errNoIPsYet
+				}
+			}
+
+			return errNoIPsYet
+		}
+
+		if data == nil || data.Result == nil {
+			return errNoIPsYet
+		}
+
+		hasIPv4, hasIPv6 := c.checkIPAddresses(*data.Result)
+
+		if waitForIPConfig == nil {
+			if !hasIPv4 && !hasIPv6 {
+				return errNoIPsYet
+			}
+
+			result = data
+
+			return nil
+		}
+
+		requiredIPv4 := waitForIPConfig.IPv4
+		requiredIPv6 := waitForIPConfig.IPv6
+
+		if !requiredIPv4 && !requiredIPv6 {
+			if !hasIPv4 && !hasIPv6 {
+				return errNoIPsYet
+			}
+
+			result = data
+
+			return nil
+		}
+
+		if (requiredIPv4 && !hasIPv4) || (requiredIPv6 && !hasIPv6) {
+			return errNoIPsYet
+		}
+
+		result = data
+
+		return nil
+	})
 
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return nil, fmt.Errorf(
@@ -728,7 +652,7 @@ func (c *Client) WaitForNetworkInterfacesFromVMAgent(
 		return nil, fmt.Errorf("error waiting for VM network interfaces: %w", err)
 	}
 
-	return data, nil
+	return result, nil
 }
 
 // checkIPAddresses checks network interfaces for valid IP addresses and returns whether IPv4 and IPv6 are present.
@@ -767,28 +691,25 @@ func (c *Client) checkIPAddresses(
 func (c *Client) WaitForVMConfigUnlock(ctx context.Context, ignoreErrorResponse bool) error {
 	stillLocked := errors.New("still locked")
 
-	err := retry.New(
-		retry.Context(ctx),
-		retry.UntilSucceeded(),
-		retry.Delay(1*time.Second),
-		retry.LastErrorOnly(true),
-		retry.RetryIf(func(err error) bool {
+	op := retry.NewPollOperation("VM config unlock",
+		retry.WithRetryIf(func(err error) bool {
 			return errors.Is(err, stillLocked) || ignoreErrorResponse
 		}),
-	).Do(
-		func() error {
-			data, err := c.GetVMStatus(ctx)
-			if err != nil {
-				return err
-			}
-
-			if data.Lock != nil && *data.Lock != "" {
-				return stillLocked
-			}
-
-			return nil
-		},
 	)
+
+	err := op.DoPoll(ctx, func() error {
+		data, err := c.GetVMStatus(ctx)
+		if err != nil {
+			return err
+		}
+
+		if data.Lock != nil && *data.Lock != "" {
+			return stillLocked
+		}
+
+		return nil
+	})
+
 	if errors.Is(err, context.DeadlineExceeded) {
 		return fmt.Errorf("timeout while waiting for VM %d configuration to become unlocked", c.VMID)
 	}
@@ -803,31 +724,27 @@ func (c *Client) WaitForVMConfigUnlock(ctx context.Context, ignoreErrorResponse 
 // WaitForVMStatus waits for a virtual machine to reach a specific status.
 func (c *Client) WaitForVMStatus(ctx context.Context, status string) error {
 	status = strings.ToLower(status)
-
 	unexpectedStatus := fmt.Errorf("unexpected status %q", status)
 
-	err := retry.New(
-		retry.Context(ctx),
-		retry.UntilSucceeded(),
-		retry.Delay(1*time.Second),
-		retry.LastErrorOnly(true),
-		retry.RetryIf(func(err error) bool {
+	op := retry.NewPollOperation("VM status",
+		retry.WithRetryIf(func(err error) bool {
 			return errors.Is(err, unexpectedStatus)
 		}),
-	).Do(
-		func() error {
-			data, err := c.GetVMStatus(ctx)
-			if err != nil {
-				return err
-			}
-
-			if data.Status != status {
-				return unexpectedStatus
-			}
-
-			return nil
-		},
 	)
+
+	err := op.DoPoll(ctx, func() error {
+		data, err := c.GetVMStatus(ctx)
+		if err != nil {
+			return err
+		}
+
+		if data.Status != status {
+			return unexpectedStatus
+		}
+
+		return nil
+	})
+
 	if errors.Is(err, context.DeadlineExceeded) {
 		return fmt.Errorf("timeout while waiting for VM %d to enter the status %q", c.VMID, status)
 	}

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -134,6 +134,11 @@ func (b *CreateRequestBody) AddCustomStorageDevice(iface string, device CustomSt
 	b.CustomStorageDevices[iface] = &device
 }
 
+// CloneResponseBody contains the body from a clone response.
+type CloneResponseBody struct {
+	Data *string `json:"data,omitempty"`
+}
+
 // CreateResponseBody contains the body from a create response.
 type CreateResponseBody struct {
 	TaskID *string `json:"data,omitempty"`

--- a/proxmox/retry/retry.go
+++ b/proxmox/retry/retry.go
@@ -80,7 +80,7 @@ func ErrorContains(substr string) func(error) bool {
 }
 
 // NewTaskOperation creates an Operation for async UPID-based task operations
-// (create, clone, delete, start, resize). Defaults: exponential backoff,
+// (create, clone, delete, start). Defaults: exponential backoff,
 // retry logging, LastErrorOnly(false), WaitForTask errors are unrecoverable,
 // 3 attempts.
 func NewTaskOperation(name string, opts ...Option) *Operation {

--- a/proxmox/retry/retry.go
+++ b/proxmox/retry/retry.go
@@ -1,0 +1,256 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	retrylib "github.com/avast/retry-go/v5"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
+)
+
+// Operation configures retry behavior for a Proxmox API operation.
+type Operation struct {
+	name      string
+	attempts  uint
+	baseDelay time.Duration
+	retryIf   func(error) bool
+	// Category-specific behavior, set by preset constructors.
+	logOnRetry     bool
+	lastErrorOnly  bool
+	useBackoff     bool
+	isAlreadyDone  func(error) bool
+	untilSucceeded bool
+}
+
+// Option configures an Operation.
+type Option func(*Operation)
+
+// WithAttempts sets the maximum number of retry attempts.
+func WithAttempts(n uint) Option {
+	return func(o *Operation) { o.attempts = n }
+}
+
+// WithBaseDelay sets the base delay between retry attempts.
+func WithBaseDelay(d time.Duration) Option {
+	return func(o *Operation) { o.baseDelay = d }
+}
+
+// WithRetryIf sets the predicate that determines whether an error is retryable.
+func WithRetryIf(fn func(error) bool) Option {
+	return func(o *Operation) { o.retryIf = fn }
+}
+
+// WithAlreadyDoneCheck sets a predicate that detects when a retry attempt finds
+// evidence that the first attempt already succeeded (e.g. "already exists").
+// Only checked on retry attempts, not the first attempt.
+func WithAlreadyDoneCheck(fn func(error) bool) Option {
+	return func(o *Operation) { o.isAlreadyDone = fn }
+}
+
+// IsTransientAPIError returns true for HTTP 5xx, "got no worker upid",
+// and "got timeout" errors.
+func IsTransientAPIError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var httpErr *api.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.Code >= http.StatusInternalServerError
+	}
+
+	return strings.Contains(err.Error(), "got no worker upid") ||
+		strings.Contains(err.Error(), "got timeout")
+}
+
+// ErrorContains returns a predicate that checks if the error message contains substr.
+func ErrorContains(substr string) func(error) bool {
+	return func(err error) bool {
+		if err == nil {
+			return false
+		}
+
+		return strings.Contains(err.Error(), substr)
+	}
+}
+
+// NewTaskOperation creates an Operation for async UPID-based task operations
+// (create, clone, delete, start, resize). Defaults: exponential backoff,
+// retry logging, LastErrorOnly(false), WaitForTask errors are unrecoverable,
+// 3 attempts.
+func NewTaskOperation(name string, opts ...Option) *Operation {
+	o := &Operation{
+		name:          name,
+		attempts:      3,
+		baseDelay:     1 * time.Second,
+		logOnRetry:    true,
+		lastErrorOnly: false,
+		useBackoff:    true,
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o
+}
+
+// DoTask executes an async task operation with retry. The dispatchFn is retried
+// according to the operation's retry configuration. Errors from waitFn are
+// wrapped in retry.Unrecoverable to prevent re-dispatch after a wait failure.
+// The isAlreadyDone check (if configured) is only applied on retry attempts.
+func (o *Operation) DoTask(
+	ctx context.Context,
+	dispatchFn func() (*string, error),
+	waitFn func(ctx context.Context, taskID string) error,
+) error {
+	retrying := false
+
+	retryOpts := []retrylib.Option{
+		retrylib.Context(ctx),
+		retrylib.Attempts(o.attempts),
+		retrylib.Delay(o.baseDelay),
+		retrylib.LastErrorOnly(o.lastErrorOnly),
+	}
+
+	if o.useBackoff {
+		retryOpts = append(retryOpts, retrylib.DelayType(retrylib.BackOffDelay))
+	}
+
+	if o.retryIf != nil {
+		retryOpts = append(retryOpts, retrylib.RetryIf(o.retryIf))
+	}
+
+	retryOpts = append(retryOpts, retrylib.OnRetry(func(n uint, err error) {
+		retrying = true
+
+		if o.logOnRetry {
+			tflog.Warn(ctx, "retrying "+o.name, map[string]any{
+				"attempt": n,
+				"error":   err.Error(),
+			})
+		}
+	}))
+
+	//nolint:wrapcheck // errors from dispatchFn/waitFn pass through intentionally
+	return retrylib.New(retryOpts...).Do(func() error {
+		taskID, err := dispatchFn()
+		if err != nil {
+			if retrying && o.isAlreadyDone != nil && o.isAlreadyDone(err) {
+				return nil
+			}
+
+			return err
+		}
+
+		// nil taskID with nil error means the operation is already done
+		// (e.g., "already running") — skip the wait.
+		if taskID == nil {
+			return nil
+		}
+
+		if err := waitFn(ctx, *taskID); err != nil {
+			return retrylib.Unrecoverable(err)
+		}
+
+		return nil
+	})
+}
+
+// NewAPICallOperation creates an Operation for synchronous API calls that block
+// server-side (e.g. PUT /config). Defaults: exponential backoff, retry logging,
+// LastErrorOnly(false), 3 attempts, 1s base delay.
+func NewAPICallOperation(name string, opts ...Option) *Operation {
+	o := &Operation{
+		name:          name,
+		attempts:      3,
+		baseDelay:     1 * time.Second,
+		logOnRetry:    true,
+		lastErrorOnly: false,
+		useBackoff:    true,
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o
+}
+
+// Do executes a synchronous API call with retry.
+func (o *Operation) Do(ctx context.Context, fn func() error) error {
+	retryOpts := []retrylib.Option{
+		retrylib.Context(ctx),
+		retrylib.Attempts(o.attempts),
+		retrylib.Delay(o.baseDelay),
+		retrylib.LastErrorOnly(o.lastErrorOnly),
+	}
+
+	if o.useBackoff {
+		retryOpts = append(retryOpts, retrylib.DelayType(retrylib.BackOffDelay))
+	}
+
+	if o.retryIf != nil {
+		retryOpts = append(retryOpts, retrylib.RetryIf(o.retryIf))
+	}
+
+	if o.logOnRetry {
+		retryOpts = append(retryOpts, retrylib.OnRetry(func(n uint, err error) {
+			tflog.Warn(ctx, "retrying "+o.name, map[string]any{
+				"attempt": n,
+				"error":   err.Error(),
+			})
+		}))
+	}
+
+	//nolint:wrapcheck // errors from fn pass through intentionally
+	return retrylib.New(retryOpts...).Do(fn)
+}
+
+// NewPollOperation creates an Operation for wait-for-condition polling loops
+// (e.g. WaitForVMStatus, WaitForConfigUnlock). Defaults: fixed 1s delay,
+// no attempt limit (relies on context deadline), LastErrorOnly(true),
+// no retry logging.
+func NewPollOperation(name string, opts ...Option) *Operation {
+	o := &Operation{
+		name:           name,
+		baseDelay:      1 * time.Second,
+		lastErrorOnly:  true,
+		untilSucceeded: true,
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	return o
+}
+
+// DoPoll executes a polling loop with retry until fn returns nil or a
+// non-retryable error. Uses fixed delay and no attempt limit by default.
+func (o *Operation) DoPoll(ctx context.Context, fn func() error) error {
+	retryOpts := []retrylib.Option{
+		retrylib.Context(ctx),
+		retrylib.Delay(o.baseDelay),
+		retrylib.DelayType(retrylib.FixedDelay),
+		retrylib.LastErrorOnly(o.lastErrorOnly),
+	}
+
+	if o.untilSucceeded {
+		retryOpts = append(retryOpts, retrylib.UntilSucceeded())
+	} else {
+		retryOpts = append(retryOpts, retrylib.Attempts(o.attempts))
+	}
+
+	if o.retryIf != nil {
+		retryOpts = append(retryOpts, retrylib.RetryIf(o.retryIf))
+	}
+
+	//nolint:wrapcheck // errors from fn pass through intentionally
+	return retrylib.New(retryOpts...).Do(fn)
+}

--- a/proxmox/retry/retry_test.go
+++ b/proxmox/retry/retry_test.go
@@ -1,0 +1,354 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
+)
+
+func TestIsTransientAPIError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"HTTP 500", &api.HTTPError{Code: http.StatusInternalServerError}, true},
+		{"HTTP 503", &api.HTTPError{Code: http.StatusServiceUnavailable}, true},
+		{"HTTP 400", &api.HTTPError{Code: http.StatusBadRequest}, false},
+		{"HTTP 404", &api.HTTPError{Code: http.StatusNotFound}, false},
+		{"got no worker upid", fmt.Errorf("got no worker upid"), true},
+		{"got timeout", fmt.Errorf("got timeout"), true},
+		{"wrapped got timeout", fmt.Errorf("error: %w", fmt.Errorf("got timeout")), true},
+		{"generic error", errors.New("something else"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsTransientAPIError(tt.err))
+		})
+	}
+}
+
+func TestErrorContains(t *testing.T) {
+	t.Parallel()
+
+	check := ErrorContains("already exists")
+	assert.True(t, check(fmt.Errorf("container 100 already exists")))
+	assert.False(t, check(fmt.Errorf("something else")))
+	assert.False(t, check(nil))
+}
+
+func TestDoTask_Success(t *testing.T) {
+	t.Parallel()
+
+	op := NewTaskOperation("test-op",
+		WithRetryIf(IsTransientAPIError),
+	)
+
+	dispatched := 0
+	waited := 0
+
+	err := op.DoTask(t.Context(),
+		func() (*string, error) {
+			dispatched++
+			id := "UPID:test:1234"
+
+			return &id, nil
+		},
+		func(_ context.Context, taskID string) error {
+			waited++
+
+			assert.Equal(t, "UPID:test:1234", taskID)
+
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, dispatched)
+	assert.Equal(t, 1, waited)
+}
+
+func TestDoTask_RetryOnTransientError(t *testing.T) {
+	t.Parallel()
+
+	op := NewTaskOperation("test-op",
+		WithBaseDelay(1*time.Millisecond),
+		WithRetryIf(IsTransientAPIError),
+	)
+
+	dispatched := 0
+
+	err := op.DoTask(t.Context(),
+		func() (*string, error) {
+			dispatched++
+			if dispatched == 1 {
+				return nil, &api.HTTPError{Code: http.StatusInternalServerError}
+			}
+
+			id := "UPID:test:1234"
+
+			return &id, nil
+		},
+		func(_ context.Context, _ string) error { return nil },
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, dispatched)
+}
+
+func TestDoTask_AlreadyDoneOnRetry(t *testing.T) {
+	t.Parallel()
+
+	op := NewTaskOperation("test-op",
+		WithBaseDelay(1*time.Millisecond),
+		WithRetryIf(IsTransientAPIError),
+		WithAlreadyDoneCheck(ErrorContains("already exists")),
+	)
+
+	dispatched := 0
+
+	err := op.DoTask(t.Context(),
+		func() (*string, error) {
+			dispatched++
+			if dispatched == 1 {
+				return nil, &api.HTTPError{Code: http.StatusInternalServerError}
+			}
+			// Second attempt: "already exists" because first actually succeeded
+			return nil, fmt.Errorf("container 100 already exists")
+		},
+		func(_ context.Context, _ string) error {
+			t.Fatal("waitFn should not be called when already done")
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, dispatched)
+}
+
+func TestDoTask_AlreadyDoneIgnoredOnFirstAttempt(t *testing.T) {
+	t.Parallel()
+
+	op := NewTaskOperation("test-op",
+		WithBaseDelay(1*time.Millisecond),
+		WithRetryIf(IsTransientAPIError),
+		WithAlreadyDoneCheck(ErrorContains("already exists")),
+	)
+
+	err := op.DoTask(t.Context(),
+		func() (*string, error) {
+			return nil, fmt.Errorf("container 100 already exists")
+		},
+		func(_ context.Context, _ string) error { return nil },
+	)
+
+	// "already exists" on first attempt is a real error, not suppressed
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+func TestDoTask_NilTaskIDSkipsWait(t *testing.T) {
+	t.Parallel()
+
+	op := NewTaskOperation("test-op",
+		WithBaseDelay(1*time.Millisecond),
+		WithRetryIf(IsTransientAPIError),
+	)
+
+	err := op.DoTask(t.Context(),
+		func() (*string, error) {
+			// nil taskID, nil error = "already done" (e.g., already running)
+			return nil, nil //nolint:nilnil // testing defensive nil-taskID handling
+		},
+		func(_ context.Context, _ string) error {
+			t.Fatal("waitFn should not be called when taskID is nil")
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+}
+
+func TestDoTask_WaitErrorIsUnrecoverable(t *testing.T) {
+	t.Parallel()
+
+	op := NewTaskOperation("test-op",
+		WithBaseDelay(1*time.Millisecond),
+		WithRetryIf(IsTransientAPIError),
+	)
+
+	dispatched := 0
+
+	err := op.DoTask(t.Context(),
+		func() (*string, error) {
+			dispatched++
+			id := "UPID:test:1234"
+
+			return &id, nil
+		},
+		func(_ context.Context, _ string) error {
+			return fmt.Errorf("task failed with exit code: ERROR")
+		},
+	)
+
+	require.Error(t, err)
+	// Dispatch should only happen once — waitFn error is unrecoverable
+	assert.Equal(t, 1, dispatched)
+}
+
+func TestDoTask_NoRetryOnNonTransient(t *testing.T) {
+	t.Parallel()
+
+	op := NewTaskOperation("test-op",
+		WithBaseDelay(1*time.Millisecond),
+		WithRetryIf(IsTransientAPIError),
+	)
+
+	dispatched := 0
+
+	err := op.DoTask(t.Context(),
+		func() (*string, error) {
+			dispatched++
+			return nil, &api.HTTPError{Code: http.StatusBadRequest, Message: "bad request"}
+		},
+		func(_ context.Context, _ string) error { return nil },
+	)
+
+	require.Error(t, err)
+	assert.Equal(t, 1, dispatched)
+}
+
+func TestDo_Success(t *testing.T) {
+	t.Parallel()
+
+	op := NewAPICallOperation("test-op",
+		WithRetryIf(ErrorContains("got timeout")),
+	)
+
+	called := 0
+
+	err := op.Do(t.Context(), func() error {
+		called++
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, called)
+}
+
+func TestDo_RetryOnTimeout(t *testing.T) {
+	t.Parallel()
+
+	op := NewAPICallOperation("test-op",
+		WithBaseDelay(1*time.Millisecond),
+		WithRetryIf(ErrorContains("got timeout")),
+	)
+
+	called := 0
+
+	err := op.Do(t.Context(), func() error {
+		called++
+		if called == 1 {
+			return fmt.Errorf("got timeout")
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, called)
+}
+
+func TestDo_NoRetryOnNonMatchingError(t *testing.T) {
+	t.Parallel()
+
+	op := NewAPICallOperation("test-op",
+		WithBaseDelay(1*time.Millisecond),
+		WithRetryIf(ErrorContains("got timeout")),
+	)
+
+	called := 0
+
+	err := op.Do(t.Context(), func() error {
+		called++
+		return fmt.Errorf("permission denied")
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, 1, called)
+}
+
+func TestDoPoll_Success(t *testing.T) {
+	t.Parallel()
+
+	stillWaiting := errors.New("still waiting")
+	op := NewPollOperation("test-poll",
+		WithRetryIf(func(err error) bool { return errors.Is(err, stillWaiting) }),
+	)
+
+	called := 0
+
+	err := op.DoPoll(t.Context(), func() error {
+		called++
+		if called < 3 {
+			return stillWaiting
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, called)
+}
+
+func TestDoPoll_ContextTimeout(t *testing.T) {
+	t.Parallel()
+
+	stillWaiting := errors.New("still waiting")
+	op := NewPollOperation("test-poll",
+		WithBaseDelay(1*time.Millisecond),
+		WithRetryIf(func(err error) bool { return errors.Is(err, stillWaiting) }),
+	)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	err := op.DoPoll(ctx, func() error {
+		return stillWaiting
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestDoPoll_NonRetryableError(t *testing.T) {
+	t.Parallel()
+
+	stillWaiting := errors.New("still waiting")
+	op := NewPollOperation("test-poll",
+		WithRetryIf(func(err error) bool { return errors.Is(err, stillWaiting) }),
+	)
+
+	called := 0
+
+	err := op.DoPoll(t.Context(), func() error {
+		called++
+		return fmt.Errorf("unexpected API error")
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, 1, called)
+}

--- a/proxmox/retry/retry_test.go
+++ b/proxmox/retry/retry_test.go
@@ -26,9 +26,11 @@ func TestIsTransientAPIError(t *testing.T) {
 		{"HTTP 500", &api.HTTPError{Code: http.StatusInternalServerError}, true},
 		{"HTTP 503", &api.HTTPError{Code: http.StatusServiceUnavailable}, true},
 		{"HTTP 400", &api.HTTPError{Code: http.StatusBadRequest}, false},
+		{"HTTP 403", &api.HTTPError{Code: http.StatusForbidden}, false},
 		{"HTTP 404", &api.HTTPError{Code: http.StatusNotFound}, false},
 		{"got no worker upid", fmt.Errorf("got no worker upid"), true},
 		{"got timeout", fmt.Errorf("got timeout"), true},
+		{"wrapped got no worker upid", fmt.Errorf("error: %w", fmt.Errorf("got no worker upid")), true},
 		{"wrapped got timeout", fmt.Errorf("error: %w", fmt.Errorf("got timeout")), true},
 		{"generic error", errors.New("something else"), false},
 	}


### PR DESCRIPTION
### What does this PR do?
<!--- Clearly state the problem and how this PR solves it. -->

Aim to close: https://github.com/bpg/terraform-provider-proxmox/issues/2576

This PR adds retry logic to `CreateContainer` and `CloneContainer` (3 attempts, 10s delay) that retries on:
- HTTP 5xx server errors
- `"got no worker upid"` (PVE worker start failures)
- `"got timeout"` errors

Non-retryable errors (4xx, validation, auth) fail immediately without retry.

### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

#### Unit tests — retry package (15 tests)

```
go test ./proxmox/retry/ -v

--- PASS: TestIsTransientAPIError (8 subtests)
--- PASS: TestErrorContains
--- PASS: TestDoTask_Success
--- PASS: TestDoTask_RetryOnTransientError
--- PASS: TestDoTask_AlreadyDoneOnRetry
--- PASS: TestDoTask_AlreadyDoneIgnoredOnFirstAttempt
--- PASS: TestDoTask_NilTaskIDSkipsWait
--- PASS: TestDoTask_WaitErrorIsUnrecoverable
--- PASS: TestDoTask_NoRetryOnNonTransient
--- PASS: TestDo_Success
--- PASS: TestDo_RetryOnTimeout
--- PASS: TestDo_NoRetryOnNonMatchingError
--- PASS: TestDoPoll_Success
--- PASS: TestDoPoll_ContextTimeout
--- PASS: TestDoPoll_NonRetryableError
ok  	github.com/bpg/terraform-provider-proxmox/proxmox/retry
```

#### Integration tests — container operations with mock HTTP server (11 tests)

```
go test ./proxmox/nodes/containers/ -v

--- PASS: TestDeleteContainerWaitsForTask
--- PASS: TestResizeContainerDiskWaitsForTask
--- PASS: TestIsTransientAPIError (11 subtests)
--- PASS: TestCreateContainerRetries
--- PASS: TestCreateContainerNoRetryOn400
--- PASS: TestCloneContainerRetries
--- PASS: TestCloneContainerNoRetryOn400
--- PASS: TestStartContainerAlreadyRunningOnFirstAttempt
--- PASS: TestStartContainerAlreadyRunningDetectedByPreCheck
--- PASS: TestStartContainerRetriesOnNoWorkerUpid
--- PASS: TestStartContainerAlreadyRunningOnRetry
ok  	github.com/bpg/terraform-provider-proxmox/proxmox/nodes/containers
```

#### Acceptance tests — container lifecycle

```
./testacc TestAccResourceContainer -- -v

--- PASS: TestAccResourceContainer (31.84s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	32.384s
```

#### Acceptance tests — VM lifecycle (23 subtests)

```
./testacc TestAccResourceVM -- -v

--- PASS: TestAccResourceVM (0.00s)
    --- PASS: TestAccResourceVM/hotplug_duplicate_rejected (0.54s)
    --- PASS: TestAccResourceVM/hotplug_disabled (2.75s)
    --- PASS: TestAccResourceVM/timeout_persistence_across_updates (3.72s)
    --- PASS: TestAccResourceVM/create_vga_block (3.29s)
    --- PASS: TestAccResourceVM/multiline_description (3.95s)
    --- PASS: TestAccResourceVM/create_VM_without_cpu.units_and_verify_no_drift (4.13s)
    --- PASS: TestAccResourceVM/update_vga_block (4.29s)
    --- PASS: TestAccResourceVM/hotplug_order_insensitive (4.44s)
    --- PASS: TestAccResourceVM/update_watchdog_block (4.47s)
    --- PASS: TestAccResourceVM/empty_node_name (0.20s)
    --- PASS: TestAccResourceVM/hotplug_explicit_reset (4.63s)
    --- PASS: TestAccResourceVM/update_rng_block (4.95s)
    --- PASS: TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_set_to_false (1.18s)
    --- PASS: TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_update (2.04s)
    --- PASS: TestAccResourceVM/set_cpu.architecture_as_non_root_is_not_supported (2.47s)
    --- PASS: TestAccResourceVM/update_memory_block (4.12s)
    --- PASS: TestAccResourceVM/single_line_description (2.27s)
    --- PASS: TestAccResourceVM/hotplug (3.06s)
    --- PASS: TestAccResourceVM/protection (3.07s)
    --- PASS: TestAccResourceVM/update_cpu_block (3.14s)
    --- PASS: TestAccResourceVM/no_description (3.19s)
    --- PASS: TestAccResourceVM/create_virtiofs_block (4.16s)
    --- PASS: TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_defaults (4.29s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	9.705s
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000 | Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
