### PR TITLE
fix(docs): clarify SSH password inheritance with API token auth

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,8 @@ provider "proxmox" {
 }
 ```
 
+~> When using **API token** authentication, the SSH password cannot be inherited from the provider `password` field (since there is none). You must ensure that either `ssh-agent` has the appropriate keys loaded, or explicitly configure `password` or `private_key` in the `ssh` block.
+
 ## Authentication
 
 The provider supports three authentication methods (in order of precedence):
@@ -330,6 +332,8 @@ provider "proxmox" {
 If no `ssh` block is provided, the provider will attempt to connect to the target node using the credentials provided in the `username` and `password` arguments (or `PROXMOX_VE_USERNAME` and `PROXMOX_VE_PASSWORD` environment variables).
 Note that the target node is identified by the `node` argument in the resource, and may be different from the Proxmox API endpoint.
 Please refer to the [Argument Reference](#argument-reference) section to view the available arguments of the `ssh` block.
+
+~> **Important:** The SSH password is only inherited from the provider's `password` field when using **username/password** authentication. When using **API token** authentication, there is no password to inherit. In this case, you must provide SSH credentials explicitly: either configure `ssh-agent` with the appropriate keys, or set `password` or `private_key` in the `ssh` block (or their corresponding environment variables).
 
 ### SSH Agent
 
@@ -586,7 +590,7 @@ In addition to [generic provider arguments](https://developer.hashicorp.com/terr
 
 - `ssh` - (Optional) The SSH connection configuration to a Proxmox node. This is a block, whose fields are documented below.
     - `username` - (Optional) The username to use for the SSH connection. Defaults to the username used for the Proxmox API connection. Can also be sourced from `PROXMOX_VE_SSH_USERNAME`. Required when using API Token.
-    - `password` - (Optional) The password to use for the SSH connection. Defaults to the password used for the Proxmox API connection. Can also be sourced from `PROXMOX_VE_SSH_PASSWORD`.
+    - `password` - (Optional) The password to use for the SSH connection. Defaults to the password used for the Proxmox API connection when using username/password authentication. Default has no effect when using API token authentication, as there is no password to inherit. Can also be sourced from `PROXMOX_VE_SSH_PASSWORD`.
     - `agent` - (Optional) Whether to use the SSH agent for the SSH authentication. Defaults to `false`. Can also be sourced from `PROXMOX_VE_SSH_AGENT`.
     - `agent_socket` - (Optional) The path to the SSH agent socket. Defaults to the value of the `SSH_AUTH_SOCK` environment variable. Can also be sourced from `PROXMOX_VE_SSH_AUTH_SOCK`.
     - `agent_forwarding` - (Optional) Whether to enable SSH agent forwarding. Defaults to the value of the `PROXMOX_VE_SSH_AGENT_FORWARDING` environment variable, or `false` if not set.

--- a/example/main.tf
+++ b/example/main.tf
@@ -5,6 +5,8 @@ provider "proxmox" {
   ssh {
     agent    = true
     username = var.virtual_environment_ssh_username
+    # When using api_token, there is no provider password to inherit for SSH.
+    # Ensure ssh-agent has the appropriate keys loaded, or set password / private_key here.
   }
 }
 

--- a/fwprovider/provider.go
+++ b/fwprovider/provider.go
@@ -211,7 +211,10 @@ func (p *proxmoxProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 						"password": schema.StringAttribute{
 							Description: "The password used for the SSH connection. " +
 								"Defaults to the value of the `password` field of the " +
-								"`provider` block.",
+								"`provider` block when using username/password authentication. " +
+								"Default has no effect when using API token authentication, " +
+								"as there is no password to inherit. " +
+								"Can also be sourced from `PROXMOX_VE_SSH_PASSWORD`.",
 							Optional:  true,
 							Sensitive: true,
 						},

--- a/proxmoxtf/provider/schema.go
+++ b/proxmoxtf/provider/schema.go
@@ -129,7 +129,10 @@ func createSchema() map[string]*schema.Schema {
 						Sensitive: true,
 						Description: "The password used for the SSH connection. " +
 							"Defaults to the value of the `password` field of the " +
-							"`provider` block.",
+							"`provider` block when using username/password authentication. " +
+							"Default has no effect when using API token authentication, " +
+							"as there is no password to inherit. " +
+							"Can also be sourced from `PROXMOX_VE_SSH_PASSWORD`.",
 						DefaultFunc: schema.MultiEnvDefaultFunc(
 							[]string{"PROXMOX_VE_SSH_PASSWORD", "PM_VE_SSH_PASSWORD"},
 							nil,


### PR DESCRIPTION
### What does this PR do?

Clarifies that the SSH `password` field's default (inheriting from the provider's API `password`) only works with username/password authentication — not with API token authentication, since there is no password to inherit.

This was reported in #2578 where a user expected SSH password to be automatically available when using `api_token`, but the provider has no password to fall back to in that case. The fix updates schema descriptions, provider docs, and the example configuration to make this limitation explicit.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

Documentation-only change — no API behavior or code logic changes.

```text
$ make build
go build -o "./build/terraform-provider-proxmox_v0.96.0"

$ make lint
golangci-lint fmt
golangci-lint run --fix
0 issues.

$ make test
ok   github.com/bpg/terraform-provider-proxmox/... (all packages pass)

$ make docs
rendering website for provider "terraform-provider-proxmox" (as "terraform-provider-proxmox")
... (completed successfully, regenerated docs/index.md with updated schema descriptions)
```

**Files changed:**

| File | Change |
|------|--------|
| `fwprovider/provider.go` | Updated SSH `password` schema description to clarify API token limitation |
| `proxmoxtf/provider/schema.go` | Same description update for SDK provider |
| `docs/index.md` | Added warning callouts in SSH sections; argument reference auto-updated by `make docs` |
| `example/main.tf` | Added comment about ssh-agent requirement when using `api_token` |

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

Closes #2578
