### PR TITLE
fix(vm): support removal of network devices from VM configuration

### DIFF
--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -1175,10 +1175,14 @@ func TestAccResourceVMNetwork(t *testing.T) {
 				),
 			},
 			{
+				// Use network_device = [] to explicitly remove all devices.
+				// With ConfigMode: schema.SchemaConfigModeAttr, this distinguishes
+				// "remove all" from "not specified" (which preserves inherited/existing).
 				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
-					node_name = "{{.NodeName}}"
-					started   = false
+					node_name      = "{{.NodeName}}"
+					started        = false
+					network_device = []
 				}`),
 				Check: resource.ComposeTestCheckFunc(
 					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
@@ -1232,10 +1236,12 @@ func TestAccResourceVMNetwork(t *testing.T) {
 				),
 			},
 			{
+				// Use network_device = [] to explicitly remove all remaining devices.
 				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
-					node_name = "{{.NodeName}}"
-					started   = false
+					node_name      = "{{.NodeName}}"
+					started        = false
+					network_device = []
 				}`),
 				Check: resource.ComposeTestCheckFunc(
 					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
@@ -1268,8 +1274,9 @@ func TestAccResourceVMNetwork(t *testing.T) {
 				// This step tests that the state is read correctly after network device removal
 				Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "test_vm" {
-					node_name = "{{.NodeName}}"
-					started   = false
+					node_name      = "{{.NodeName}}"
+					started        = false
+					network_device = []
 				}`),
 				Check: resource.ComposeTestCheckFunc(
 					ResourceAttributes("proxmox_virtual_environment_vm.test_vm", map[string]string{
@@ -1324,10 +1331,6 @@ func TestAccResourceVMClone(t *testing.T) {
 		step []resource.TestStep
 	}{
 		{"clone with network device", []resource.TestStep{{
-			// When cloning a VM with network devices but not specifying any network_device
-			// blocks on the clone, the inherited devices are invisible to Terraform state
-			// (same behavior as disks). This preserves backward compatibility: Terraform
-			// won't try to remove inherited devices the user didn't explicitly declare.
 			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "template" {
 					node_name = "{{.NodeName}}"
@@ -1346,7 +1349,8 @@ func TestAccResourceVMClone(t *testing.T) {
 				}`),
 			Check: resource.ComposeTestCheckFunc(
 				ResourceAttributes("proxmox_virtual_environment_vm.clone", map[string]string{
-					"network_device.#": "0",
+					"network_device.#":        "1",
+					"network_device.0.bridge": "vmbr0",
 				}),
 			),
 		}}},
@@ -1408,8 +1412,6 @@ func TestAccResourceVMClone(t *testing.T) {
 			),
 		}}},
 		{"clone with network devices", []resource.TestStep{{
-			// Same as "clone with network device" — inherited devices are not visible
-			// in state when the clone doesn't declare any network_device blocks.
 			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "template" {
 					node_name = "{{.NodeName}}"
@@ -1427,7 +1429,8 @@ func TestAccResourceVMClone(t *testing.T) {
 				}`),
 			Check: resource.ComposeTestCheckFunc(
 				ResourceAttributes("proxmox_virtual_environment_vm.clone", map[string]string{
-					"network_device.#": "0",
+					"network_device.#":        "1",
+					"network_device.0.bridge": "vmbr0",
 				}),
 			),
 		}}},

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -546,9 +546,6 @@ func Read(
 		diskMap[di] = disk
 	}
 
-	// For clones with no user-specified disks, skip setting state to preserve inherited
-	// devices. Without this guard, Terraform would see the inherited disks as drift and
-	// plan to remove them on the next apply. The same pattern is used for network devices.
 	if !isClone || len(currentDiskList) > 0 {
 		var diskList []any
 

--- a/proxmoxtf/resource/vm/network/network.go
+++ b/proxmoxtf/resource/vm/network/network.go
@@ -157,10 +157,8 @@ func ExistingNetworkDeviceIndices(vmConfig *vms.GetResponseData) map[string]stru
 }
 
 // ReadNetworkDeviceObjects reads the network device objects from the response data.
-func ReadNetworkDeviceObjects(d *schema.ResourceData, vmConfig *vms.GetResponseData, isClone bool) diag.Diagnostics {
+func ReadNetworkDeviceObjects(d *schema.ResourceData, vmConfig *vms.GetResponseData) diag.Diagnostics {
 	var diags diag.Diagnostics
-
-	currentNetworkDeviceList := d.Get(MkNetworkDevice).([]any)
 
 	macAddresses := make([]any, 0)
 	networkDevices := make([]any, 0)
@@ -200,15 +198,10 @@ func ReadNetworkDeviceObjects(d *schema.ResourceData, vmConfig *vms.GetResponseD
 		}
 	}
 
-	// For clones with no user-specified network devices, skip setting state to preserve
-	// inherited devices (same pattern as disk.Read). Otherwise Terraform would detect
-	// a diff and try to remove the inherited devices on the next plan.
-	if !isClone || len(currentNetworkDeviceList) > 0 {
-		err := d.Set(MkNetworkDevice, networkDevices)
-		diags = append(diags, diag.FromErr(err)...)
-	}
+	err := d.Set(MkNetworkDevice, networkDevices)
+	diags = append(diags, diag.FromErr(err)...)
 
-	err := d.Set(mkMACAddresses, macAddresses)
+	err = d.Set(mkMACAddresses, macAddresses)
 	diags = append(diags, diag.FromErr(err)...)
 
 	return diags

--- a/proxmoxtf/resource/vm/network/schema.go
+++ b/proxmoxtf/resource/vm/network/schema.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -75,6 +76,8 @@ func Schema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Description: "The network devices",
 			Optional:    true,
+			Computed:    true,
+			ConfigMode:  schema.SchemaConfigModeAttr,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					mkNetworkDeviceBridge: {
@@ -167,6 +170,7 @@ func Schema() map[string]*schema.Schema {
 // CustomizeDiff returns the custom diff functions for the network resource.
 func CustomizeDiff() []schema.CustomizeDiffFunc {
 	return []schema.CustomizeDiffFunc{
+		forceEmptyNetworkDeviceDiff,
 		customdiff.ComputedIf(
 			mkIPv4Addresses,
 			func(_ context.Context, d *schema.ResourceDiff, _ any) bool {
@@ -189,4 +193,28 @@ func CustomizeDiff() []schema.CustomizeDiffFunc {
 			},
 		),
 	}
+}
+
+// forceEmptyNetworkDeviceDiff forces a diff when the user explicitly sets network_device = []
+// to remove all devices. With ConfigMode: schema.SchemaConfigModeAttr, the raw config
+// distinguishes null (unset → inherit/compute) from empty list (explicit removal).
+func forceEmptyNetworkDeviceDiff(_ context.Context, d *schema.ResourceDiff, _ any) error {
+	rawConfig := d.GetRawConfig()
+	networkDeviceConfig := rawConfig.GetAttr(MkNetworkDevice)
+
+	// If the config is null, the user didn't specify network_device at all → no action needed.
+	// Computed will fill in inherited/existing devices from state.
+	if networkDeviceConfig.IsNull() {
+		return nil
+	}
+
+	// If the config is an explicit empty list, the user wants zero devices.
+	// Force the planned value to empty so Terraform detects a diff.
+	if networkDeviceConfig.IsKnown() && networkDeviceConfig.LengthInt() == 0 {
+		if err := d.SetNew(MkNetworkDevice, []any{}); err != nil {
+			return fmt.Errorf("error forcing empty network_device diff: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -4939,7 +4939,7 @@ func vmReadCustom(
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	diags = append(diags, network.ReadNetworkDeviceObjects(d, vmConfig, len(clone) > 0)...)
+	diags = append(diags, network.ReadNetworkDeviceObjects(d, vmConfig)...)
 
 	// Compare the operating system configuration to the one stored in the state.
 	operatingSystem := map[string]any{}


### PR DESCRIPTION
### What does this PR do?

Fixes #2259 — removing network device blocks from a VM configuration now correctly removes the devices from Proxmox.

The root cause was twofold:

1. The `network_device` attribute was `Optional+Computed` with default block config mode. When the user removed all `network_device` blocks, Terraform treated it as "not specified → let the provider compute" and `HasChange()` never fired.
2. The update logic only deleted device indices beyond the new plan count, rather than comparing the current API state against the plan to find removed devices.

This PR fixes both problems:

- **Schema:** Adds `ConfigMode: schema.SchemaConfigModeAttr` to the `network_device` attribute while keeping `Computed: true`. This enables Terraform to distinguish between null (attribute not mentioned → inherit/compute) and an explicit empty list (`network_device = []` → remove all devices). Existing block syntax (`network_device { ... }`) continues to work unchanged.
- **CustomizeDiff:** Adds `forceEmptyNetworkDeviceDiff` that detects when the raw config explicitly sets `network_device = []` and forces a diff so the update logic runs.
- **Update:** Compares the current API state against the plan — devices present on the VM but absent from the plan are sent to the Proxmox API via the `delete` parameter (e.g. `delete=net1,net2`).
- **Read:** Always writes inherited devices to state (no clone guard needed). Cloned VMs show their inherited network devices in Terraform state, matching the basic premise of cloning.

**User-facing change:** To remove ALL network devices from a VM, use `network_device = []`. Simply removing all `network_device` blocks preserves existing devices (same behavior as before this fix — this was never working). Partial removal (e.g. 2 → 1 devices) continues to work with normal block syntax.

> **Note:** This is not a breaking change. On `main`, removing all `network_device` blocks already had no effect (the bug). This fix preserves that behavior and adds `network_device = []` as the explicit removal mechanism. The `ConfigModeAttr` change may affect JSON configuration syntax (CDKTF); HCL users are unaffected.

The 3 network device removal test cases from PR #2260 (previously skipped due to backward incompatibility) are now enabled and passing. Clone tests verify that inherited devices remain visible in state.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

**Network device removal tests** (previously skipped, now enabled):

```
$ ./testacc TestAccResourceVMNetwork

ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	74.957s
```

**Clone tests** (verifying inherited devices remain visible in state):

```
$ ./testacc TestAccResourceVMClone

ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	7.703s
```

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2259
