### PR TITLE
feat(vm): Allow specifying multiple nodes

### DIFF
--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -88,6 +88,34 @@ func TestAccResourceVM(t *testing.T) {
 				}`),
 			ExpectError: regexp.MustCompile(`expected "node_name" to not be an empty string, got `),
 		}}},
+		{"node_name and node_names are mutually exclusive", []resource.TestStep{{
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_invalid_nodes" {
+					node_name  = "{{.NodeName}}"
+					node_names = ["{{.NodeName}}"]
+					started    = false
+				}`),
+			ExpectError: regexp.MustCompile(`"node_name": only one of `),
+			PlanOnly:    true,
+		}}},
+		{"node_names with one allowed node", []resource.TestStep{{
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_node_names_single" {
+					node_names = ["{{.NodeName}}"]
+					started    = false
+				}`),
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_node_names_single", map[string]string{
+					"node_names.#":      "1",
+					"current_node_name": te.NodeName,
+				}),
+				resource.TestCheckTypeSetElemAttr(
+					"proxmox_virtual_environment_vm.test_node_names_single",
+					"node_names.*",
+					te.NodeName,
+				),
+			),
+		}}},
 		{"name", []resource.TestStep{{
 			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "vm" {

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -32,6 +32,7 @@ import (
 	"github.com/bpg/terraform-provider-proxmox/proxmox/cluster"
 	haresources "github.com/bpg/terraform-provider-proxmox/proxmox/cluster/ha/resources"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/pools"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
@@ -267,6 +268,8 @@ const (
 	mkName                = "name"
 
 	mkNodeName                         = "node_name"
+	mkNodeNames                        = "node_names"
+	mkCurrentNodeName                  = "current_node_name"
 	mkOperatingSystem                  = "operating_system"
 	mkOperatingSystemType              = "type"
 	mkPoolID                           = "pool_id"
@@ -1223,8 +1226,27 @@ func VM() *schema.Resource {
 		mkNodeName: {
 			Type:         schema.TypeString,
 			Description:  "The node name",
-			Required:     true,
+			Optional:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
+			ExactlyOneOf: []string{mkNodeName, mkNodeNames},
+		},
+		mkNodeNames: {
+			Type:        schema.TypeSet,
+			Description: "The node names on which the VM is allowed to run",
+			Optional:    true,
+			ExactlyOneOf: []string{
+				mkNodeName,
+				mkNodeNames,
+			},
+			Elem: &schema.Schema{
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+		},
+		mkCurrentNodeName: {
+			Type:        schema.TypeString,
+			Description: "The node name on which the VM is currently running",
+			Computed:    true,
 		},
 		mkNUMA: {
 			Type:        schema.TypeList,
@@ -1768,6 +1790,25 @@ func VM() *schema.Resource {
 					return !d.Get(mkMigrate).(bool)
 				},
 			),
+			customdiff.ForceNewIf(
+				mkNodeNames,
+				func(_ context.Context, d *schema.ResourceDiff, _ any) bool {
+					if !d.HasChange(mkNodeNames) {
+						return false
+					}
+
+					if d.Get(mkMigrate).(bool) {
+						return false
+					}
+
+					currentNodeName, ok := d.GetOk(mkCurrentNodeName)
+					if !ok {
+						return true
+					}
+
+					return !slices.Contains(stringSetValues(d.Get(mkNodeNames)), currentNodeName.(string))
+				},
+			),
 			forceNewOnTPMVersionChange,
 			forceNewOnEFIDiskTypeChange,
 		),
@@ -1783,6 +1824,11 @@ func VM() *schema.Resource {
 				err = d.Set(mkNodeName, node)
 				if err != nil {
 					return nil, fmt.Errorf("failed setting state during import: %w", err)
+				}
+
+				err = d.Set(mkCurrentNodeName, node)
+				if err != nil {
+					return nil, fmt.Errorf("failed setting current node state during import: %w", err)
 				}
 
 				return []*schema.ResourceData{d}, nil
@@ -2054,7 +2100,17 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m any) diag.Diag
 	description := d.Get(mkDescription).(string)
 	name := d.Get(mkName).(string)
 	tags := d.Get(mkTags).([]any)
-	nodeName := d.Get(mkNodeName).(string)
+
+	nodeName, err := selectVMNodeForCreate(ctx, client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	err = d.Set(mkCurrentNodeName, nodeName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	poolID := d.Get(mkPoolID).(string)
 	vmIDUntyped, hasVMID := d.GetOk(mkVMID)
 	vmID := vmIDUntyped.(int)
@@ -2870,7 +2926,10 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		return diag.FromErr(err)
 	}
 
-	nodeName := d.Get(mkNodeName).(string)
+	nodeName, err := selectVMNodeForCreate(ctx, client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	operatingSystem, err := structure.GetSchemaBlock(
 		resource,
@@ -3137,6 +3196,11 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		return diag.FromErr(err)
 	}
 
+	err = d.Set(mkCurrentNodeName, nodeName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(strconv.Itoa(vmID))
 
 	diags := disk.CreateCustomDisks(ctx, client, nodeName, vmID, diskDeviceObjects)
@@ -3192,7 +3256,10 @@ func vmCreateStart(ctx context.Context, d *schema.ResourceData, m any) diag.Diag
 		return diag.FromErr(err)
 	}
 
-	nodeName := d.Get(mkNodeName).(string)
+	nodeName, err := getCurrentVMNodeName(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	vmID, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -3948,14 +4015,34 @@ func vmRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics
 		return diag.FromErr(err)
 	}
 
-	if vmNodeName != d.Get(mkNodeName) {
-		err = d.Set(mkNodeName, vmNodeName)
+	err = d.Set(mkCurrentNodeName, *vmNodeName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	currentNodeName := *vmNodeName
+
+	if isMultiNodePlacementConfigured(d) {
+		configuredNodes := getConfiguredVMNodeNames(d)
+		if slices.Contains(configuredNodes, currentNodeName) {
+			err = d.Set(mkNodeNames, configuredNodes)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		} else {
+			err = d.Set(mkNodeNames, []string{currentNodeName})
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	} else if currentNodeName != d.Get(mkNodeName) {
+		err = d.Set(mkNodeName, currentNodeName)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	nodeName := d.Get(mkNodeName).(string)
+	nodeName := currentNodeName
 
 	vmAPI := client.Node(nodeName).VM(vmID)
 
@@ -4030,7 +4117,11 @@ func vmReadCustom(
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	nodeName := d.Get(mkNodeName).(string)
+	nodeName, err := getCurrentVMNodeName(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	clone := d.Get(mkClone).([]any)
 
 	// Compare the agent configuration to the one stored in the state.
@@ -5241,8 +5332,14 @@ func vmReadCustom(
 	// during import these core attributes might not be set, so set them explicitly here
 	d.SetId(strconv.Itoa(vmID))
 	e = d.Set(mkVMID, vmID)
+
 	diags = append(diags, diag.FromErr(e)...)
-	e = d.Set(mkNodeName, nodeName)
+	if !isMultiNodePlacementConfigured(d) {
+		e = d.Set(mkNodeName, nodeName)
+		diags = append(diags, diag.FromErr(e)...)
+	}
+
+	e = d.Set(mkCurrentNodeName, nodeName)
 	diags = append(diags, diag.FromErr(e)...)
 
 	diags = setDefaultIfNotExists(d, diags, mkMigrate, dvMigrate)
@@ -5516,7 +5613,11 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 		return diag.FromErr(e)
 	}
 
-	nodeName := d.Get(mkNodeName).(string)
+	nodeName, e := getCurrentVMNodeName(d)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	rebootRequired := false
 
 	vmID, e := strconv.Atoi(d.Id())
@@ -5530,18 +5631,34 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 	}
 
 	// If the node name has changed we need to migrate the VM to the new node before we do anything else.
-	if d.HasChange(mkNodeName) {
-		migrateTimeoutSec := d.Get(mkTimeoutMigrate).(int)
-
-		migrateCtx, cancel := context.WithTimeout(ctx, time.Duration(migrateTimeoutSec)*time.Second)
-		defer cancel()
-
-		oldNodeNameValue, _ := d.GetChange(mkNodeName)
-		oldNodeName := oldNodeNameValue.(string)
-
-		err := migrateVM(migrateCtx, client, vmID, oldNodeName, nodeName)
+	if d.HasChange(mkNodeName) || d.HasChange(mkNodeNames) {
+		targetNodeName, shouldMigrate, err := getVMNodeMigrationTarget(ctx, d, client)
 		if err != nil {
 			return diag.FromErr(err)
+		}
+
+		if shouldMigrate {
+			migrateTimeoutSec := d.Get(mkTimeoutMigrate).(int)
+
+			migrateCtx, cancel := context.WithTimeout(ctx, time.Duration(migrateTimeoutSec)*time.Second)
+			defer cancel()
+
+			currentNodeName, err := getCurrentVMNodeName(d)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+
+			err = migrateVM(migrateCtx, client, vmID, currentNodeName, targetNodeName)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+
+			nodeName = targetNodeName
+
+			e = d.Set(mkCurrentNodeName, nodeName)
+			if e != nil {
+				return diag.FromErr(e)
+			}
 		}
 	}
 
@@ -6371,7 +6488,11 @@ func vmUpdateDiskLocationAndSize(
 		return diag.FromErr(err)
 	}
 
-	nodeName := d.Get(mkNodeName).(string)
+	nodeName, err := getCurrentVMNodeName(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	started := d.Get(mkStarted).(bool)
 	template := d.Get(mkTemplate).(bool)
 
@@ -6695,7 +6816,10 @@ func vmDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 		return diag.FromErr(err)
 	}
 
-	nodeName := d.Get(mkNodeName).(string)
+	nodeName, err := getCurrentVMNodeName(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	vmID, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -6826,6 +6950,191 @@ func parseImportIDWithNodeName(id string) (string, string, error) {
 	}
 
 	return nodeName, id, nil
+}
+
+func isMultiNodePlacementConfigured(d *schema.ResourceData) bool {
+	nodeNames, ok := d.GetOk(mkNodeNames)
+	if !ok {
+		return false
+	}
+
+	return len(nodeNames.(*schema.Set).List()) > 0
+}
+
+func getConfiguredVMNodeNames(d *schema.ResourceData) []string {
+	if isMultiNodePlacementConfigured(d) {
+		return stringSetValues(d.Get(mkNodeNames))
+	}
+
+	nodeName, ok := d.GetOk(mkNodeName)
+	if !ok {
+		return nil
+	}
+
+	return []string{nodeName.(string)}
+}
+
+func getCurrentVMNodeName(d *schema.ResourceData) (string, error) {
+	currentNodeName, ok := d.GetOk(mkCurrentNodeName)
+	if ok && currentNodeName.(string) != "" {
+		return currentNodeName.(string), nil
+	}
+
+	return "", fmt.Errorf("failed to determine current VM node from state")
+}
+
+func stringSetValues(nodes any) []string {
+	var values []string
+
+	switch v := nodes.(type) {
+	case *schema.Set:
+		for _, value := range v.List() {
+			values = append(values, value.(string))
+		}
+	case []any:
+		for _, value := range v {
+			values = append(values, value.(string))
+		}
+	case []string:
+		values = append(values, v...)
+	}
+
+	slices.Sort(values)
+
+	return values
+}
+
+func selectVMNodeForCreate(ctx context.Context, client proxmox.Client, d *schema.ResourceData) (string, error) {
+	configuredNodes := getConfiguredVMNodeNames(d)
+	if len(configuredNodes) == 0 {
+		return "", fmt.Errorf("no target node configured")
+	}
+
+	if len(configuredNodes) == 1 {
+		return configuredNodes[0], nil
+	}
+
+	return selectLeastUtilizedNode(ctx, client, configuredNodes)
+}
+
+func getVMNodeMigrationTarget(
+	ctx context.Context,
+	d *schema.ResourceData,
+	client proxmox.Client,
+) (string, bool, error) {
+	currentNodeName, err := getCurrentVMNodeName(d)
+	if err != nil {
+		return "", false, err
+	}
+
+	configuredNodes := getConfiguredVMNodeNames(d)
+	if len(configuredNodes) == 0 {
+		return "", false, fmt.Errorf("no target node configured")
+	}
+
+	if !isMultiNodePlacementConfigured(d) {
+		targetNodeName := configuredNodes[0]
+
+		return targetNodeName, targetNodeName != currentNodeName, nil
+	}
+
+	if slices.Contains(configuredNodes, currentNodeName) {
+		return "", false, nil
+	}
+
+	targetNodeName, err := selectLeastUtilizedNode(ctx, client, configuredNodes)
+	if err != nil {
+		return "", false, err
+	}
+
+	return targetNodeName, true, nil
+}
+
+type vmNodePlacement struct {
+	name              string
+	cpuUtilization    float64
+	memoryUtilization float64
+}
+
+func selectLeastUtilizedNode(ctx context.Context, client proxmox.Client, nodeNames []string) (string, error) {
+	nodes, err := client.Node("").ListNodes(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return selectLeastUtilizedNodeFromList(nodeNames, nodes)
+}
+
+func selectLeastUtilizedNodeFromList(nodeNames []string, nodes []*nodes.ListResponseData) (string, error) {
+	candidates := make([]vmNodePlacement, 0, len(nodeNames))
+	selectedNodeNames := make(map[string]struct{}, len(nodeNames))
+
+	for _, nodeName := range nodeNames {
+		selectedNodeNames[nodeName] = struct{}{}
+	}
+
+	for _, node := range nodes {
+		if _, ok := selectedNodeNames[node.Name]; !ok {
+			continue
+		}
+
+		if node.Status == nil || *node.Status != "online" {
+			continue
+		}
+
+		candidates = append(candidates, vmNodePlacement{
+			name:              node.Name,
+			cpuUtilization:    getNodeCPUUtilization(node),
+			memoryUtilization: getNodeMemoryUtilization(node),
+		})
+
+		delete(selectedNodeNames, node.Name)
+	}
+
+	if len(selectedNodeNames) > 0 {
+		missingNodeNames := make([]string, 0, len(selectedNodeNames))
+		for nodeName := range selectedNodeNames {
+			missingNodeNames = append(missingNodeNames, nodeName)
+		}
+
+		slices.Sort(missingNodeNames)
+
+		return "", fmt.Errorf("failed to find online nodes from node_names: %s", strings.Join(missingNodeNames, ", "))
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].memoryUtilization != candidates[j].memoryUtilization {
+			return candidates[i].memoryUtilization < candidates[j].memoryUtilization
+		}
+
+		if candidates[i].cpuUtilization != candidates[j].cpuUtilization {
+			return candidates[i].cpuUtilization < candidates[j].cpuUtilization
+		}
+
+		return candidates[i].name < candidates[j].name
+	})
+
+	if len(candidates) == 0 {
+		return "", fmt.Errorf("failed to find an online node from node_names")
+	}
+
+	return candidates[0].name, nil
+}
+
+func getNodeCPUUtilization(node *nodes.ListResponseData) float64 {
+	if node.CPUUtilization == nil {
+		return 1.0
+	}
+
+	return *node.CPUUtilization
+}
+
+func getNodeMemoryUtilization(node *nodes.ListResponseData) float64 {
+	if node.MemoryUsed == nil || node.MemoryAvailable == nil || *node.MemoryAvailable == 0 {
+		return 1.0
+	}
+
+	return float64(*node.MemoryUsed) / float64(*node.MemoryAvailable)
 }
 
 func getAgentTimeout(d *schema.ResourceData) (time.Duration, error) {

--- a/proxmoxtf/resource/vm/vm_test.go
+++ b/proxmoxtf/resource/vm/vm_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/disk"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/network"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/test"
@@ -33,10 +34,6 @@ func TestVMSchema(t *testing.T) {
 
 	s := VM().Schema
 
-	test.AssertRequiredArguments(t, s, []string{
-		mkNodeName,
-	})
-
 	test.AssertOptionalArguments(t, s, []string{
 		mkACPI,
 		mkAgent,
@@ -57,6 +54,8 @@ func TestVMSchema(t *testing.T) {
 		mkMachine,
 		mkMemory,
 		mkName,
+		mkNodeName,
+		mkNodeNames,
 		network.MkNetworkDevice,
 		mkOperatingSystem,
 		mkPoolID,
@@ -88,6 +87,8 @@ func TestVMSchema(t *testing.T) {
 		mkMachine:         schema.TypeString,
 		mkMemory:          schema.TypeList,
 		mkName:            schema.TypeString,
+		mkNodeName:        schema.TypeString,
+		mkNodeNames:       schema.TypeSet,
 		mkOperatingSystem: schema.TypeList,
 		mkPoolID:          schema.TypeString,
 		mkSerialDevice:    schema.TypeList,
@@ -97,6 +98,15 @@ func TestVMSchema(t *testing.T) {
 		mkVirtiofs:        schema.TypeList,
 		mkVMID:            schema.TypeInt,
 		mkSCSIHardware:    schema.TypeString,
+	})
+
+	test.AssertComputedAttributes(t, s, []string{
+		mkCurrentNodeName,
+	})
+
+	test.AssertExactlyOneOfArguments(t, s, map[string][]string{
+		mkNodeName:  {mkNodeName, mkNodeNames},
+		mkNodeNames: {mkNodeName, mkNodeNames},
 	})
 
 	agentSchema := test.AssertNestedSchemaExistence(t, s, mkAgent)
@@ -481,6 +491,142 @@ func Test_parseImportIDWIthNodeName(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedNodeName, nodeName)
 			require.Equal(t, tt.expectedID, id)
+		})
+	}
+}
+
+func TestSelectLeastUtilizedNodeFromList(t *testing.T) {
+	t.Parallel()
+
+	online := "online"
+	offline := "offline"
+	lowCPU := 0.10
+	highCPU := 0.80
+	midCPU := 0.40
+	lowMemTotal := int64(100)
+	lowMemUsed := int64(20)
+	highMemTotal := int64(100)
+	highMemUsed := int64(70)
+	tieMemTotal := int64(100)
+	tieMemUsed := int64(20)
+
+	tests := []struct {
+		name      string
+		nodeNames []string
+		nodes     []*nodes.ListResponseData
+		want      string
+		wantErr   string
+	}{
+		{
+			name:      "prefers lower memory utilization",
+			nodeNames: []string{"node-a", "node-b"},
+			nodes: []*nodes.ListResponseData{
+				{Name: "node-a", Status: &online, CPUUtilization: &midCPU, MemoryAvailable: &highMemTotal, MemoryUsed: &highMemUsed},
+				{Name: "node-b", Status: &online, CPUUtilization: &highCPU, MemoryAvailable: &lowMemTotal, MemoryUsed: &lowMemUsed},
+			},
+			want: "node-b",
+		},
+		{
+			name:      "uses cpu as tie breaker",
+			nodeNames: []string{"node-a", "node-b"},
+			nodes: []*nodes.ListResponseData{
+				{Name: "node-a", Status: &online, CPUUtilization: &highCPU, MemoryAvailable: &tieMemTotal, MemoryUsed: &tieMemUsed},
+				{Name: "node-b", Status: &online, CPUUtilization: &lowCPU, MemoryAvailable: &tieMemTotal, MemoryUsed: &tieMemUsed},
+			},
+			want: "node-b",
+		},
+		{
+			name:      "ignores offline nodes",
+			nodeNames: []string{"node-a", "node-b"},
+			nodes: []*nodes.ListResponseData{
+				{Name: "node-a", Status: &offline, CPUUtilization: &lowCPU, MemoryAvailable: &lowMemTotal, MemoryUsed: &lowMemUsed},
+				{Name: "node-b", Status: &online, CPUUtilization: &midCPU, MemoryAvailable: &highMemTotal, MemoryUsed: &highMemUsed},
+			},
+			wantErr: "failed to find online nodes from node_names: node-a",
+		},
+		{
+			name:      "fails when no configured node is found",
+			nodeNames: []string{"node-a"},
+			nodes:     []*nodes.ListResponseData{},
+			wantErr:   "failed to find online nodes from node_names: node-a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := selectLeastUtilizedNodeFromList(tt.nodeNames, tt.nodes)
+
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNodePlacementHelpers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		config      map[string]any
+		wantNodes   []string
+		wantMulti   bool
+		wantCurrent string
+		wantErr     string
+	}{
+		{
+			name: "single node placement",
+			config: map[string]any{
+				mkNodeName: "node-a",
+			},
+			wantNodes: []string{"node-a"},
+			wantMulti: false,
+			wantErr:   "failed to determine current VM node from state",
+		},
+		{
+			name: "multi node placement",
+			config: map[string]any{
+				mkNodeNames: []any{"node-b", "node-a"},
+			},
+			wantNodes: []string{"node-a", "node-b"},
+			wantMulti: true,
+			wantErr:   "failed to determine current VM node from state",
+		},
+		{
+			name: "current node uses computed state",
+			config: map[string]any{
+				mkNodeNames:       []any{"node-b", "node-a"},
+				mkCurrentNodeName: "node-b",
+			},
+			wantCurrent: "node-b",
+			wantNodes:   []string{"node-a", "node-b"},
+			wantMulti:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := schema.TestResourceDataRaw(t, VM().Schema, tt.config)
+
+			require.Equal(t, tt.wantMulti, isMultiNodePlacementConfigured(d))
+			require.Equal(t, tt.wantNodes, getConfiguredVMNodeNames(d))
+
+			currentNode, err := getCurrentVMNodeName(d)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantCurrent, currentNode)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Fixes #2081
This allows specifying multiple nodes a VM is allowed to run on. When a VM is newly deployed or needs to be migrated, it is migrated to the node in the list with the least utilization (sorting by memory first, cpu second and then node name as tie braker). This way, a user can manually migrate VMs across e.g. identical nodes and terraform won't complain; only moving the nodes out of the allowed node range will make it migrate the VM back to one node of the list.

It is still possible to set node_name. node_name and node_names are mutually exclusive. I ran the examples and some acceptance tests and found no regressions (I tried to keep the existing behaviour). Therefore, I didn't mark this as breaking change.

I tested:

- Deploying a new VM with node_names (deployed on node with lowest memory consumption)
- Migrating the VM to a node in the node_names list (no config drift reported)
- Migrating the VM to a node outside the node_names list (config drift detects; VM is migrated to node with lowest memory consumption)
- Switching from node_names to a node_name in the config (node is migrated to that node if not on it)
- Switching from node_name to node_names in the config (node is migrated to the node with the lowest memory consumption in that list if not on one of these nodes already)
- Destroy VM (VM is removed)

I added a current_node_name field that is computed to differentiate explicitely between the configured node and the node the VM is currently running on.

I didn't add documentation yet since I don't know if this feature is wanted; If yes, I will document it. I will then also make the commit message more verbose and explain the change in more detail.

One area I'm unsure about is the metric that determines where a VM is placed. By using the node with the lowest memory consumption, we automatically load balance, which I think is useful. However, if you have hundrets of nodes, it might take some time to compute it. Is that an issue? In my tests with a few nodes in that list, it is no problem. An alternative approach might be to randomly assign VMs (or maybe add a config flag to set whether the metric or random selection should be used?).

I added unit tests for the new functions and two acceptance test parts. However, since the test cluster setup only includes one node, I only test the node_names list with one node in it, so the migration behaviour etc. cannot be tested with an acceptance test. Unit tests should cover this however, so is it fine to leave it like this?

### Contributor's Note
- [X] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [X] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [X] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [X] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work
<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

Acceptance test output:
```
TF_ACC=1 env $(cat testacc.env | xargs) go test --tags=acceptance -count=1 -v ./fwprovider/test -run '^TestAccResourceVM$'
=== RUN   TestAccResourceVM
=== PAUSE TestAccResourceVM
=== CONT  TestAccResourceVM
=== RUN   TestAccResourceVM/multiline_description
=== PAUSE TestAccResourceVM/multiline_description
=== RUN   TestAccResourceVM/single_line_description
=== PAUSE TestAccResourceVM/single_line_description
=== RUN   TestAccResourceVM/no_description
=== PAUSE TestAccResourceVM/no_description
=== RUN   TestAccResourceVM/empty_node_name
=== PAUSE TestAccResourceVM/empty_node_name
=== RUN   TestAccResourceVM/node_name_and_node_names_are_mutually_exclusive
=== PAUSE TestAccResourceVM/node_name_and_node_names_are_mutually_exclusive
=== RUN   TestAccResourceVM/node_names_with_one_allowed_node
=== PAUSE TestAccResourceVM/node_names_with_one_allowed_node
=== RUN   TestAccResourceVM/name
=== PAUSE TestAccResourceVM/name
=== RUN   TestAccResourceVM/protection
=== PAUSE TestAccResourceVM/protection
=== RUN   TestAccResourceVM/update_cpu_block
=== PAUSE TestAccResourceVM/update_cpu_block
=== RUN   TestAccResourceVM/create_VM_without_cpu.units_and_verify_no_drift
=== PAUSE TestAccResourceVM/create_VM_without_cpu.units_and_verify_no_drift
=== RUN   TestAccResourceVM/set_cpu.architecture_as_non_root_is_not_supported
=== PAUSE TestAccResourceVM/set_cpu.architecture_as_non_root_is_not_supported
=== RUN   TestAccResourceVM/update_memory_block
=== PAUSE TestAccResourceVM/update_memory_block
=== RUN   TestAccResourceVM/create_vga_block
=== PAUSE TestAccResourceVM/create_vga_block
=== RUN   TestAccResourceVM/update_vga_block
=== PAUSE TestAccResourceVM/update_vga_block
=== RUN   TestAccResourceVM/update_watchdog_block
=== PAUSE TestAccResourceVM/update_watchdog_block
=== RUN   TestAccResourceVM/update_rng_block
=== PAUSE TestAccResourceVM/update_rng_block
=== RUN   TestAccResourceVM/create_virtiofs_block
=== PAUSE TestAccResourceVM/create_virtiofs_block
=== RUN   TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_defaults
=== PAUSE TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_defaults
=== RUN   TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_set_to_false
=== PAUSE TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_set_to_false
=== RUN   TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_update
=== PAUSE TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_update
=== RUN   TestAccResourceVM/hotplug
=== PAUSE TestAccResourceVM/hotplug
=== RUN   TestAccResourceVM/hotplug_disabled
=== PAUSE TestAccResourceVM/hotplug_disabled
=== RUN   TestAccResourceVM/hotplug_order_insensitive
=== PAUSE TestAccResourceVM/hotplug_order_insensitive
=== RUN   TestAccResourceVM/hotplug_duplicate_rejected
=== PAUSE TestAccResourceVM/hotplug_duplicate_rejected
=== RUN   TestAccResourceVM/hotplug_explicit_reset
=== PAUSE TestAccResourceVM/hotplug_explicit_reset
=== RUN   TestAccResourceVM/timeout_persistence_across_updates
=== PAUSE TestAccResourceVM/timeout_persistence_across_updates
=== CONT  TestAccResourceVM/multiline_description
=== CONT  TestAccResourceVM/hotplug_order_insensitive
=== CONT  TestAccResourceVM/update_memory_block
=== CONT  TestAccResourceVM/timeout_persistence_across_updates
=== CONT  TestAccResourceVM/hotplug_explicit_reset
=== CONT  TestAccResourceVM/hotplug_duplicate_rejected
=== CONT  TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_defaults
=== CONT  TestAccResourceVM/name
=== CONT  TestAccResourceVM/node_names_with_one_allowed_node
=== CONT  TestAccResourceVM/node_name_and_node_names_are_mutually_exclusive
=== CONT  TestAccResourceVM/empty_node_name
=== CONT  TestAccResourceVM/no_description
=== CONT  TestAccResourceVM/single_line_description
=== CONT  TestAccResourceVM/hotplug
=== CONT  TestAccResourceVM/hotplug_disabled
=== CONT  TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_update
=== CONT  TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_set_to_false
=== CONT  TestAccResourceVM/create_VM_without_cpu.units_and_verify_no_drift
=== CONT  TestAccResourceVM/set_cpu.architecture_as_non_root_is_not_supported
=== CONT  TestAccResourceVM/update_cpu_block
=== CONT  TestAccResourceVM/protection
=== CONT  TestAccResourceVM/update_watchdog_block
=== CONT  TestAccResourceVM/create_virtiofs_block
=== CONT  TestAccResourceVM/update_rng_block
=== CONT  TestAccResourceVM/create_vga_block
=== CONT  TestAccResourceVM/update_vga_block
--- PASS: TestAccResourceVM (0.00s)
    --- PASS: TestAccResourceVM/name (0.89s)
    --- PASS: TestAccResourceVM/hotplug_duplicate_rejected (1.18s)
    --- PASS: TestAccResourceVM/node_name_and_node_names_are_mutually_exclusive (0.48s)
    --- PASS: TestAccResourceVM/empty_node_name (0.22s)
    --- PASS: TestAccResourceVM/multiline_description (3.32s)
    --- PASS: TestAccResourceVM/hotplug_order_insensitive (3.79s)
    --- PASS: TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_defaults (4.07s)
    --- PASS: TestAccResourceVM/node_names_with_one_allowed_node (3.60s)
    --- PASS: TestAccResourceVM/no_description (3.25s)
    --- PASS: TestAccResourceVM/hotplug_explicit_reset (5.20s)
    --- PASS: TestAccResourceVM/update_memory_block (5.23s)
    --- PASS: TestAccResourceVM/timeout_persistence_across_updates (5.25s)
    --- PASS: TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_update (1.92s)
    --- PASS: TestAccResourceVM/purge_on_destroy_and_delete_unreferenced_disks_on_destroy_set_to_false (1.51s)
    --- PASS: TestAccResourceVM/single_line_description (3.34s)
    --- PASS: TestAccResourceVM/hotplug_disabled (3.35s)
    --- PASS: TestAccResourceVM/hotplug (4.34s)
    --- PASS: TestAccResourceVM/set_cpu.architecture_as_non_root_is_not_supported (3.20s)
    --- PASS: TestAccResourceVM/create_VM_without_cpu.units_and_verify_no_drift (3.92s)
    --- PASS: TestAccResourceVM/update_cpu_block (4.50s)
    --- PASS: TestAccResourceVM/protection (4.29s)
    --- PASS: TestAccResourceVM/create_virtiofs_block (4.09s)
    --- PASS: TestAccResourceVM/create_vga_block (3.93s)
    --- PASS: TestAccResourceVM/update_watchdog_block (6.12s)
    --- PASS: TestAccResourceVM/update_vga_block (4.42s)
    --- PASS: TestAccResourceVM/update_rng_block (6.18s)
PASS
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/test       13.617s
```

If wanted, I can also paste the output of the plan's/apply's here, but that should be easy to test manually ;)

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2081

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
