### PR TITLE
fix(vm): replace enumerated network and IP config fields with dynamic unmarshaling

### DIFF
--- a/fwprovider/nodes/clonedvm/resource.go
+++ b/fwprovider/nodes/clonedvm/resource.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -976,27 +975,7 @@ func readDiskSlot(config *vms.GetResponseData, slot string, current DiskModel) D
 }
 
 func networkDeviceBySlot(config *vms.GetResponseData, slot string) *vms.CustomNetworkDevice {
-	idx, ok := slotIndex(slot, "net")
-	if !ok {
-		return nil
-	}
-
-	val := reflect.ValueOf(config)
-	if val.Kind() == reflect.Pointer {
-		val = val.Elem()
-	}
-
-	field := val.FieldByName(fmt.Sprintf("NetworkDevice%d", idx))
-	if !field.IsValid() || field.IsNil() {
-		return nil
-	}
-
-	device, ok := field.Interface().(*vms.CustomNetworkDevice)
-	if !ok {
-		return nil
-	}
-
-	return device
+	return config.NetworkDevices[slot]
 }
 
 func slotIndex(slot string, prefix string) (int, bool) {

--- a/fwprovider/nodes/clonedvm/resource_test.go
+++ b/fwprovider/nodes/clonedvm/resource_test.go
@@ -11,7 +11,6 @@ package clonedvm_test
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -670,22 +669,7 @@ func checkNetworkSlot(te *test.Environment, resourceName, slot string, expected 
 }
 
 func networkSlotPresent(config *vms.GetResponseData, slot string) bool {
-	idx, ok := slotIndex(slot, "net")
-	if !ok {
-		return false
-	}
-
-	val := reflect.ValueOf(config)
-	if val.Kind() == reflect.Pointer {
-		val = val.Elem()
-	}
-
-	field := val.FieldByName(fmt.Sprintf("NetworkDevice%d", idx))
-	if !field.IsValid() || field.IsNil() {
-		return false
-	}
-
-	return true
+	return config.NetworkDevices[slot] != nil
 }
 
 func checkMemoryConfig(

--- a/proxmox/nodes/vms/custom_cloud_init.go
+++ b/proxmox/nodes/vms/custom_cloud_init.go
@@ -43,6 +43,9 @@ type CustomCloudInitIPConfig struct {
 	IPv6        *string `json:"ip6,omitempty" url:"ip6,omitempty"`
 }
 
+// CustomCloudInitIPConfigMap is a map of CustomCloudInitIPConfig per IP config key (e.g. "ipconfig0").
+type CustomCloudInitIPConfigMap map[string]*CustomCloudInitIPConfig
+
 // CustomCloudInitSSHKeys handles QEMU cloud-init SSH keys parameters.
 type CustomCloudInitSSHKeys []string
 

--- a/proxmox/nodes/vms/custom_network_device.go
+++ b/proxmox/nodes/vms/custom_network_device.go
@@ -35,6 +35,9 @@ type CustomNetworkDevice struct {
 // CustomNetworkDevices handles QEMU network device parameters.
 type CustomNetworkDevices []CustomNetworkDevice
 
+// CustomNetworkDeviceMap is a map of CustomNetworkDevice per network device key (e.g. "net0").
+type CustomNetworkDeviceMap map[string]*CustomNetworkDevice
+
 // EncodeValues converts a CustomNetworkDevice struct to a URL value.
 func (r *CustomNetworkDevice) EncodeValues(key string, v *url.Values) error {
 	values := []string{

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -27,6 +27,10 @@ var (
 	regexPCIDevice = regexp.MustCompile(`^hostpci\d+$`)
 	// regexVirtiofsShare is a regex pattern for matching virtiofs share names.
 	regexVirtiofsShare = regexp.MustCompile(`^virtiofs\d+$`)
+	// regexNetworkDevice is a regex pattern for matching network device names.
+	regexNetworkDevice = regexp.MustCompile(`^net\d+$`)
+	// regexIPConfig is a regex pattern for matching cloud-init IP config names.
+	regexIPConfig = regexp.MustCompile(`^ipconfig\d+$`)
 )
 
 // WaitForIPConfig specifies which IP address types to wait for when waiting for network interfaces.
@@ -229,38 +233,7 @@ type GetResponseData struct {
 	HookScript           *string                         `json:"hookscript,omitempty"`
 	Hotplug              *types.CustomCommaSeparatedList `json:"hotplug,omitempty"`
 	Hugepages            *string                         `json:"hugepages,omitempty"`
-	IPConfig0            *CustomCloudInitIPConfig        `json:"ipconfig0,omitempty"`
-	IPConfig1            *CustomCloudInitIPConfig        `json:"ipconfig1,omitempty"`
-	IPConfig2            *CustomCloudInitIPConfig        `json:"ipconfig2,omitempty"`
-	IPConfig3            *CustomCloudInitIPConfig        `json:"ipconfig3,omitempty"`
-	IPConfig4            *CustomCloudInitIPConfig        `json:"ipconfig4,omitempty"`
-	IPConfig5            *CustomCloudInitIPConfig        `json:"ipconfig5,omitempty"`
-	IPConfig6            *CustomCloudInitIPConfig        `json:"ipconfig6,omitempty"`
-	IPConfig7            *CustomCloudInitIPConfig        `json:"ipconfig7,omitempty"`
-	IPConfig8            *CustomCloudInitIPConfig        `json:"ipconfig8,omitempty"`
-	IPConfig9            *CustomCloudInitIPConfig        `json:"ipconfig9,omitempty"`
-	IPConfig10           *CustomCloudInitIPConfig        `json:"ipconfig10,omitempty"`
-	IPConfig11           *CustomCloudInitIPConfig        `json:"ipconfig11,omitempty"`
-	IPConfig12           *CustomCloudInitIPConfig        `json:"ipconfig12,omitempty"`
-	IPConfig13           *CustomCloudInitIPConfig        `json:"ipconfig13,omitempty"`
-	IPConfig14           *CustomCloudInitIPConfig        `json:"ipconfig14,omitempty"`
-	IPConfig15           *CustomCloudInitIPConfig        `json:"ipconfig15,omitempty"`
-	IPConfig16           *CustomCloudInitIPConfig        `json:"ipconfig16,omitempty"`
-	IPConfig17           *CustomCloudInitIPConfig        `json:"ipconfig17,omitempty"`
-	IPConfig18           *CustomCloudInitIPConfig        `json:"ipconfig18,omitempty"`
-	IPConfig19           *CustomCloudInitIPConfig        `json:"ipconfig19,omitempty"`
-	IPConfig20           *CustomCloudInitIPConfig        `json:"ipconfig20,omitempty"`
-	IPConfig21           *CustomCloudInitIPConfig        `json:"ipconfig21,omitempty"`
-	IPConfig22           *CustomCloudInitIPConfig        `json:"ipconfig22,omitempty"`
-	IPConfig23           *CustomCloudInitIPConfig        `json:"ipconfig23,omitempty"`
-	IPConfig24           *CustomCloudInitIPConfig        `json:"ipconfig24,omitempty"`
-	IPConfig25           *CustomCloudInitIPConfig        `json:"ipconfig25,omitempty"`
-	IPConfig26           *CustomCloudInitIPConfig        `json:"ipconfig26,omitempty"`
-	IPConfig27           *CustomCloudInitIPConfig        `json:"ipconfig27,omitempty"`
-	IPConfig28           *CustomCloudInitIPConfig        `json:"ipconfig28,omitempty"`
-	IPConfig29           *CustomCloudInitIPConfig        `json:"ipconfig29,omitempty"`
-	IPConfig30           *CustomCloudInitIPConfig        `json:"ipconfig30,omitempty"`
-	IPConfig31           *CustomCloudInitIPConfig        `json:"ipconfig31,omitempty"`
+	IPConfigs            CustomCloudInitIPConfigMap      `json:"-"`
 	KeepHugepages        *types.CustomBool               `json:"keephugepages,omitempty"`
 	KeyboardLayout       *string                         `json:"keyboard,omitempty"`
 	KVMArguments         *string                         `json:"args,omitempty"`
@@ -271,38 +244,7 @@ type GetResponseData struct {
 	MigrateDowntime      *float64                        `json:"migrate_downtime,omitempty"`
 	MigrateSpeed         *int                            `json:"migrate_speed,omitempty"`
 	Name                 *string                         `json:"name,omitempty"`
-	NetworkDevice0       *CustomNetworkDevice            `json:"net0,omitempty"`
-	NetworkDevice1       *CustomNetworkDevice            `json:"net1,omitempty"`
-	NetworkDevice2       *CustomNetworkDevice            `json:"net2,omitempty"`
-	NetworkDevice3       *CustomNetworkDevice            `json:"net3,omitempty"`
-	NetworkDevice4       *CustomNetworkDevice            `json:"net4,omitempty"`
-	NetworkDevice5       *CustomNetworkDevice            `json:"net5,omitempty"`
-	NetworkDevice6       *CustomNetworkDevice            `json:"net6,omitempty"`
-	NetworkDevice7       *CustomNetworkDevice            `json:"net7,omitempty"`
-	NetworkDevice8       *CustomNetworkDevice            `json:"net8,omitempty"`
-	NetworkDevice9       *CustomNetworkDevice            `json:"net9,omitempty"`
-	NetworkDevice10      *CustomNetworkDevice            `json:"net10,omitempty"`
-	NetworkDevice11      *CustomNetworkDevice            `json:"net11,omitempty"`
-	NetworkDevice12      *CustomNetworkDevice            `json:"net12,omitempty"`
-	NetworkDevice13      *CustomNetworkDevice            `json:"net13,omitempty"`
-	NetworkDevice14      *CustomNetworkDevice            `json:"net14,omitempty"`
-	NetworkDevice15      *CustomNetworkDevice            `json:"net15,omitempty"`
-	NetworkDevice16      *CustomNetworkDevice            `json:"net16,omitempty"`
-	NetworkDevice17      *CustomNetworkDevice            `json:"net17,omitempty"`
-	NetworkDevice18      *CustomNetworkDevice            `json:"net18,omitempty"`
-	NetworkDevice19      *CustomNetworkDevice            `json:"net19,omitempty"`
-	NetworkDevice20      *CustomNetworkDevice            `json:"net20,omitempty"`
-	NetworkDevice21      *CustomNetworkDevice            `json:"net21,omitempty"`
-	NetworkDevice22      *CustomNetworkDevice            `json:"net22,omitempty"`
-	NetworkDevice23      *CustomNetworkDevice            `json:"net23,omitempty"`
-	NetworkDevice24      *CustomNetworkDevice            `json:"net24,omitempty"`
-	NetworkDevice25      *CustomNetworkDevice            `json:"net25,omitempty"`
-	NetworkDevice26      *CustomNetworkDevice            `json:"net26,omitempty"`
-	NetworkDevice27      *CustomNetworkDevice            `json:"net27,omitempty"`
-	NetworkDevice28      *CustomNetworkDevice            `json:"net28,omitempty"`
-	NetworkDevice29      *CustomNetworkDevice            `json:"net29,omitempty"`
-	NetworkDevice30      *CustomNetworkDevice            `json:"net30,omitempty"`
-	NetworkDevice31      *CustomNetworkDevice            `json:"net31,omitempty"`
+	NetworkDevices       CustomNetworkDeviceMap          `json:"-"`
 	NUMAEnabled          *types.CustomBool               `json:"numa,omitempty"`
 	NUMADevices0         *CustomNUMADevice               `json:"numa0,omitempty"`
 	NUMADevices1         *CustomNUMADevice               `json:"numa1,omitempty"`
@@ -496,6 +438,8 @@ func (d *GetResponseData) UnmarshalJSON(b []byte) error {
 	data.StorageDevices = make(CustomStorageDevices)
 	data.PCIDevices = make(CustomPCIDevices)
 	data.VirtiofsShares = make(CustomVirtiofsShares)
+	data.NetworkDevices = make(CustomNetworkDeviceMap)
+	data.IPConfigs = make(CustomCloudInitIPConfigMap)
 
 	for key, value := range byAttr {
 		for _, prefix := range StorageInterfaces {
@@ -527,6 +471,24 @@ func (d *GetResponseData) UnmarshalJSON(b []byte) error {
 			}
 
 			data.VirtiofsShares[key] = &share
+		}
+
+		if regexNetworkDevice.MatchString(key) {
+			var device CustomNetworkDevice
+			if err := json.Unmarshal([]byte(`"`+value.(string)+`"`), &device); err != nil {
+				return fmt.Errorf("failed to unmarshal %s: %w", key, err)
+			}
+
+			data.NetworkDevices[key] = &device
+		}
+
+		if regexIPConfig.MatchString(key) {
+			var ipConfig CustomCloudInitIPConfig
+			if err := json.Unmarshal([]byte(`"`+value.(string)+`"`), &ipConfig); err != nil {
+				return fmt.Errorf("failed to unmarshal %s: %w", key, err)
+			}
+
+			data.IPConfigs[key] = &ipConfig
 		}
 	}
 

--- a/proxmox/nodes/vms/vms_types_test.go
+++ b/proxmox/nodes/vms/vms_types_test.go
@@ -29,7 +29,11 @@ func TestUnmarshalGetResponseData(t *testing.T) {
 		"hostpci0": "0000:81:00.2",
 		"hostpci1": "host=81:00.4,pcie=0,rombar=1,x-vga=0",
 		"hostpci12": "mapping=mappeddevice,pcie=0,rombar=1,x-vga=0",
-		"virtiofs0":"test,cache=always,direct-io=1,expose-acl=1"
+		"virtiofs0":"test,cache=always,direct-io=1,expose-acl=1",
+		"net0": "model=virtio,bridge=vmbr0,firewall=1",
+		"net3": "model=e1000,bridge=vmbr1",
+		"ipconfig0": "ip=192.168.1.100/24,gw=192.168.1.1",
+		"ipconfig1": "ip6=fd00::100/64,gw6=fd00::1"
 	}`, "local-lvm:vm-100-disk-0,aio=io_uring,backup=1,cache=none,discard=ignore,replicate=1,size=8G,ssd=1")
 
 	var data GetResponseData
@@ -63,6 +67,25 @@ func TestUnmarshalGetResponseData(t *testing.T) {
 	assert.NotNil(t, data.VirtiofsShares)
 	assert.Len(t, data.VirtiofsShares, 1)
 	assert.Equal(t, "always", *data.VirtiofsShares["virtiofs0"].Cache)
+
+	assert.NotNil(t, data.NetworkDevices)
+	assert.Len(t, data.NetworkDevices, 2)
+	assert.NotNil(t, data.NetworkDevices["net0"])
+	assert.Equal(t, "virtio", data.NetworkDevices["net0"].Model)
+	assert.Equal(t, "vmbr0", *data.NetworkDevices["net0"].Bridge)
+	assert.NotNil(t, data.NetworkDevices["net3"])
+	assert.Equal(t, "e1000", data.NetworkDevices["net3"].Model)
+	assert.Equal(t, "vmbr1", *data.NetworkDevices["net3"].Bridge)
+	assert.Nil(t, data.NetworkDevices["net1"])
+
+	assert.NotNil(t, data.IPConfigs)
+	assert.Len(t, data.IPConfigs, 2)
+	assert.NotNil(t, data.IPConfigs["ipconfig0"])
+	assert.Equal(t, "192.168.1.100/24", *data.IPConfigs["ipconfig0"].IPv4)
+	assert.Equal(t, "192.168.1.1", *data.IPConfigs["ipconfig0"].GatewayIPv4)
+	assert.NotNil(t, data.IPConfigs["ipconfig1"])
+	assert.Equal(t, "fd00::100/64", *data.IPConfigs["ipconfig1"].IPv6)
+	assert.Equal(t, "fd00::1", *data.IPConfigs["ipconfig1"].GatewayIPv6)
 }
 
 func assertDevice(t *testing.T, dev *CustomStorageDevice) {

--- a/proxmoxtf/resource/vm/network/network.go
+++ b/proxmoxtf/resource/vm/network/network.go
@@ -105,52 +105,26 @@ func valueOrDefault[T any](v *T, def T) T {
 	return *v
 }
 
-// getNetworkDeviceObjects extracts the ordered list of network device pointers from the API response.
+// getNetworkDeviceObjects builds an ordered slice of network device pointers from the API response map.
 func getNetworkDeviceObjects(vmConfig *vms.GetResponseData) []*vms.CustomNetworkDevice {
-	return []*vms.CustomNetworkDevice{
-		vmConfig.NetworkDevice0,
-		vmConfig.NetworkDevice1,
-		vmConfig.NetworkDevice2,
-		vmConfig.NetworkDevice3,
-		vmConfig.NetworkDevice4,
-		vmConfig.NetworkDevice5,
-		vmConfig.NetworkDevice6,
-		vmConfig.NetworkDevice7,
-		vmConfig.NetworkDevice8,
-		vmConfig.NetworkDevice9,
-		vmConfig.NetworkDevice10,
-		vmConfig.NetworkDevice11,
-		vmConfig.NetworkDevice12,
-		vmConfig.NetworkDevice13,
-		vmConfig.NetworkDevice14,
-		vmConfig.NetworkDevice15,
-		vmConfig.NetworkDevice16,
-		vmConfig.NetworkDevice17,
-		vmConfig.NetworkDevice18,
-		vmConfig.NetworkDevice19,
-		vmConfig.NetworkDevice20,
-		vmConfig.NetworkDevice21,
-		vmConfig.NetworkDevice22,
-		vmConfig.NetworkDevice23,
-		vmConfig.NetworkDevice24,
-		vmConfig.NetworkDevice25,
-		vmConfig.NetworkDevice26,
-		vmConfig.NetworkDevice27,
-		vmConfig.NetworkDevice28,
-		vmConfig.NetworkDevice29,
-		vmConfig.NetworkDevice30,
-		vmConfig.NetworkDevice31,
+	result := make([]*vms.CustomNetworkDevice, MaxNetworkDevices)
+
+	for key, device := range vmConfig.NetworkDevices {
+		var idx int
+		if _, err := fmt.Sscanf(key, "net%d", &idx); err == nil && idx >= 0 && idx < MaxNetworkDevices {
+			result[idx] = device
+		}
 	}
+
+	return result
 }
 
 // ExistingNetworkDeviceIndices returns the set of "net<i>" keys that currently exist on the VM.
 func ExistingNetworkDeviceIndices(vmConfig *vms.GetResponseData) map[string]struct{} {
-	result := make(map[string]struct{})
+	result := make(map[string]struct{}, len(vmConfig.NetworkDevices))
 
-	for i, nd := range getNetworkDeviceObjects(vmConfig) {
-		if nd != nil {
-			result[fmt.Sprintf("net%d", i)] = struct{}{}
-		}
+	for key := range vmConfig.NetworkDevices {
+		result[key] = struct{}{}
 	}
 
 	return result

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -4676,40 +4676,15 @@ func vmReadCustom(
 	}
 
 	ipConfigLast := -1
-	ipConfigObjects := []*vms.CustomCloudInitIPConfig{
-		vmConfig.IPConfig0,
-		vmConfig.IPConfig1,
-		vmConfig.IPConfig2,
-		vmConfig.IPConfig3,
-		vmConfig.IPConfig4,
-		vmConfig.IPConfig5,
-		vmConfig.IPConfig6,
-		vmConfig.IPConfig7,
-		vmConfig.IPConfig8,
-		vmConfig.IPConfig9,
-		vmConfig.IPConfig10,
-		vmConfig.IPConfig11,
-		vmConfig.IPConfig12,
-		vmConfig.IPConfig13,
-		vmConfig.IPConfig14,
-		vmConfig.IPConfig15,
-		vmConfig.IPConfig16,
-		vmConfig.IPConfig17,
-		vmConfig.IPConfig18,
-		vmConfig.IPConfig19,
-		vmConfig.IPConfig20,
-		vmConfig.IPConfig21,
-		vmConfig.IPConfig22,
-		vmConfig.IPConfig23,
-		vmConfig.IPConfig24,
-		vmConfig.IPConfig25,
-		vmConfig.IPConfig26,
-		vmConfig.IPConfig27,
-		vmConfig.IPConfig28,
-		vmConfig.IPConfig29,
-		vmConfig.IPConfig30,
-		vmConfig.IPConfig31,
+	ipConfigObjects := make([]*vms.CustomCloudInitIPConfig, network.MaxNetworkDevices)
+
+	for key, ipConfig := range vmConfig.IPConfigs {
+		var idx int
+		if _, err := fmt.Sscanf(key, "ipconfig%d", &idx); err == nil && idx >= 0 && idx < network.MaxNetworkDevices {
+			ipConfigObjects[idx] = ipConfig
+		}
 	}
+
 	ipConfigList := make([]any, len(ipConfigObjects))
 
 	for ipConfigIndex, ipConfig := range ipConfigObjects {


### PR DESCRIPTION
### What does this PR do?

Replaces 64 individually enumerated `NetworkDevice0`–`NetworkDevice31` and `IPConfig0`–`IPConfig31` struct fields in `GetResponseData` with map-based dynamic unmarshaling — the same proven pattern already used for `StorageDevices`, `PCIDevices`, and `VirtiofsShares`.

This eliminates 64 lines of boilerplate fields and the manual bridging functions (`getNetworkDeviceObjects()`, inline `ipConfigObjects` slice) that converted them into slices. It also removes reflection-based field access in the Framework provider's cloned VM resource.

Pure internal refactoring — no user-facing changes to the Terraform schema or provider behavior.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

**Unit tests** (`make test`): all pass, including new assertions for `NetworkDevices` and `IPConfigs` in `TestUnmarshalGetResponseData`.

**Acceptance tests** — three suites covering all consumer paths:

```
$ ./testacc TestAccResourceVMNetwork -- -v
--- PASS: TestAccResourceVMNetwork (11.41s)
    --- PASS: TestAccResourceVMNetwork/remove_network_device (3.31s)
    --- PASS: TestAccResourceVMNetwork/multiple_network_devices_removal (3.95s)
    --- PASS: TestAccResourceVMNetwork/network_device_state_consistency (3.95s)
    --- PASS: TestAccResourceVMNetwork/network_device_disconnected (4.33s)
    --- PASS: TestAccResourceVMNetwork/network_interfaces (39.30s)
    --- PASS: TestAccResourceVMNetwork/wait_for_IPv4_address (39.89s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	51.841s
```

```
$ ./testacc TestAccResourceVMInitialization
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	86.252s
```

```
$ ./testacc TestAccResourceClonedVM
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/clonedvm	180.174s
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

Closes #2676
