### PR TITLE
fix(vm): skip cdrom devices during disk read-back on import

### DIFF
--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -385,6 +385,11 @@ func Read(
 			continue
 		}
 
+		// skip CDROM devices — they are managed by the cdrom block, not the disk block
+		if dd.Media != nil && *dd.Media == "cdrom" {
+			continue
+		}
+
 		disk := map[string]any{}
 
 		datastoreID, pathInDatastore, hasDatastoreID := strings.Cut(dd.FileVolume, ":")


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where importing a VM with a CDROM device (e.g., an ISO attached via `media=cdrom`) caused the CDROM to leak into the `disk` block in Terraform state. This happened because `disk.Read()` only skipped cloud-init drives and `FileVolume=="none"` devices, but not `media=cdrom` devices. During import (when no prior disk state exists), all storage devices—including CDROMs—were added to the disk block. For VMs with ISOs, this resulted in `file_format=iso` appearing in state, which the schema validator rejected (`expected one of ["qcow2" "raw" "vmdk"], got iso`).

The fix adds a `media=cdrom` check in the SDK disk read-back function, matching the pattern already used in the update path (`vm.go:5833`).

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

```
$ ./testacc TestAccResourceVMDiskCDROMNotInDiskBlock -- -v

=== RUN   TestAccResourceVMDiskCDROMNotInDiskBlock
=== PAUSE TestAccResourceVMDiskCDROMNotInDiskBlock
=== CONT  TestAccResourceVMDiskCDROMNotInDiskBlock
--- PASS: TestAccResourceVMDiskCDROMNotInDiskBlock (3.52s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	4.050s
```

The test creates a VM with a `cdrom { file_id = "cdrom" }` block and a `disk` block, then imports it via `ImportState`. Before the fix, the imported state showed `disk.# = 2` with the cdrom leaking into `disk.0` as `interface=ide2, path_in_datastore=cdrom`. After the fix, `disk.# = 1` with only the real disk at `scsi0`.

Existing tests verified — no regressions:

```
$ ./testacc TestAccResourceVMCDROM -- -v
--- PASS: TestAccResourceVMCDROM/none_cdrom (2.42s)
--- PASS: TestAccResourceVMCDROM/enable_cdrom (2.73s)
--- PASS: TestAccResourceVMCDROM/default_no_cdrom (3.05s)
--- PASS: TestAccResourceVMCDROM/scsi_cdrom (3.44s)
--- PASS: TestAccResourceVMCDROM/sata_cdrom (3.47s)
PASS

$ ./testacc TestAccResourceVMDisks -- -v
--- PASS: TestAccResourceVMDisks/disk_resize_with_cdrom_in_boot_order (18.82s)
--- PASS: TestAccResourceVMDisks/disk_ordering_consistency (41.27s)
[...all subtests PASS...]
PASS
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

Closes #2550
