### PR TITLE
chore(vm): deprecate 'enabled' attribute on 'network_device' block

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -487,7 +487,7 @@ output "ubuntu_vm_public_key" {
 - `network_device` - (Optional) A network device (multiple blocks supported).
     - `bridge` - (Optional) The name of the network bridge (defaults to `vmbr0`).
     - `disconnected` - (Optional) Whether to disconnect the network device from the network (defaults to `false`).
-    - `enabled` - (Optional) Whether to enable the network device (defaults to `true`).
+    - `enabled` - (Optional, **Deprecated**) Whether to enable the network device (defaults to `true`). Remove the `network_device` block from your configuration instead of setting `enabled = false`.
     - `firewall` - (Optional) Whether this interface's firewall rules should be used (defaults to `false`).
     - `mac_address` - (Optional) The MAC address.
     - `model` - (Optional) The network device model (defaults to `virtio`).

--- a/proxmoxtf/resource/vm/network/schema.go
+++ b/proxmoxtf/resource/vm/network/schema.go
@@ -96,6 +96,8 @@ func Schema() map[string]*schema.Schema {
 						Description: "Whether to enable the network device",
 						Optional:    true,
 						Default:     dvNetworkDeviceEnabled,
+						Deprecated: "The `enabled` attribute is deprecated and will be removed in a future release. " +
+							"Remove the `network_device` block from your configuration instead of setting `enabled = false`.",
 					},
 					mkNetworkDeviceFirewall: {
 						Type:        schema.TypeBool,


### PR DESCRIPTION
### What does this PR do?

Marks the `enabled` attribute on the `network_device` block as deprecated in the SDK provider schema and docs. Since #2259, network device removal works by removing the `network_device` block from the configuration, making `enabled = false` redundant. This adds a deprecation warning guiding users to remove the block instead of setting `enabled = false`. No behavior change — existing configurations continue to work.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

Schema-only deprecation — no behaviour change. Existing unit tests pass, lint is clean.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

Closes #2673
