### PR TITLE
fix(vm): reboot after disk resize when disk is not hotpluggable

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -375,7 +375,10 @@ output "ubuntu_vm_public_key" {
 - `hotplug` - (Optional) Selectively enable hotplug features. Use `0` to
     disable, `1` to enable all. Valid features: `disk`, `network`, `usb`,
     `memory`, `cpu`. Memory hotplug requires NUMA to be enabled. If not set,
-    PVE defaults to `network,disk,usb`.
+    PVE defaults to `network,disk,usb`. When `disk` is included in the
+    hotplug list, disk resizes on a running VM are applied live without a
+    reboot. When `disk` is excluded, the provider will reboot the VM after
+    resize (controlled by `reboot_after_update`).
 - `usb` - (Optional) A host USB device mapping (multiple blocks supported).
     - `host` - (Optional) The Host USB device or port or the value `spice`. Use either this or `mapping`.
     - `mapping` - (Optional) The cluster-wide resource mapping name of the device, for example "usbdevice". Use either this or `host`.
@@ -525,7 +528,12 @@ output "ubuntu_vm_public_key" {
 - `pool_id` - (Optional) The identifier for a pool to assign the virtual machine to.
 - `protection` - (Optional) Sets the protection flag of the VM. This will disable the remove VM and remove disk operations (defaults to `false`).
 - `reboot` - (Optional) Reboot the VM after initial creation (defaults to `false`).
-- `reboot_after_update` - (Optional) Reboot the VM after update if needed (defaults to `true`).
+- `reboot_after_update` - (Optional) Whether the provider is allowed to
+    reboot the VM after an update when the change requires it (defaults to
+    `true`). Reboots are triggered by changes to non-hotpluggable settings
+    (e.g. BIOS, boot order, CPU type) and by disk resizes when `disk` is
+    excluded from `hotplug`. If set to `false`, the provider emits a warning
+    instead of rebooting.
 - `rng` - (Optional) The random number generator configuration. Can only be set by `root@pam.`
     - `source` - The file on the host to gather entropy from. In most cases, `/dev/urandom` should be preferred over `/dev/random` to avoid entropy-starvation issues on the host.
     - `max_bytes` - (Optional) Maximum bytes of entropy allowed to get injected into the guest every `period` milliseconds (defaults to `1024`). Prefer a lower value when using `/dev/random` as source.

--- a/fwprovider/test/resource_vm_disks_test.go
+++ b/fwprovider/test/resource_vm_disks_test.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -2035,6 +2036,348 @@ func TestAccResourceVMDiskCDROMNotInDiskBlock(t *testing.T) {
 
 					return nil
 				},
+			},
+		},
+	})
+}
+
+// TestAccResourceVMDiskResizeNonHotpluggable tests that resizing a disk on a running VM
+// triggers a reboot when disk is excluded from the hotplug setting.
+// Also tests the double-reboot scenario (AIO change + resize with non-hotpluggable disk).
+// Regression test for https://github.com/bpg/terraform-provider-proxmox/issues/2684
+func TestAccResourceVMDiskResizeNonHotpluggable(t *testing.T) {
+	te := InitEnvironment(t)
+
+	imageFileID := te.DownloadCloudImage()
+	te.AddTemplateVars(map[string]any{"ImageFileID": imageFileID})
+
+	var capturedUptime int
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create a running VM with disk excluded from hotplug
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_disk_resize_no_hotplug" {
+					node_name           = "{{.NodeName}}"
+					started             = true
+					stop_on_destroy     = true
+					reboot_after_update = true
+					name                = "test-disk-resize-nohp"
+					hotplug             = "network,usb"
+
+					disk {
+						datastore_id = "local-lvm"
+						file_id      = "{{.ImageFileID}}"
+						interface    = "scsi0"
+						size         = 8
+					}
+					initialization {
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_device {
+						bridge = "vmbr0"
+					}
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_disk_resize_no_hotplug", map[string]string{
+						"disk.0.size": "8",
+						"hotplug":     "network,usb",
+					}),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["proxmox_virtual_environment_vm.test_disk_resize_no_hotplug"]
+						if !ok {
+							return fmt.Errorf("resource not found")
+						}
+
+						vmID, err := strconv.Atoi(rs.Primary.Attributes["vm_id"])
+						if err != nil {
+							return fmt.Errorf("failed to parse vm_id: %w", err)
+						}
+
+						// wait for uptime to accumulate
+						time.Sleep(5 * time.Second)
+
+						ctx := context.Background()
+
+						status, err := te.NodeClient().VM(vmID).GetVMStatus(ctx)
+						if err != nil {
+							return fmt.Errorf("failed to get VM status: %w", err)
+						}
+
+						if status.Uptime == nil || *status.Uptime < 3 {
+							return fmt.Errorf("VM uptime too low, expected >= 3 seconds, got %v", status.Uptime)
+						}
+
+						capturedUptime = *status.Uptime
+
+						return nil
+					},
+				),
+			},
+			{
+				// Step 2: Resize only — provider should reboot because disk is not hotpluggable.
+				// This is the primary bug scenario from issue #2684.
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_disk_resize_no_hotplug" {
+					node_name           = "{{.NodeName}}"
+					started             = true
+					stop_on_destroy     = true
+					reboot_after_update = true
+					name                = "test-disk-resize-nohp"
+					hotplug             = "network,usb"
+
+					disk {
+						datastore_id = "local-lvm"
+						file_id      = "{{.ImageFileID}}"
+						interface    = "scsi0"
+						size         = 16
+					}
+					initialization {
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_device {
+						bridge = "vmbr0"
+					}
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_disk_resize_no_hotplug", map[string]string{
+						"disk.0.size": "16",
+					}),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["proxmox_virtual_environment_vm.test_disk_resize_no_hotplug"]
+						if !ok {
+							return fmt.Errorf("resource not found")
+						}
+
+						vmID, err := strconv.Atoi(rs.Primary.Attributes["vm_id"])
+						if err != nil {
+							return fmt.Errorf("failed to parse vm_id: %w", err)
+						}
+
+						ctx := context.Background()
+
+						status, err := te.NodeClient().VM(vmID).GetVMStatus(ctx)
+						if err != nil {
+							return fmt.Errorf("failed to get VM status: %w", err)
+						}
+
+						if status.Uptime == nil {
+							return fmt.Errorf("VM uptime is nil")
+						}
+
+						// Uptime should be reset (reboot happened) — new uptime should be less than captured.
+						if *status.Uptime >= capturedUptime {
+							return fmt.Errorf(
+								"VM was NOT rebooted after disk resize: uptime before=%d, after=%d (expected reboot)",
+								capturedUptime, *status.Uptime,
+							)
+						}
+
+						return nil
+					},
+				),
+			},
+			{
+				// Step 3: Change AIO + resize — triggers double reboot:
+				// 1. Pre-resize reboot for AIO pending change
+				// 2. Post-resize reboot because disk is not hotpluggable
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_disk_resize_no_hotplug" {
+					node_name           = "{{.NodeName}}"
+					started             = true
+					stop_on_destroy     = true
+					reboot_after_update = true
+					name                = "test-disk-resize-nohp"
+					hotplug             = "network,usb"
+
+					disk {
+						datastore_id = "local-lvm"
+						file_id      = "{{.ImageFileID}}"
+						interface    = "scsi0"
+						size         = 24
+						aio          = "threads"
+					}
+					initialization {
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_device {
+						bridge = "vmbr0"
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_disk_resize_no_hotplug", map[string]string{
+					"disk.0.size": "24",
+					"disk.0.aio":  "threads",
+				}),
+			},
+			{
+				// Step 4: Refresh state to verify everything persists
+				RefreshState: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceVMDiskResizeDefaultHotplug tests that resizing a disk on a running VM
+// does NOT trigger an unnecessary reboot when hotplug is not explicitly configured.
+// PVE defaults to "network,disk,usb", so disk is hotpluggable by default.
+// This protects against the isHotpluggable default change causing regressions.
+func TestAccResourceVMDiskResizeDefaultHotplug(t *testing.T) {
+	te := InitEnvironment(t)
+
+	imageFileID := te.DownloadCloudImage()
+	te.AddTemplateVars(map[string]any{"ImageFileID": imageFileID})
+
+	var capturedUptime int
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create a running VM without setting hotplug (PVE default)
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_disk_resize_default_hp" {
+					node_name           = "{{.NodeName}}"
+					started             = true
+					stop_on_destroy     = true
+					reboot_after_update = true
+					name                = "test-disk-resize-defhp"
+
+					disk {
+						datastore_id = "local-lvm"
+						file_id      = "{{.ImageFileID}}"
+						interface    = "scsi0"
+						size         = 8
+					}
+					initialization {
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_device {
+						bridge = "vmbr0"
+					}
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_disk_resize_default_hp", map[string]string{
+						"disk.0.size": "8",
+					}),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["proxmox_virtual_environment_vm.test_disk_resize_default_hp"]
+						if !ok {
+							return fmt.Errorf("resource not found")
+						}
+
+						vmID, err := strconv.Atoi(rs.Primary.Attributes["vm_id"])
+						if err != nil {
+							return fmt.Errorf("failed to parse vm_id: %w", err)
+						}
+
+						// wait for uptime to accumulate
+						time.Sleep(5 * time.Second)
+
+						ctx := context.Background()
+
+						status, err := te.NodeClient().VM(vmID).GetVMStatus(ctx)
+						if err != nil {
+							return fmt.Errorf("failed to get VM status: %w", err)
+						}
+
+						if status.Uptime == nil || *status.Uptime < 3 {
+							return fmt.Errorf("VM uptime too low, expected >= 3 seconds, got %v", status.Uptime)
+						}
+
+						capturedUptime = *status.Uptime
+
+						return nil
+					},
+				),
+			},
+			{
+				// Step 2: Resize — should succeed WITHOUT reboot since disk is
+				// hotpluggable by default. Uptime should keep increasing.
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_disk_resize_default_hp" {
+					node_name           = "{{.NodeName}}"
+					started             = true
+					stop_on_destroy     = true
+					reboot_after_update = true
+					name                = "test-disk-resize-defhp"
+
+					disk {
+						datastore_id = "local-lvm"
+						file_id      = "{{.ImageFileID}}"
+						interface    = "scsi0"
+						size         = 16
+					}
+					initialization {
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_device {
+						bridge = "vmbr0"
+					}
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_disk_resize_default_hp", map[string]string{
+						"disk.0.size": "16",
+					}),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["proxmox_virtual_environment_vm.test_disk_resize_default_hp"]
+						if !ok {
+							return fmt.Errorf("resource not found")
+						}
+
+						vmID, err := strconv.Atoi(rs.Primary.Attributes["vm_id"])
+						if err != nil {
+							return fmt.Errorf("failed to parse vm_id: %w", err)
+						}
+
+						ctx := context.Background()
+
+						status, err := te.NodeClient().VM(vmID).GetVMStatus(ctx)
+						if err != nil {
+							return fmt.Errorf("failed to get VM status: %w", err)
+						}
+
+						if status.Uptime == nil {
+							return fmt.Errorf("VM uptime is nil")
+						}
+
+						// Uptime should NOT be reset — no reboot should have occurred.
+						if *status.Uptime < capturedUptime {
+							return fmt.Errorf(
+								"VM was unexpectedly rebooted after disk resize with default hotplug: "+
+									"uptime before=%d, after=%d (expected no reboot)",
+								capturedUptime, *status.Uptime,
+							)
+						}
+
+						return nil
+					},
+				),
+			},
+			{
+				// Step 3: Refresh state to verify size persists
+				RefreshState: true,
 			},
 		},
 	})

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -78,6 +78,11 @@ const (
 	dvCPUAffinity         = ""
 	dvDescription         = ""
 
+	// dvHotplug is the Proxmox VE default hotplug value.
+	// When hotplug is not explicitly configured, PVE uses "network,disk,usb".
+	// See: https://pve.proxmox.com/wiki/Manual:_qm.conf
+	dvHotplug = "network,disk,usb"
+
 	dvEFIDiskDatastoreID                = "local-lvm"
 	dvEFIDiskFileFormat                 = "raw"
 	dvEFIDiskType                       = "2m"
@@ -3899,7 +3904,8 @@ func hotplugContains(hotplug, feature string) bool {
 func isHotpluggable(d *schema.ResourceData, feature string) bool {
 	hotplug, ok := d.GetOk(mkHotplug)
 	if !ok {
-		return false
+		// When hotplug is not explicitly configured, PVE defaults to "network,disk,usb".
+		return hotplugContains(dvHotplug, feature)
 	}
 
 	return hotplugContains(hotplug.(string), feature)
@@ -6617,6 +6623,51 @@ func vmUpdateDiskLocationAndSize(
 		err = vmAPI.ResizeVMDisk(ctx, reqBody)
 		if err != nil {
 			return diag.FromErr(err)
+		}
+	}
+
+	// If disks were resized on a running VM and disk is not hotpluggable,
+	// reboot so the guest OS can process the size change (e.g. cloud-init growpart).
+	// This is separate from the config-change reboot above: that one applies pending
+	// config changes BEFORE resize; this one notifies the guest AFTER resize.
+	// No !reboot guard: even if we already rebooted for config changes, that happened
+	// BEFORE resize — the guest still needs a post-resize reboot to see the new size.
+	if len(diskResizeBodies) > 0 && started && !template && !isHotpluggable(d, "disk") {
+		canReboot := d.Get(mkRebootAfterUpdate).(bool)
+		if !canReboot {
+			return []diag.Diagnostic{{
+				Severity: diag.Warning,
+				Summary: "a reboot is required after disk resize because disk is not hotpluggable, " +
+					"but automatic reboots are disabled by 'reboot_after_update = false'. " +
+					"Please reboot the VM manually to apply the disk size change.",
+			}}
+		}
+
+		vmStatus, err := vmAPI.GetVMStatus(ctx)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		if vmStatus.Status != "stopped" {
+			agentEnabled, diags := isAgentEnabled(ctx, vmAPI)
+			if diags != nil {
+				return diags
+			}
+
+			if agentEnabled {
+				rebootTimeoutSec := d.Get(mkTimeoutReboot).(int)
+				if e := vmAPI.RebootVMAndWaitForRunning(ctx, rebootTimeoutSec); e != nil {
+					return diag.FromErr(e)
+				}
+			} else {
+				if e := vmStop(ctx, vmAPI, d); e != nil {
+					return e
+				}
+
+				if diags := vmStart(ctx, vmAPI, d); diags != nil {
+					return diags
+				}
+			}
 		}
 	}
 

--- a/proxmoxtf/resource/vm/vm_test.go
+++ b/proxmoxtf/resource/vm/vm_test.go
@@ -435,6 +435,11 @@ func TestHotplugContains(t *testing.T) {
 		{"single feature no match", "cpu", "memory", false},
 		{"default proxmox value", "disk,network,usb", "cpu", false},
 		{"cpu in list", "disk,cpu,network", "cpu", true},
+		{"pve default includes disk", "network,disk,usb", "disk", true},
+		{"pve default includes network", "network,disk,usb", "network", true},
+		{"pve default includes usb", "network,disk,usb", "usb", true},
+		{"pve default excludes cpu", "network,disk,usb", "cpu", false},
+		{"pve default excludes memory", "network,disk,usb", "memory", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where resizing a disk on a running VM did not trigger a reboot when `disk` was excluded from the `hotplug` setting. After the hotplug fix in #2412, CPU/memory/network changes are hotplugged without reboot. If the only change is a disk size increase and disk is not hotpluggable, `rebootRequired` stays `false`, no reboot occurs, and cloud-init's `growpart` never runs — leaving the guest filesystem at the old size.

This PR makes two changes:
1. **Fix `isHotpluggable()` default** — when `hotplug` is not explicitly configured, PVE defaults to `network,disk,usb`. Previously `isHotpluggable()` returned `false` for all features in this case.
2. **Add post-resize reboot** — after disk resize on a running VM, if disk is not hotpluggable, reboot the VM so the guest OS can process the size change. Respects `reboot_after_update = false` by emitting a warning instead. In the combined case (config change + disk resize + non-hotpluggable), the VM reboots twice: once before resize (for config) and once after (for the guest to see the new size).

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

**TDD RED phase — test fails without fix (no reboot after disk resize):**

```
$ ./testacc TestAccResourceVMDiskResizeNonHotpluggable
--- FAIL: TestAccResourceVMDiskResizeNonHotpluggable (29.06s)
    resource_vm_disks_test.go:2055: Step 2/2 error: Check failed: Check 2/2 error:
      VM was NOT rebooted after disk resize: uptime before=6, after=9 (expected reboot)
FAIL
```

**TDD GREEN phase — test passes with fix (VM rebooted after resize, including double-reboot step):**

```
$ ./testacc TestAccResourceVMDiskResizeNonHotpluggable -- -v
=== RUN   TestAccResourceVMDiskResizeNonHotpluggable
--- PASS: TestAccResourceVMDiskResizeNonHotpluggable (42.49s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	42.964s
```

Test verifies reboot via uptime check: captures VM uptime after step 1, asserts uptime reset (reboot occurred) after step 2 resize. Step 3 tests AIO change + resize (double reboot: pre-resize for config + post-resize for disk size).

**Default hotplug test — no unnecessary reboot when disk is hotpluggable by default:**

```
$ ./testacc TestAccResourceVMDiskResizeDefaultHotplug -- -v
=== RUN   TestAccResourceVMDiskResizeDefaultHotplug
--- PASS: TestAccResourceVMDiskResizeDefaultHotplug (32.10s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	37.177s
```

Test verifies NO reboot via uptime check: asserts uptime kept increasing (no reboot) after resize with PVE default hotplug.

**Regression tests — no regressions:**

```
$ ./testacc TestAccResourceVMDiskResizeWithOptionChange
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	36.574s
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

Closes #2684
