### PR TITLE
fix(firewall): handle "already exists" error in SG and IPSet create

### DIFF
--- a/.claude/commands/bpg/start-issue.md
+++ b/.claude/commands/bpg/start-issue.md
@@ -278,7 +278,7 @@ Update `.dev/${ISSUE_NUM}_SESSION_STATE.md` with:
 - If `gh` CLI is not authenticated, the skill will prompt for manual verification
 - Branch names are auto-truncated to avoid filesystem issues
 - Session state file is gitignored, so it won't be committed
-- Always create the acceptance test before implementing the fix
+- **Acceptance tests first:** Always create the acceptance test BEFORE implementing the fix. The test must reproduce the bug with the current code and fail, proving the issue exists. Only then implement the fix and verify the test passes.
 - Stale `/tmp/testacc.log` and `/tmp/api_debug.log` are cleared to ensure clean slate
 - Use `/bpg:resume` to continue work if you need to come back later
 

--- a/proxmox/api/client.go
+++ b/proxmox/api/client.go
@@ -371,6 +371,10 @@ func validateResponseCode(res *http.Response) error {
 			return errors.Join(ErrResourceDoesNotExist, httpError)
 		}
 
+		if strings.Contains(msg, "already exists") {
+			return errors.Join(ErrResourceAlreadyExists, httpError)
+		}
+
 		return httpError
 	}
 

--- a/proxmox/api/errors.go
+++ b/proxmox/api/errors.go
@@ -23,6 +23,9 @@ const ErrNoDataObjectInResponse Error = "the server did not include a data objec
 // ErrResourceDoesNotExist is returned when the requested resource does not exist.
 const ErrResourceDoesNotExist Error = "the requested resource does not exist"
 
+// ErrResourceAlreadyExists is returned when attempting to create a resource that already exists.
+const ErrResourceAlreadyExists Error = "the requested resource already exists"
+
 // HTTPError is a generic error type for HTTP errors.
 type HTTPError struct {
 	Code    int


### PR DESCRIPTION
### What does this PR do?

When `SecurityGroupCreate` or `IPSetCreate` partially succeeds (resource created on Proxmox but error returned to the client), the provider doesn't save state because `d.SetId()` is called too late. On the next `apply`, Terraform tries to create again and gets "already exists", leaving an orphaned resource. This PR adds an `ErrResourceAlreadyExists` sentinel error to the API layer (matching the existing `ErrResourceDoesNotExist` pattern) and uses it to adopt pre-existing resources into state. It also moves `d.SetId()` earlier so partial failures (e.g. rule/CIDR additions) still track the created resource.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

```
$ ./testacc TestAccResourceClusterFirewallSecurityGroupCreateAlreadyExists -- -v
=== RUN   TestAccResourceClusterFirewallSecurityGroupCreateAlreadyExists
--- PASS: TestAccResourceClusterFirewallSecurityGroupCreateAlreadyExists (0.98s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	1.561s

$ ./testacc TestAccResourceFirewallIPSetCreateAlreadyExists -- -v
=== RUN   TestAccResourceFirewallIPSetCreateAlreadyExists
--- PASS: TestAccResourceFirewallIPSetCreateAlreadyExists (0.77s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	1.235s
```

### Community Note

- Please vote on this pull request by adding a :+1: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2622
