### PR TITLE
fix(storage): unknown `encryption_key_fingerprint` after PBS apply

### DIFF
--- a/fwprovider/storage/model_pbs.go
+++ b/fwprovider/storage/model_pbs.go
@@ -8,6 +8,8 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -121,6 +123,17 @@ func (m *PBSStorageModel) fromAPI(ctx context.Context, datastore *storage.Datast
 
 	if datastore.Shared != nil {
 		m.Shared = types.BoolValue(*datastore.Shared.PointerBool())
+	}
+
+	if datastore.EncryptionKey != nil {
+		var encryptionKey storage.EncryptionKey
+		if err := json.Unmarshal([]byte(*datastore.EncryptionKey), &encryptionKey); err != nil {
+			return fmt.Errorf("cannot unmarshal encryption key: %w", err)
+		}
+
+		m.EncryptionKeyFingerprint = types.StringValue(encryptionKey.Fingerprint)
+	} else {
+		m.EncryptionKeyFingerprint = types.StringNull()
 	}
 
 	// only populate backups if user has configured it to avoid "was absent, but now present" error

--- a/fwprovider/storage/model_pbs_test.go
+++ b/fwprovider/storage/model_pbs_test.go
@@ -1,0 +1,84 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/storage"
+)
+
+func TestPBSStorageModel_FromAPI_EncryptionKeyFingerprint(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("sets fingerprint when encryption key present", func(t *testing.T) {
+		t.Parallel()
+
+		encKeyJSON := `{"fingerprint":"sha256:abc123","data":"secret","created":"2025-08-18T15:04:05Z","modified":"2025-08-18T15:04:05Z"}`
+		server := "pbs.example.com"
+		datastore := "backup1"
+		username := "user@pbs"
+		storageID := "pbs-test"
+
+		model := &PBSStorageModel{
+			modelBase: modelBase{
+				ID:           types.StringValue(storageID),
+				Nodes:        types.SetNull(types.StringType),
+				ContentTypes: types.SetNull(types.StringType),
+			},
+			EncryptionKeyFingerprint: types.StringUnknown(),
+			GeneratedEncryptionKey:   types.StringUnknown(),
+		}
+
+		err := model.fromAPI(ctx, &storage.DatastoreGetResponseData{
+			ID:            &storageID,
+			Server:        &server,
+			Datastore:     &datastore,
+			Username:      &username,
+			EncryptionKey: &encKeyJSON,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, "sha256:abc123", model.EncryptionKeyFingerprint.ValueString())
+	})
+
+	t.Run("sets fingerprint to null when no encryption key", func(t *testing.T) {
+		t.Parallel()
+
+		server := "pbs.example.com"
+		datastore := "backup1"
+		username := "user@pbs"
+		storageID := "pbs-test"
+
+		model := &PBSStorageModel{
+			modelBase: modelBase{
+				ID:           types.StringValue(storageID),
+				Nodes:        types.SetNull(types.StringType),
+				ContentTypes: types.SetNull(types.StringType),
+			},
+			EncryptionKeyFingerprint: types.StringUnknown(),
+			GeneratedEncryptionKey:   types.StringUnknown(),
+		}
+
+		err := model.fromAPI(ctx, &storage.DatastoreGetResponseData{
+			ID:        &storageID,
+			Server:    &server,
+			Datastore: &datastore,
+			Username:  &username,
+		})
+
+		require.NoError(t, err)
+		require.True(t, model.EncryptionKeyFingerprint.IsNull(),
+			"EncryptionKeyFingerprint should be null when no encryption key, got: %s", model.EncryptionKeyFingerprint)
+	})
+}


### PR DESCRIPTION
### What does this PR do?

Fixes `proxmox_virtual_environment_storage_pbs` returning "Provider returned invalid result object after apply" when `generate_encryption_key = false`. The `fromAPI` method never populated `encryption_key_fingerprint`, leaving it as unknown after apply. This adds encryption key handling in `fromAPI()` to parse the fingerprint from the API response or set it to null when no encryption key is configured.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

Unit test verifying both code paths (encryption key present and absent):

```text
=== RUN   TestPBSStorageModel_FromAPI_EncryptionKeyFingerprint
=== RUN   TestPBSStorageModel_FromAPI_EncryptionKeyFingerprint/sets_fingerprint_when_encryption_key_present
=== RUN   TestPBSStorageModel_FromAPI_EncryptionKeyFingerprint/sets_fingerprint_to_null_when_no_encryption_key
--- PASS: TestPBSStorageModel_FromAPI_EncryptionKeyFingerprint (0.00s)
    --- PASS: TestPBSStorageModel_FromAPI_EncryptionKeyFingerprint/sets_fingerprint_when_encryption_key_present (0.00s)
    --- PASS: TestPBSStorageModel_FromAPI_EncryptionKeyFingerprint/sets_fingerprint_to_null_when_no_encryption_key (0.00s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/storage	0.275s
```

No acceptance test available (requires a PBS server that I don't have in my test lab).

### Community Note

- Please vote on this pull request by adding a :+1: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2572
