### PR TITLE
chore(docs): update os type `l26` linux kernel range for vm

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -510,7 +510,7 @@ output "ubuntu_vm_public_key" {
 - `operating_system` - (Optional) The Operating System configuration.
     - `type` - (Optional) The type (defaults to `other`).
         - `l24` - Linux Kernel 2.4.
-        - `l26` - Linux Kernel 2.6 - 5.X.
+        - `l26` - Linux Kernel 2.6 - 6.X.
         - `other` - Unspecified OS.
         - `solaris` - OpenIndiania, OpenSolaris og Solaris Kernel.
         - `w2k` - Windows 2000.


### PR DESCRIPTION
### What does this PR do?

Updates `docs/resources/virtual_environment_vm.md` for OS type `l26` which support Linux Kernel 2.6 up 6.X.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request