### PR TITLE
fix(access): remove overly restrictive `username_claim` validation on openid realm

### DIFF
--- a/docs/resources/virtual_environment_realm_openid.md
+++ b/docs/resources/virtual_environment_realm_openid.md
@@ -70,7 +70,7 @@ resource "proxmox_virtual_environment_realm_openid" "example" {
 - `prompt` (String) Specifies whether the authorization server prompts for reauthentication and/or consent (e.g., 'none', 'login', 'consent', 'select_account').
 - `query_userinfo` (Boolean) Query the OpenID userinfo endpoint for claims. Required when the identity provider does not include claims in the ID token.
 - `scopes` (String) Space-separated list of OpenID scopes to request.
-- `username_claim` (String) OpenID claim used to generate the unique username (subject, username, or email).
+- `username_claim` (String) OpenID claim used to generate the unique username. Common values are `subject`, `username`, `email`, and `upn`.
 
 ### Read-Only
 
@@ -100,13 +100,14 @@ The `client_key` is sent to Proxmox and stored securely, but it's never returned
 
 ### Username Claim
 
-The `username_claim` attribute is **fixed after creation** — it cannot be changed once the realm is created. Changing it requires destroying and recreating the realm. Valid values:
+The `username_claim` attribute is **fixed after creation** — it cannot be changed once the realm is created. Changing it requires destroying and recreating the realm. Common values:
 
 - `subject` (default) — Uses the OpenID `sub` claim
 - `username` — Uses the `preferred_username` claim
 - `email` — Uses the `email` claim
+- `upn` — Uses the User Principal Name claim (common with ADFS/Azure AD)
 
-Ensure the chosen claim provides unique, stable identifiers for your users.
+Any valid OpenID claim name can be used. Ensure the chosen claim provides unique, stable identifiers for your users.
 
 ### Common Configuration Scenarios
 

--- a/fwprovider/access/model_realm_openid.go
+++ b/fwprovider/access/model_realm_openid.go
@@ -175,11 +175,7 @@ func (m *realmOpenIDModel) fromAPIResponse(data *access.RealmGetResponseData, di
 	m.ACRValues = types.StringPointerValue(data.ACRValues)
 	m.Comment = types.StringPointerValue(data.Comment)
 
-	// Scopes is Computed; guard against nil to prevent perpetual drift
-	// if PVE omits it from the response.
-	if data.Scopes != nil {
-		m.Scopes = types.StringPointerValue(data.Scopes)
-	}
+	m.Scopes = types.StringPointerValue(data.Scopes)
 
 	// Set optional boolean fields
 	m.AutoCreate = types.BoolPointerValue(data.AutoCreate.PointerBool())

--- a/fwprovider/access/resource_realm_openid.go
+++ b/fwprovider/access/resource_realm_openid.go
@@ -97,11 +97,9 @@ func (r *realmOpenIDResource) Schema(
 				Computed:    true,
 			},
 			"username_claim": schema.StringAttribute{
-				Description: "OpenID claim used to generate the unique username (subject, username, or email).",
-				Optional:    true,
-				Validators: []validator.String{
-					stringvalidator.OneOf("subject", "username", "email"),
-				},
+				Description: "OpenID claim used to generate the unique username." +
+					" Common values are `subject`, `username`, `email`, and `upn`.",
+				Optional: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/fwprovider/access/resource_realm_openid_test.go
+++ b/fwprovider/access/resource_realm_openid_test.go
@@ -16,6 +16,40 @@ import (
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/test"
 )
 
+func TestAccRealmOpenIDUsernameClaim(t *testing.T) {
+	t.Parallel()
+
+	te := test.InitEnvironment(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			// Create with username_claim = "upn" (custom claim used by ADFS/Azure AD)
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_realm_openid" "test_upn" {
+						realm          = "test-upn"
+						issuer_url     = "https://accounts.google.com"
+						client_id      = "test-client-id"
+						username_claim = "upn"
+					}
+				`),
+				Check: test.ResourceAttributes("proxmox_virtual_environment_realm_openid.test_upn", map[string]string{
+					"realm":          "test-upn",
+					"username_claim": "upn",
+				}),
+			},
+			// Import state
+			{
+				ResourceName:            "proxmox_virtual_environment_realm_openid.test_upn",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_key"},
+			},
+		},
+	})
+}
+
 func TestAccRealmOpenID(t *testing.T) {
 	t.Parallel()
 

--- a/templates/resources/virtual_environment_realm_openid.md.tmpl
+++ b/templates/resources/virtual_environment_realm_openid.md.tmpl
@@ -18,6 +18,7 @@ description: |-
 | /access/domains | Realm.Allocate |
 
 {{ if .HasExample -}}
+
 ## Example Usage
 
 {{ codefile "terraform" .ExampleFile }}
@@ -47,13 +48,14 @@ The `client_key` is sent to Proxmox and stored securely, but it's never returned
 
 ### Username Claim
 
-The `username_claim` attribute is **fixed after creation** — it cannot be changed once the realm is created. Changing it requires destroying and recreating the realm. Valid values:
+The `username_claim` attribute is **fixed after creation** — it cannot be changed once the realm is created. Changing it requires destroying and recreating the realm. Common values:
 
 - `subject` (default) — Uses the OpenID `sub` claim
 - `username` — Uses the `preferred_username` claim
 - `email` — Uses the `email` claim
+- `upn` — Uses the User Principal Name claim (common with ADFS/Azure AD)
 
-Ensure the chosen claim provides unique, stable identifiers for your users.
+Any valid OpenID claim name can be used. Ensure the chosen claim provides unique, stable identifiers for your users.
 
 ### Common Configuration Scenarios
 


### PR DESCRIPTION
### What does this PR do?

The `username_claim` attribute on `proxmox_virtual_environment_realm_openid` was validated
with `stringvalidator.OneOf("subject", "username", "email")`, but the Proxmox API itself
accepts any string value for this parameter (confirmed in [PVE source](https://git.proxmox.com/?p=pve-access-control.git;a=blob;f=src/PVE/Auth/OpenId.pm)).
This caused users setting `username_claim = "upn"` (common with ADFS/Azure AD) to get a
validation error during `terraform plan`.

This PR removes the `OneOf` validator so any valid OpenID claim name can be used,
matching the upstream API behavior. It also fixes a pre-existing bug where `scopes`
returned `Unknown` after create when unset by the user.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

**Acceptance test** (`TestAccRealmOpenIDUsernameClaim` — creates realm with `username_claim = "upn"`):

```
=== RUN   TestAccRealmOpenIDUsernameClaim
=== PAUSE TestAccRealmOpenIDUsernameClaim
=== CONT  TestAccRealmOpenIDUsernameClaim
--- PASS: TestAccRealmOpenIDUsernameClaim (0.87s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/access	1.294s
```

**Mitmproxy verification** — `username-claim=upn` sent correctly and returned by API:

```
POST https://pve.../api2/json/access/domains
    username-claim: upn
 << 200 OK

GET https://pve.../api2/json/access/domains/test-upn
 << 200 OK
    "username-claim": "upn"
```

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2667
