### PR TITLE
fix(provider): preserve null `tos` in ACME account when API returns empty string

### DIFF
--- a/fwprovider/cluster/acme/resource_acme_account.go
+++ b/fwprovider/cluster/acme/resource_acme_account.go
@@ -335,8 +335,12 @@ func (r *acmeAccountResource) read(ctx context.Context, data *acmeAccountModel) 
 	}
 
 	data.Directory = types.StringValue(acc.Directory)
-	data.TOS = types.StringValue(acc.TOS)
 	data.Location = types.StringValue(acc.Location)
+
+	if acc.TOS != "" {
+		data.TOS = types.StringValue(acc.TOS)
+	}
+
 	data.Contact = types.StringValue(contact)
 	data.CreatedAt = types.StringValue(acc.Account.CreatedAt)
 


### PR DESCRIPTION
### What does this PR do?

Fixes "inconsistent result after apply" error when creating an ACME account without the `tos` attribute (e.g. with a self-hosted step-ca that has no Terms of Service).

The `read` function unconditionally set `data.TOS = types.StringValue(acc.TOS)`, which changed a null plan value to `""` when the API returned an empty string. Since `tos` is `Optional`-only (not `Computed`), Terraform rejected this as inconsistent. The fix only sets `data.TOS` when the API returns a non-empty value, preserving null otherwise.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

> **Note on acceptance tests:** The bug only reproduces with a self-hosted ACME CA (e.g. step-ca) that returns an empty `tos` field. Let's Encrypt requires ToS acceptance, so the without-tos scenario cannot be tested against LE staging. The existing acceptance test (`TestAccResourceACMEAccount/basic_account_creation`) passes and confirms no regression for the standard flow.

### Proof of Work

```
$ ./testacc --no-proxy "TestAccResourceACMEAccount/basic_account_creation" -- -v

=== RUN   TestAccResourceACMEAccount
=== PAUSE TestAccResourceACMEAccount
=== CONT  TestAccResourceACMEAccount
=== RUN   TestAccResourceACMEAccount/basic_account_creation
--- PASS: TestAccResourceACMEAccount (5.95s)
    --- PASS: TestAccResourceACMEAccount/basic_account_creation (5.95s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/acme	6.893s
```

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2265
