### PR TITLE
fix(vm): skip cloud-init device update when only config changed

### DIFF
--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -973,6 +973,81 @@ func TestAccResourceVMInitialization(t *testing.T) {
 				},
 			},
 		}}},
+		{"native cloud-init: config update on running VM should not fail", []resource.TestStep{{
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm_cloudinit_running" {
+					node_name       = "{{.NodeName}}"
+					started         = true
+					stop_on_destroy = true
+					cpu {
+						cores = 1
+					}
+					memory {
+						dedicated = 1024
+					}
+					disk {
+						datastore_id = "local-lvm"
+						file_id      = "{{.ImageFileID}}"
+						interface    = "virtio0"
+						size         = 8
+					}
+					initialization {
+						datastore_id = "local-lvm"
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_device {
+						bridge = "vmbr0"
+					}
+				}`),
+			Check: ResourceAttributes("proxmox_virtual_environment_vm.test_vm_cloudinit_running", map[string]string{
+				"initialization.0.datastore_id": "local-lvm",
+			}),
+		}, {
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm_cloudinit_running" {
+					node_name       = "{{.NodeName}}"
+					started         = true
+					stop_on_destroy = true
+					cpu {
+						cores = 1
+					}
+					memory {
+						dedicated = 1024
+					}
+					disk {
+						datastore_id = "local-lvm"
+						file_id      = "{{.ImageFileID}}"
+						interface    = "virtio0"
+						size         = 8
+					}
+					initialization {
+						datastore_id = "local-lvm"
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+						dns {
+							servers = ["1.1.1.1"]
+						}
+					}
+					network_device {
+						bridge = "vmbr0"
+					}
+				}`),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_vm_cloudinit_running", plancheck.ResourceActionUpdate),
+				},
+			},
+			Check: ResourceAttributes("proxmox_virtual_environment_vm.test_vm_cloudinit_running", map[string]string{
+				"initialization.0.dns.0.servers.0": "1.1.1.1",
+			}),
+		}}},
 	}
 
 	for _, tt := range tests {

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5958,14 +5958,12 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 		initialization := d.Get(mkInitialization).([]any)
 
 		if updateBody.CloudInitConfig != nil && len(initialization) > 0 && initialization[0] != nil {
-			var fileVolume string
-
 			initializationBlock := initialization[0].(map[string]any)
 			initializationDatastoreID := initializationBlock[mkInitializationDatastoreID].(string)
 			initializationInterface := initializationBlock[mkInitializationInterface].(string)
 			initializationFileFormat := initializationBlock[mkInitializationFileFormat].(string)
 
-			existingInterface, existingDevice := findExistingCloudInitDrive(vmConfig, vmID, "")
+			existingInterface, _ := findExistingCloudInitDrive(vmConfig, vmID, "")
 			if initializationInterface == "" && existingInterface == "" {
 				initializationInterface = "ide2"
 			} else if initializationInterface == "" {
@@ -6000,8 +5998,8 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 			}
 
 			if mustChangeInterface || mustChangeDatastore || mustChangeFileFormat || existingInterface == "" {
-				// CloudInit must be moved, either from a device to another or from a datastore
-				// to another (or both). This requires the VM to be stopped.
+				// CloudInit device must be created or moved (interface, datastore, or format changed).
+				// This requires the VM to be stopped.
 				if !stoppedBeforeUpdate {
 					if er := vmShutdown(ctx, vmAPI, d); er != nil {
 						return er
@@ -6013,20 +6011,23 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 				}
 
 				stoppedBeforeUpdate = true
-				fileVolume = fmt.Sprintf("%s:cloudinit", initializationDatastoreID)
-			} else {
-				fileVolume = existingDevice.FileVolume
-			}
 
-			device := vms.CustomStorageDevice{
-				FileVolume: fileVolume,
-			}
+				fileVolume := fmt.Sprintf("%s:cloudinit", initializationDatastoreID)
 
-			if initializationFileFormat != "" {
-				device.Format = &initializationFileFormat
-			}
+				device := vms.CustomStorageDevice{
+					FileVolume: fileVolume,
+				}
 
-			updateBody.AddCustomStorageDevice(initializationInterface, device)
+				if initializationFileFormat != "" {
+					device.Format = &initializationFileFormat
+				}
+
+				updateBody.AddCustomStorageDevice(initializationInterface, device)
+			}
+			// When only cloud-init config changed (DNS, IP, user settings) but the device
+			// structure is unchanged, we skip AddCustomStorageDevice. The cloud-init parameters
+			// are already set on updateBody.CloudInitConfig (line above), and
+			// RebuildCloudInitDisk is called after the update to regenerate the ISO.
 		}
 
 		cloudInitRebuildRequired = true


### PR DESCRIPTION
### What does this PR do?

Fixes #2707 — updating cloud-init configuration (e.g. adding DNS servers) on a running VM
failed with `ide2: hotplug problem - unable to change media type`.

The root cause: when only cloud-init *config* changed (DNS, IP, user settings) but the
device structure was unchanged (same interface, datastore, format), the provider still
re-sent the `ide2` device spec to the Proxmox API without the `media=cdrom` field. Proxmox
interpreted this as a media type change attempt and rejected it.

The fix moves `AddCustomStorageDevice` inside the structural-change branch, so the device
spec is only sent when the cloud-init drive actually needs to be created or moved. For
config-only changes, the cloud-init parameters are sent via `CloudInitConfig` on the update
body and `RebuildCloudInitDisk` regenerates the ISO — no device update needed.

### Related Issues

This is a recurring problem area around cloud-init device handling during updates:

| Issue/PR      | Title                                                           | Relevance                                                              |
|---------------|-----------------------------------------------------------------|------------------------------------------------------------------------|
| #2620         | Update fails after creation - unable to change media type       | Same error — closed as user error but underlying provider bug remained |
| #1083 / #1141 | Re-use ide, sata, and scsi cloud-init storage                   | Introduced the device reuse logic that this fix builds on              |
| #2484         | Resizing disk deletes cdrom / cloud-init                        | Same update code path, different symptom                               |
| #1701         | Cloud-init IP config lost when changing CPU/memory on cloned VM | Related cloud-init update issue                                        |

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

**Test coverage: Strong** — the acceptance test directly reproduces the exact bug scenario
and verifies the fix. The test was verified to fail without the fix and pass with it (TDD).

#### TDD Evidence — RED (without fix)

```
--- FAIL: TestAccResourceVMInitialization (30.32s)
    --- FAIL: TestAccResourceVMInitialization/native_cloud-init:_config_update_on_running_VM_should_not_fail (17.87s)
        resource_vm_test.go:1055: Step 2/2 error: Error running apply: exit status 1

            Error: All attempts fail:
            #1: received an HTTP 400 response - Reason: Parameter verification failed.
                (ide2: hotplug problem - unable to change media type)
```

#### TDD Evidence — GREEN (with fix)

```
./testacc "TestAccResourceVMInitialization/native_cloud-init:_config_update_on_running_VM_should_not_fail" -- -v

=== RUN   TestAccResourceVMInitialization
=== RUN   TestAccResourceVMInitialization/native_cloud-init:_config_update_on_running_VM_should_not_fail
--- PASS: TestAccResourceVMInitialization (26.61s)
    --- PASS: TestAccResourceVMInitialization/native_cloud-init:_config_update_on_running_VM_should_not_fail (17.25s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	29.975s
```

#### Regression check — all initialization tests pass

```
./testacc "TestAccResourceVMInitialization"

ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	77.993s
```

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2707
