### PR TITLE
feat(vm)!: support multi-cdrom management and import

### DIFF
--- a/docs/data-sources/virtual_environment_file.md
+++ b/docs/data-sources/virtual_environment_file.md
@@ -74,7 +74,8 @@ resource "proxmox_virtual_environment_vm" "example" {
   vm_id     = 100
 
   cdrom {
-    file_id = data.proxmox_virtual_environment_file.ubuntu_iso.id
+    interface = "ide2"
+    file_id   = data.proxmox_virtual_environment_file.ubuntu_iso.id
   }
 
   cpu {

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -49,6 +49,16 @@ resource "proxmox_virtual_environment_vm" "ubuntu_vm" {
     interface    = "scsi0"
   }
 
+  cdrom {
+    interface = "ide2"
+    file_id   = "none"
+  }
+
+  cdrom {
+    interface = "sata3"
+    file_id   = proxmox_virtual_environment_download_file.latest_ubuntu_22_jammy_qcow2_img.id
+  }
+
   initialization {
     # uncomment and specify the datastore for cloud-init disk if default `local-lvm` is not available
     # datastore_id = "local-lvm"
@@ -165,15 +175,15 @@ output "ubuntu_vm_public_key" {
     - `ovmf` - OVMF (UEFI).
     - `seabios` - SeaBIOS.
 - `boot_order` - (Optional) Specify a list of devices to boot from in the order they appear in the list.
-- `cdrom` - (Optional) The CD-ROM configuration.
+- `cdrom` - (Optional, repeatable) The CD-ROM configuration. Define one block per CD-ROM drive you want to manage. If no `cdrom` blocks are defined, the provider manages no CD-ROM devices.
     - `enabled` - (Optional) Whether to enable the CD-ROM drive (defaults
         to `false`). *Deprecated*. The attribute will be removed in the next version of the provider.
         Set `file_id` to `none` to leave the CD-ROM drive empty.
     - `file_id` - (Optional) A file ID for an ISO file (defaults to `cdrom` as
         in the physical drive). Use `none` to leave the CD-ROM drive empty.
-    - `interface` - (Optional) A hardware interface to connect CD-ROM drive to (defaults to `ide3`).
-      "Must be one of `ideN`, `sataN`, `scsiN`, where N is the index of the interface. " +
-      "Note that `q35` machine type only supports `ide0` and `ide2` of IDE interfaces.
+    - `interface` - (Required) A hardware interface to connect the CD-ROM drive to.
+      Must be one of `ideN`, `sataN`, `scsiN`, where `N` is the index of the interface.
+      Note that `q35` machine type only supports `ide0` and `ide2` of IDE interfaces.
 - `clone` - (Optional) The cloning configuration.
     - `datastore_id` - (Optional) The identifier for the target datastore.
     - `node_name` - (Optional) The name of the source node (leave blank, if

--- a/example/resource_virtual_environment_vm.tf
+++ b/example/resource_virtual_environment_vm.tf
@@ -94,7 +94,8 @@ resource "proxmox_virtual_environment_vm" "example_template" {
   name    = "terraform-provider-proxmox-example-template"
 
   cdrom {
-    file_id = "none"
+    interface = "ide2"
+    file_id   = "none"
   }
 
   network_device {

--- a/examples/data-sources/proxmox_virtual_environment_file/data-source.tf
+++ b/examples/data-sources/proxmox_virtual_environment_file/data-source.tf
@@ -56,7 +56,8 @@ resource "proxmox_virtual_environment_vm" "example" {
   vm_id     = 100
 
   cdrom {
-    file_id = data.proxmox_virtual_environment_file.ubuntu_iso.id
+    interface = "ide2"
+    file_id   = data.proxmox_virtual_environment_file.ubuntu_iso.id
   }
 
   cpu {

--- a/fwprovider/test/resource_vm_cdrom_test.go
+++ b/fwprovider/test/resource_vm_cdrom_test.go
@@ -9,9 +9,14 @@
 package test
 
 import (
+	"fmt"
+	"math/rand"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccResourceVMCDROM(t *testing.T) {
@@ -41,10 +46,12 @@ func TestAccResourceVMCDROM(t *testing.T) {
 					name 	  = "test-cdrom"
 					cdrom {
 						file_id   = "none"
+						interface = "ide2"
 					}
 				}`),
 				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom", map[string]string{
-					"cdrom.0.file_id": "none",
+					"cdrom.0.file_id":   "none",
+					"cdrom.0.interface": "ide2",
 				}),
 			},
 			{
@@ -100,10 +107,12 @@ func TestAccResourceVMCDROM(t *testing.T) {
 					name 	  = "test-cdrom"
 					cdrom {
 						file_id   = "none"
+						interface = "ide2"
 					}
 				}`),
 				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom", map[string]string{
-					"cdrom.0.file_id": "none",
+					"cdrom.0.file_id":   "none",
+					"cdrom.0.interface": "ide2",
 				}),
 			},
 			{
@@ -114,11 +123,192 @@ func TestAccResourceVMCDROM(t *testing.T) {
 					name 	  = "test-cdrom"
 					cdrom {
 						file_id   = "cdrom"
+						interface = "ide2"
 					}
 				}`),
 				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom", map[string]string{
-					"cdrom.0.file_id": "cdrom",
+					"cdrom.0.file_id":   "cdrom",
+					"cdrom.0.interface": "ide2",
 				}),
+			},
+		}},
+		{"multiple cdroms", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name 	  = "test-cdrom"
+					cdrom {
+						file_id   = "none"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "none"
+						interface = "sata3"
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom", map[string]string{
+					"cdrom.#":           "2",
+					"cdrom.0.interface": "ide2",
+					"cdrom.0.file_id":   "none",
+					"cdrom.1.interface": "sata3",
+					"cdrom.1.file_id":   "none",
+				}),
+			},
+			{
+				RefreshState: true,
+			},
+		}},
+		{"remove one cdrom from multiple", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name 	  = "test-cdrom"
+					cdrom {
+						file_id   = "none"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "none"
+						interface = "sata3"
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom", map[string]string{
+					"cdrom.#":           "2",
+					"cdrom.0.interface": "ide2",
+					"cdrom.1.interface": "sata3",
+				}),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name 	  = "test-cdrom"
+					cdrom {
+						file_id   = "none"
+						interface = "ide2"
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom", map[string]string{
+					"cdrom.#":           "1",
+					"cdrom.0.interface": "ide2",
+					"cdrom.0.file_id":   "none",
+				}),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name 	  = "test-cdrom"
+					cdrom {
+						file_id   = "none"
+						interface = "ide2"
+					}
+				}`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		}},
+		{"clone with multiple cdroms", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "template_cdrom" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-template"
+					template  = true
+
+					cdrom {
+						file_id   = "none"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "none"
+						interface = "sata3"
+					}
+				}
+				resource "proxmox_virtual_environment_vm" "clone_cdrom" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-clone"
+
+					clone {
+						vm_id = proxmox_virtual_environment_vm.template_cdrom.vm_id
+					}
+
+					cdrom {
+						file_id   = "none"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "none"
+						interface = "sata3"
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.clone_cdrom", map[string]string{
+					"cdrom.#":           "2",
+					"cdrom.0.interface": "ide2",
+					"cdrom.0.file_id":   "none",
+					"cdrom.1.interface": "sata3",
+					"cdrom.1.file_id":   "none",
+				}),
+			},
+			{
+				RefreshState: true,
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "template_cdrom" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-template"
+					template  = true
+
+					cdrom {
+						file_id   = "none"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "none"
+						interface = "sata3"
+					}
+				}
+				resource "proxmox_virtual_environment_vm" "clone_cdrom" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-clone"
+
+					clone {
+						vm_id = proxmox_virtual_environment_vm.template_cdrom.vm_id
+					}
+
+					cdrom {
+						file_id   = "none"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "none"
+						interface = "sata3"
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.clone_cdrom", map[string]string{
+					"cdrom.#":           "2",
+					"cdrom.0.interface": "ide2",
+					"cdrom.1.interface": "sata3",
+				}),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		}},
 	}
@@ -133,4 +323,464 @@ func TestAccResourceVMCDROM(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestAccResourceVMCDROMImportMultiple(t *testing.T) {
+	t.Parallel()
+
+	te := InitEnvironment(t)
+	testVMID := 100000 + rand.Intn(99999) //nolint:gosec
+
+	te.AddTemplateVars(map[string]any{
+		"TestVMID": testVMID,
+	})
+
+	config := te.RenderConfig(`
+		resource "proxmox_virtual_environment_vm" "test_cdrom_import" {
+			node_name = "{{.NodeName}}"
+			started   = false
+			vm_id     = {{.TestVMID}}
+			name      = "test-cdrom-import"
+
+			cdrom {
+				file_id   = "none"
+				interface = "ide2"
+			}
+			cdrom {
+				file_id   = "none"
+				interface = "sata3"
+			}
+		}`)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom_import", map[string]string{
+					"cdrom.#":           "2",
+					"cdrom.0.interface": "ide2",
+					"cdrom.1.interface": "sata3",
+				}),
+			},
+			{
+				ResourceName:      "proxmox_virtual_environment_vm.test_cdrom_import",
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     fmt.Sprintf("%s/%d", te.NodeName, testVMID),
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 instance state, got %d", len(states))
+					}
+
+					attrs := states[0].Attributes
+					if attrs["cdrom.#"] != "2" {
+						return fmt.Errorf("expected cdrom.# = 2 after import, got %s", attrs["cdrom.#"])
+					}
+
+					importedCDROMs := map[string]string{
+						attrs["cdrom.0.interface"]: attrs["cdrom.0.file_id"],
+						attrs["cdrom.1.interface"]: attrs["cdrom.1.file_id"],
+					}
+
+					if importedCDROMs["ide2"] != "none" {
+						return fmt.Errorf("expected ide2 cdrom file_id none after import, got %q", importedCDROMs["ide2"])
+					}
+
+					if importedCDROMs["sata3"] != "none" {
+						return fmt.Errorf("expected sata3 cdrom file_id none after import, got %q", importedCDROMs["sata3"])
+					}
+
+					return nil
+				},
+			},
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccResourceVMCDROMInterfaceMove(t *testing.T) {
+	t.Parallel()
+
+	te := InitEnvironment(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom_move" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-move"
+
+					cdrom {
+						file_id   = "none"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "none"
+						interface = "sata3"
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom_move", map[string]string{
+					"cdrom.#":           "2",
+					"cdrom.0.interface": "ide2",
+					"cdrom.1.interface": "sata3",
+				}),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom_move" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-move"
+
+					cdrom {
+						file_id   = "none"
+						interface = "scsi5"
+					}
+					cdrom {
+						file_id   = "none"
+						interface = "sata3"
+					}
+				}`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_cdrom_move", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom_move", map[string]string{
+					"cdrom.#":           "2",
+					"cdrom.0.interface": "sata3",
+					"cdrom.1.interface": "scsi5",
+				}),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom_move" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-move"
+
+					cdrom {
+						file_id   = "none"
+						interface = "scsi5"
+					}
+					cdrom {
+						file_id   = "none"
+						interface = "sata3"
+					}
+				}`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccResourceVMCDROMCloneMultiplePhysical(t *testing.T) {
+	t.Parallel()
+
+	te := InitEnvironment(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "template_cdrom_physical" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-template-physical"
+					template  = true
+
+					cdrom {
+						file_id   = "cdrom"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "cdrom"
+						interface = "sata3"
+					}
+				}
+				resource "proxmox_virtual_environment_vm" "clone_cdrom_physical" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-clone-physical"
+
+					clone {
+						vm_id = proxmox_virtual_environment_vm.template_cdrom_physical.vm_id
+					}
+
+					cdrom {
+						file_id   = "cdrom"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "cdrom"
+						interface = "sata3"
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.clone_cdrom_physical", map[string]string{
+					"cdrom.#":           "2",
+					"cdrom.0.interface": "ide2",
+					"cdrom.0.file_id":   "cdrom",
+					"cdrom.1.interface": "sata3",
+					"cdrom.1.file_id":   "cdrom",
+				}),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "template_cdrom_physical" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-template-physical"
+					template  = true
+
+					cdrom {
+						file_id   = "cdrom"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "cdrom"
+						interface = "sata3"
+					}
+				}
+				resource "proxmox_virtual_environment_vm" "clone_cdrom_physical" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-clone-physical"
+
+					clone {
+						vm_id = proxmox_virtual_environment_vm.template_cdrom_physical.vm_id
+					}
+
+					cdrom {
+						file_id   = "cdrom"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "cdrom"
+						interface = "sata3"
+					}
+				}`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccResourceVMCDROMImportSubsetManaged(t *testing.T) {
+	t.Parallel()
+
+	te := InitEnvironment(t)
+	testVMID := 100000 + rand.Intn(99999) //nolint:gosec
+
+	te.AddTemplateVars(map[string]any{
+		"TestVMID": testVMID,
+	})
+
+	createConfig := te.RenderConfig(`
+		resource "proxmox_virtual_environment_vm" "test_cdrom_subset" {
+			node_name = "{{.NodeName}}"
+			started   = false
+			vm_id     = {{.TestVMID}}
+			name      = "test-cdrom-subset"
+
+			cdrom {
+				file_id   = "none"
+				interface = "ide2"
+			}
+			cdrom {
+				file_id   = "none"
+				interface = "sata3"
+			}
+		}`)
+
+	managedSubsetConfig := te.RenderConfig(`
+		resource "proxmox_virtual_environment_vm" "test_cdrom_subset" {
+			node_name = "{{.NodeName}}"
+			started   = false
+			vm_id     = {{.TestVMID}}
+			name      = "test-cdrom-subset"
+
+			cdrom {
+				file_id   = "none"
+				interface = "ide2"
+			}
+		}`)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: createConfig,
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom_subset", map[string]string{
+					"cdrom.#":           "2",
+					"cdrom.0.interface": "ide2",
+					"cdrom.1.interface": "sata3",
+				}),
+			},
+			{
+				ResourceName:      "proxmox_virtual_environment_vm.test_cdrom_subset",
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     fmt.Sprintf("%s/%d", te.NodeName, testVMID),
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 instance state, got %d", len(states))
+					}
+
+					attrs := states[0].Attributes
+					if attrs["cdrom.#"] != "2" {
+						return fmt.Errorf("expected imported state to include both discovered cdroms, got %s", attrs["cdrom.#"])
+					}
+
+					return nil
+				},
+			},
+			{
+				Config: managedSubsetConfig,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom_subset", map[string]string{
+					"cdrom.#":           "1",
+					"cdrom.0.interface": "ide2",
+					"cdrom.0.file_id":   "none",
+				}),
+			},
+		},
+	})
+}
+
+func TestAccResourceVMCDROMMixedUpdate(t *testing.T) {
+	t.Parallel()
+
+	te := InitEnvironment(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom_mixed_update" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-mixed-update"
+
+					cdrom {
+						file_id   = "none"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "none"
+						interface = "sata3"
+					}
+				}`),
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom_mixed_update", map[string]string{
+					"cdrom.#":           "2",
+					"cdrom.0.interface": "ide2",
+					"cdrom.0.file_id":   "none",
+					"cdrom.1.interface": "sata3",
+					"cdrom.1.file_id":   "none",
+				}),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom_mixed_update" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-mixed-update"
+
+					cdrom {
+						file_id   = "cdrom"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "none"
+						interface = "scsi5"
+					}
+				}`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("proxmox_virtual_environment_vm.test_cdrom_mixed_update", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_cdrom_mixed_update", map[string]string{
+					"cdrom.#":           "2",
+					"cdrom.0.interface": "ide2",
+					"cdrom.0.file_id":   "cdrom",
+					"cdrom.1.interface": "scsi5",
+					"cdrom.1.file_id":   "none",
+				}),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom_mixed_update" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-mixed-update"
+
+					cdrom {
+						file_id   = "cdrom"
+						interface = "ide2"
+					}
+					cdrom {
+						file_id   = "none"
+						interface = "scsi5"
+					}
+				}`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccResourceVMCDROMRejectsInvalidQ35IDEInterface(t *testing.T) {
+	t.Parallel()
+
+	te := InitEnvironment(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_cdrom_q35_invalid_ide" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-cdrom-q35-invalid-ide"
+					machine   = "q35"
+
+					cdrom {
+						file_id   = "none"
+						interface = "ide3"
+					}
+				}`),
+				ExpectError: regexp.MustCompile(`cdrom interface "ide3" is invalid for q35 machine type: only ide0 and ide2 are supported on the IDE bus`),
+			},
+		},
+	})
 }

--- a/fwprovider/test/resource_vm_disks_test.go
+++ b/fwprovider/test/resource_vm_disks_test.go
@@ -2046,6 +2046,287 @@ func TestAccResourceVMDiskCDROMNotInDiskBlock(t *testing.T) {
 	})
 }
 
+// TestAccResourceVMDiskImportKeepsInterfaceMapping verifies that importing a VM
+// with multiple disks on different interfaces and a CD-ROM keeps the correct
+// disk-to-interface mapping and produces no drift afterwards.
+// Regression test for https://github.com/bpg/terraform-provider-proxmox/issues/2285
+func TestAccResourceVMDiskImportKeepsInterfaceMapping(t *testing.T) {
+	t.Parallel()
+
+	te := InitEnvironment(t)
+
+	testVMID := 100000 + rand.Intn(99999) //nolint:gosec
+
+	te.AddTemplateVars(map[string]any{
+		"TestVMID": testVMID,
+	})
+
+	config := te.RenderConfig(`
+		resource "proxmox_virtual_environment_vm" "test_import_interface_mapping" {
+			node_name = "{{.NodeName}}"
+			started   = false
+			vm_id     = {{.TestVMID}}
+			name      = "test-import-interface-mapping"
+
+			cdrom {
+				file_id   = "none"
+				interface = "ide2"
+			}
+
+			disk {
+				datastore_id = "local-lvm"
+				interface    = "ide0"
+				size         = 11
+			}
+
+			disk {
+				datastore_id = "local-lvm"
+				interface    = "scsi0"
+				size         = 23
+			}
+		}`)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_import_interface_mapping", map[string]string{
+					"disk.#":            "2",
+					"cdrom.0.interface": "ide2",
+				}),
+			},
+			{
+				ResourceName:      "proxmox_virtual_environment_vm.test_import_interface_mapping",
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     fmt.Sprintf("%s/%d", te.NodeName, testVMID),
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 instance state, got %d", len(states))
+					}
+
+					attrs := states[0].Attributes
+
+					if attrs["disk.#"] != "2" {
+						return fmt.Errorf("expected disk.# = 2 after import, got %s", attrs["disk.#"])
+					}
+
+					importedDisks := map[string]string{
+						attrs["disk.0.interface"]: attrs["disk.0.size"],
+						attrs["disk.1.interface"]: attrs["disk.1.size"],
+					}
+
+					if importedDisks["ide0"] != "11" {
+						return fmt.Errorf("expected ide0 disk size 11 after import, got %q", importedDisks["ide0"])
+					}
+
+					if importedDisks["scsi0"] != "23" {
+						return fmt.Errorf("expected scsi0 disk size 23 after import, got %q", importedDisks["scsi0"])
+					}
+
+					if attrs["cdrom.0.interface"] != "ide2" {
+						return fmt.Errorf("expected cdrom.0.interface = ide2 after import, got %s", attrs["cdrom.0.interface"])
+					}
+
+					return nil
+				},
+			},
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccResourceVMDiskImportKeepsDiskAndCDROMMappings verifies that importing a VM
+// with multiple disks and multiple CD-ROMs preserves the correct interface mapping
+// for all managed storage devices and produces no drift afterwards.
+func TestAccResourceVMDiskImportKeepsDiskAndCDROMMappings(t *testing.T) {
+	t.Parallel()
+
+	te := InitEnvironment(t)
+
+	testVMID := 100000 + rand.Intn(99999) //nolint:gosec
+
+	te.AddTemplateVars(map[string]any{
+		"TestVMID": testVMID,
+	})
+
+	config := te.RenderConfig(`
+		resource "proxmox_virtual_environment_vm" "test_import_storage_mapping" {
+			node_name = "{{.NodeName}}"
+			started   = false
+			vm_id     = {{.TestVMID}}
+			name      = "test-import-storage-mapping"
+
+			cdrom {
+				file_id   = "none"
+				interface = "ide2"
+			}
+
+			cdrom {
+				file_id   = "cdrom"
+				interface = "ide3"
+			}
+
+			cdrom {
+				file_id   = "none"
+				interface = "sata2"
+			}
+
+			cdrom {
+				file_id   = "cdrom"
+				interface = "scsi2"
+			}
+
+			cdrom {
+				file_id   = "none"
+				interface = "scsi3"
+			}
+
+			disk {
+				datastore_id = "local-lvm"
+				interface    = "ide0"
+				size         = 11
+			}
+
+			disk {
+				datastore_id = "local-lvm"
+				interface    = "scsi0"
+				size         = 23
+			}
+
+			disk {
+				datastore_id = "local-lvm"
+				interface    = "scsi1"
+				size         = 31
+			}
+
+			disk {
+				datastore_id = "local-lvm"
+				interface    = "virtio0"
+				size         = 43
+			}
+
+			disk {
+				datastore_id = "local-lvm"
+				interface    = "sata0"
+				size         = 59
+			}
+		}`)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: ResourceAttributes("proxmox_virtual_environment_vm.test_import_storage_mapping", map[string]string{
+					"disk.#":            "5",
+					"cdrom.#":           "5",
+					"cdrom.0.interface": "ide2",
+					"cdrom.1.interface": "ide3",
+					"cdrom.2.interface": "sata2",
+					"cdrom.3.interface": "scsi2",
+					"cdrom.4.interface": "scsi3",
+				}),
+			},
+			{
+				ResourceName:      "proxmox_virtual_environment_vm.test_import_storage_mapping",
+				ImportState:       true,
+				ImportStateVerify: false,
+				ImportStateId:     fmt.Sprintf("%s/%d", te.NodeName, testVMID),
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 instance state, got %d", len(states))
+					}
+
+					attrs := states[0].Attributes
+
+					if attrs["disk.#"] != "5" {
+						return fmt.Errorf("expected disk.# = 5 after import, got %s", attrs["disk.#"])
+					}
+
+					if attrs["cdrom.#"] != "5" {
+						return fmt.Errorf("expected cdrom.# = 5 after import, got %s", attrs["cdrom.#"])
+					}
+
+					importedDisks := map[string]string{
+						attrs["disk.0.interface"]: attrs["disk.0.size"],
+						attrs["disk.1.interface"]: attrs["disk.1.size"],
+						attrs["disk.2.interface"]: attrs["disk.2.size"],
+						attrs["disk.3.interface"]: attrs["disk.3.size"],
+						attrs["disk.4.interface"]: attrs["disk.4.size"],
+					}
+
+					if importedDisks["ide0"] != "11" {
+						return fmt.Errorf("expected ide0 disk size 11 after import, got %q", importedDisks["ide0"])
+					}
+
+					if importedDisks["scsi0"] != "23" {
+						return fmt.Errorf("expected scsi0 disk size 23 after import, got %q", importedDisks["scsi0"])
+					}
+
+					if importedDisks["scsi1"] != "31" {
+						return fmt.Errorf("expected scsi1 disk size 31 after import, got %q", importedDisks["scsi1"])
+					}
+
+					if importedDisks["virtio0"] != "43" {
+						return fmt.Errorf("expected virtio0 disk size 43 after import, got %q", importedDisks["virtio0"])
+					}
+
+					if importedDisks["sata0"] != "59" {
+						return fmt.Errorf("expected sata0 disk size 59 after import, got %q", importedDisks["sata0"])
+					}
+
+					importedCDROMs := map[string]string{
+						attrs["cdrom.0.interface"]: attrs["cdrom.0.file_id"],
+						attrs["cdrom.1.interface"]: attrs["cdrom.1.file_id"],
+						attrs["cdrom.2.interface"]: attrs["cdrom.2.file_id"],
+						attrs["cdrom.3.interface"]: attrs["cdrom.3.file_id"],
+						attrs["cdrom.4.interface"]: attrs["cdrom.4.file_id"],
+					}
+
+					if importedCDROMs["ide2"] != "none" {
+						return fmt.Errorf("expected ide2 cdrom file_id none after import, got %q", importedCDROMs["ide2"])
+					}
+
+					if importedCDROMs["ide3"] != "cdrom" {
+						return fmt.Errorf("expected ide3 cdrom file_id cdrom after import, got %q", importedCDROMs["ide3"])
+					}
+
+					if importedCDROMs["sata2"] != "none" {
+						return fmt.Errorf("expected sata2 cdrom file_id none after import, got %q", importedCDROMs["sata2"])
+					}
+
+					if importedCDROMs["scsi2"] != "cdrom" {
+						return fmt.Errorf("expected scsi2 cdrom file_id cdrom after import, got %q", importedCDROMs["scsi2"])
+					}
+
+					if importedCDROMs["scsi3"] != "none" {
+						return fmt.Errorf("expected scsi3 cdrom file_id none after import, got %q", importedCDROMs["scsi3"])
+					}
+
+					return nil
+				},
+			},
+			{
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 // TestAccResourceVMDiskResizeNonHotpluggable tests that resizing a disk on a running VM
 // triggers a reboot when disk is excluded from the hotplug setting.
 // Also tests the double-reboot scenario (AIO change + resize with non-hotpluggable disk).

--- a/proxmoxtf/resource/vm/cdrom/cdrom.go
+++ b/proxmoxtf/resource/vm/cdrom/cdrom.go
@@ -1,0 +1,250 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package cdrom
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
+	"github.com/bpg/terraform-provider-proxmox/utils"
+)
+
+func normalizeFileID(fileID string) string {
+	if fileID == "" {
+		return DefaultFileID
+	}
+
+	return fileID
+}
+
+// GetCDROMDeviceObjects converts configured CD-ROM blocks into storage devices keyed by interface.
+func GetCDROMDeviceObjects(cdrom []any) vms.CustomStorageDevices {
+	cdromMedia := "cdrom"
+	deviceObjects := vms.CustomStorageDevices{}
+
+	for _, entry := range cdrom {
+		if entry == nil {
+			continue
+		}
+
+		block := entry.(map[string]any)
+
+		cdromInterface, _ := block[MkCDROMInterface].(string)
+		if cdromInterface == "" {
+			continue
+		}
+
+		cdromFileID, _ := block[MkCDROMFileID].(string)
+		deviceObjects[cdromInterface] = &vms.CustomStorageDevice{
+			FileVolume: normalizeFileID(cdromFileID),
+			Media:      &cdromMedia,
+		}
+	}
+
+	return deviceObjects
+}
+
+// GetCDROMStorageDevices filters VM storage devices down to attached CD-ROM devices only.
+func GetCDROMStorageDevices(vmConfig *vms.GetResponseData) vms.CustomStorageDevices {
+	cdromDevices := vms.CustomStorageDevices{}
+
+	for iface, dev := range vmConfig.StorageDevices {
+		if dev == nil || dev.Media == nil || *dev.Media != "cdrom" {
+			continue
+		}
+
+		cdromDevices[iface] = dev
+	}
+
+	return cdromDevices
+}
+
+// OrderedInterfaces returns CD-ROM interfaces in state order first, then any newly discovered interfaces.
+func OrderedInterfaces(cdrom []any, deviceObjects vms.CustomStorageDevices) []string {
+	interfaces := utils.ListResourcesAttributeValue(cdrom, MkCDROMInterface)
+	if len(interfaces) == 0 {
+		return orderedKeys(deviceObjects)
+	}
+
+	ordered := make([]string, 0, len(deviceObjects))
+
+	for _, iface := range interfaces {
+		if _, ok := deviceObjects[iface]; ok {
+			ordered = append(ordered, iface)
+		}
+	}
+
+	for _, iface := range orderedKeys(deviceObjects) {
+		if slices.Contains(ordered, iface) {
+			continue
+		}
+
+		ordered = append(ordered, iface)
+	}
+
+	return ordered
+}
+
+// MergeCloneDevices adds planned CD-ROM devices into the clone storage device set.
+func MergeCloneDevices(planCDROMs vms.CustomStorageDevices, storageDevices vms.CustomStorageDevices) {
+	maps.Copy(storageDevices, planCDROMs)
+}
+
+// ValidateInterfacesForMachine enforces machine-specific CD-ROM interface restrictions.
+func ValidateInterfacesForMachine(machineType string, cdrom []any) error {
+	if !isQ35MachineType(machineType) {
+		return nil
+	}
+
+	for _, entry := range cdrom {
+		if entry == nil {
+			continue
+		}
+
+		block, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		cdromInterface, _ := block[MkCDROMInterface].(string)
+		if !strings.HasPrefix(cdromInterface, "ide") {
+			continue
+		}
+
+		if cdromInterface == "ide0" || cdromInterface == "ide2" {
+			continue
+		}
+
+		return fmt.Errorf(
+			"cdrom interface %q is invalid for q35 machine type: only ide0 and ide2 are supported on the IDE bus",
+			cdromInterface,
+		)
+	}
+
+	return nil
+}
+
+// BuildState reconstructs Terraform CD-ROM state from current devices while preserving legacy empty file_id values.
+func BuildState(currentCDROM []any, deviceObjects vms.CustomStorageDevices, isClone bool) []any {
+	cdromMap := map[string]any{}
+	currentCDROMMap := utils.MapResourcesByAttribute(currentCDROM, MkCDROMInterface)
+
+	for iface, dev := range deviceObjects {
+		cdromBlock := map[string]any{
+			MkCDROMFileID:    dev.FileVolume,
+			MkCDROMInterface: iface,
+		}
+
+		if currentBlock, ok := currentCDROMMap[iface].(map[string]any); ok {
+			preserveLegacyEmptyFileID(currentBlock, cdromBlock)
+		}
+
+		cdromMap[iface] = cdromBlock
+	}
+
+	if isClone && len(currentCDROM) == 0 {
+		return nil
+	}
+
+	if len(currentCDROM) > 0 {
+		interfaces := utils.ListResourcesAttributeValue(currentCDROM, MkCDROMInterface)
+		cdromList := utils.OrderedListFromMapByKeyValues(cdromMap, interfaces)
+		cdromList = slices.DeleteFunc(cdromList, func(v any) bool { return v == nil })
+
+		for _, iface := range interfaces {
+			delete(cdromMap, iface)
+		}
+
+		if len(cdromMap) > 0 {
+			cdromList = append(cdromList, utils.OrderedListFromMap(cdromMap)...)
+		}
+
+		return cdromList
+	}
+
+	return utils.OrderedListFromMap(cdromMap)
+}
+
+// Read loads reconstructed CD-ROM state into the Terraform resource data.
+func Read(d *schema.ResourceData, deviceObjects vms.CustomStorageDevices, isClone bool) diag.Diagnostics {
+	currentCDROM := d.Get(MkCDROM).([]any)
+
+	cdromState := BuildState(currentCDROM, deviceObjects, isClone)
+	if cdromState == nil {
+		return nil
+	}
+
+	return diag.FromErr(d.Set(MkCDROM, cdromState))
+}
+
+// Update diffs the prior and planned CD-ROM sets and records the needed storage device changes.
+func Update(d *schema.ResourceData, updateBody *vms.UpdateRequestBody, del []string) []string {
+	if !d.HasChange(MkCDROM) {
+		return del
+	}
+
+	old, _ := d.GetChange(MkCDROM)
+	oldCDROMs := GetCDROMDeviceObjects(old.([]any))
+	newCDROMs := GetCDROMDeviceObjects(d.Get(MkCDROM).([]any))
+
+	return applyDeviceObjectDiff(oldCDROMs, newCDROMs, updateBody, del)
+}
+
+func applyDeviceObjectDiff(
+	oldCDROMs vms.CustomStorageDevices,
+	newCDROMs vms.CustomStorageDevices,
+	updateBody *vms.UpdateRequestBody,
+	del []string,
+) []string {
+	toCreate, toUpdate, toDelete := utils.MapDiff(newCDROMs, oldCDROMs)
+
+	for iface := range toDelete {
+		del = append(del, iface)
+	}
+
+	for iface, dev := range toCreate {
+		updateBody.AddCustomStorageDevice(iface, *dev)
+	}
+
+	for iface, dev := range toUpdate {
+		updateBody.AddCustomStorageDevice(iface, *dev)
+	}
+
+	return del
+}
+
+func preserveLegacyEmptyFileID(currentBlock map[string]any, nextBlock map[string]any) {
+	currentFileID, ok := currentBlock[MkCDROMFileID].(string)
+	if !ok || currentFileID != "" {
+		return
+	}
+
+	nextBlock[MkCDROMFileID] = ""
+}
+
+func isQ35MachineType(machineType string) bool {
+	return strings.HasPrefix(machineType, "q35") || strings.HasPrefix(machineType, "pc-q35-")
+}
+
+func orderedKeys(deviceObjects vms.CustomStorageDevices) []string {
+	keys := make([]string, 0, len(deviceObjects))
+
+	for iface := range deviceObjects {
+		keys = append(keys, iface)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}

--- a/proxmoxtf/resource/vm/cdrom/cdrom_test.go
+++ b/proxmoxtf/resource/vm/cdrom/cdrom_test.go
@@ -1,0 +1,423 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package cdrom
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
+)
+
+// Conversion helpers.
+
+func TestGetCDROMDeviceObjects(t *testing.T) {
+	t.Parallel()
+
+	deviceObjects := GetCDROMDeviceObjects([]any{
+		map[string]any{
+			MkCDROMInterface: "ide2",
+			MkCDROMFileID:    "none",
+		},
+		map[string]any{
+			MkCDROMInterface: "sata3",
+			MkCDROMFileID:    "",
+		},
+	})
+
+	require.Len(t, deviceObjects, 2)
+	require.Equal(t, "none", deviceObjects["ide2"].FileVolume)
+	require.Equal(t, "cdrom", deviceObjects["sata3"].FileVolume)
+	require.NotNil(t, deviceObjects["ide2"].Media)
+	require.Equal(t, "cdrom", *deviceObjects["ide2"].Media)
+}
+
+func TestGetCDROMStorageDevices(t *testing.T) {
+	t.Parallel()
+
+	cdromMedia := "cdrom"
+	diskMedia := "disk"
+
+	vmConfig := &vms.GetResponseData{
+		StorageDevices: vms.CustomStorageDevices{
+			"ide2": {
+				FileVolume: "none",
+				Media:      &cdromMedia,
+			},
+			"sata3": {
+				FileVolume: "local:iso/example.iso",
+				Media:      &cdromMedia,
+			},
+			"scsi0": {
+				FileVolume: "local-lvm:vm-100-disk-0",
+				Media:      &diskMedia,
+			},
+		},
+	}
+
+	cdroms := GetCDROMStorageDevices(vmConfig)
+
+	require.Len(t, cdroms, 2)
+	require.Contains(t, cdroms, "ide2")
+	require.Contains(t, cdroms, "sata3")
+	require.NotContains(t, cdroms, "scsi0")
+}
+
+// Schema.
+
+func TestSchema(t *testing.T) {
+	t.Parallel()
+
+	s := Schema()
+	require.Contains(t, s, MkCDROM)
+
+	cdromSchema := s[MkCDROM].Elem.(*schema.Resource).Schema
+	require.True(t, cdromSchema[MkCDROMInterface].Required)
+	require.False(t, cdromSchema[MkCDROMInterface].Optional)
+	require.Equal(t, DefaultFileID, cdromSchema[MkCDROMFileID].Default)
+}
+
+// Read and state building.
+
+func TestBuildStatePreservesOrderingAndExplicitEmptyFileID(t *testing.T) {
+	t.Parallel()
+
+	currentCDROMList := []any{
+		map[string]any{
+			MkCDROMInterface: "sata3",
+			MkCDROMFileID:    "",
+		},
+		map[string]any{
+			MkCDROMInterface: "ide2",
+			MkCDROMFileID:    "none",
+		},
+	}
+
+	cdromMedia := "cdrom"
+	deviceObjects := vms.CustomStorageDevices{
+		"ide2": {
+			FileVolume: "none",
+			Media:      &cdromMedia,
+		},
+		"sata3": {
+			FileVolume: "cdrom",
+			Media:      &cdromMedia,
+		},
+	}
+
+	cdromList := BuildState(currentCDROMList, deviceObjects, false)
+	require.Len(t, cdromList, 2)
+
+	first := cdromList[0].(map[string]any)
+	second := cdromList[1].(map[string]any)
+
+	require.Equal(t, "sata3", first[MkCDROMInterface])
+	require.Empty(t, first[MkCDROMFileID], "explicit empty file_id should be preserved from current state")
+	require.Equal(t, "ide2", second[MkCDROMInterface])
+	require.Equal(t, "none", second[MkCDROMFileID])
+}
+
+func TestReadPreservesOrderingAndExplicitEmptyFileID(t *testing.T) {
+	t.Parallel()
+
+	cdromSchema := Schema()
+	currentCDROMList := []any{
+		map[string]any{
+			MkCDROMInterface: "sata3",
+			MkCDROMFileID:    "",
+		},
+		map[string]any{
+			MkCDROMInterface: "ide2",
+			MkCDROMFileID:    "none",
+		},
+	}
+
+	resourceData := schema.TestResourceDataRaw(t, cdromSchema, map[string]any{
+		MkCDROM: currentCDROMList,
+	})
+
+	cdromMedia := "cdrom"
+	deviceObjects := vms.CustomStorageDevices{
+		"ide2": {
+			FileVolume: "none",
+			Media:      &cdromMedia,
+		},
+		"sata3": {
+			FileVolume: "cdrom",
+			Media:      &cdromMedia,
+		},
+	}
+
+	diags := Read(resourceData, deviceObjects, false)
+	require.Empty(t, diags)
+
+	cdromList := resourceData.Get(MkCDROM).([]any)
+	require.Len(t, cdromList, 2)
+
+	first := cdromList[0].(map[string]any)
+	second := cdromList[1].(map[string]any)
+
+	require.Equal(t, "sata3", first[MkCDROMInterface])
+	require.Empty(t, first[MkCDROMFileID], "explicit empty file_id should be preserved from current state")
+	require.Equal(t, "ide2", second[MkCDROMInterface])
+	require.Equal(t, "none", second[MkCDROMFileID])
+}
+
+func TestBuildStateSkipsCloneWithoutCurrentState(t *testing.T) {
+	t.Parallel()
+
+	cdromMedia := "cdrom"
+	deviceObjects := vms.CustomStorageDevices{
+		"ide2": {
+			FileVolume: "none",
+			Media:      &cdromMedia,
+		},
+	}
+
+	require.Nil(t, BuildState(nil, deviceObjects, true))
+}
+
+func TestReadSkipsSettingCDROMForCloneWithoutCurrentState(t *testing.T) {
+	t.Parallel()
+
+	cdromSchema := Schema()
+	resourceData := schema.TestResourceDataRaw(t, cdromSchema, map[string]any{})
+
+	cdromMedia := "cdrom"
+	deviceObjects := vms.CustomStorageDevices{
+		"ide2": {
+			FileVolume: "none",
+			Media:      &cdromMedia,
+		},
+	}
+
+	diags := Read(resourceData, deviceObjects, true)
+	require.Empty(t, diags)
+	require.Empty(t, resourceData.Get(MkCDROM).([]any))
+}
+
+// Clone and update behavior.
+
+func TestMergeCloneDevices(t *testing.T) {
+	t.Parallel()
+
+	ideDevices := vms.CustomStorageDevices{
+		"ide1": {
+			FileVolume: "existing",
+		},
+	}
+
+	MergeCloneDevices(GetCDROMDeviceObjects([]any{
+		map[string]any{
+			MkCDROMInterface: "ide2",
+			MkCDROMFileID:    "none",
+		},
+		map[string]any{
+			MkCDROMInterface: "sata3",
+			MkCDROMFileID:    "cdrom",
+		},
+	}), ideDevices)
+
+	require.Len(t, ideDevices, 3)
+	require.Equal(t, "existing", ideDevices["ide1"].FileVolume)
+	require.Equal(t, "none", ideDevices["ide2"].FileVolume)
+	require.Equal(t, "cdrom", ideDevices["sata3"].FileVolume)
+}
+
+func TestApplyDeviceObjectDiff(t *testing.T) {
+	t.Parallel()
+
+	updateBody := &vms.UpdateRequestBody{}
+	del := applyDeviceObjectDiff(
+		GetCDROMDeviceObjects([]any{
+			map[string]any{
+				MkCDROMInterface: "ide2",
+				MkCDROMFileID:    "none",
+			},
+			map[string]any{
+				MkCDROMInterface: "sata3",
+				MkCDROMFileID:    "none",
+			},
+		}),
+		GetCDROMDeviceObjects([]any{
+			map[string]any{
+				MkCDROMInterface: "ide2",
+				MkCDROMFileID:    "cdrom",
+			},
+			map[string]any{
+				MkCDROMInterface: "scsi5",
+				MkCDROMFileID:    "none",
+			},
+		}),
+		updateBody,
+		nil,
+	)
+
+	require.Equal(t, []string{"sata3"}, del)
+	require.NotNil(t, updateBody.CustomStorageDevices)
+	require.Len(t, updateBody.CustomStorageDevices, 2)
+
+	require.Equal(t, "cdrom", updateBody.CustomStorageDevices["ide2"].FileVolume)
+	require.Equal(t, "none", updateBody.CustomStorageDevices["scsi5"].FileVolume)
+}
+
+// Ordering and compatibility.
+
+func TestReadDeterministicOrdering(t *testing.T) {
+	t.Parallel()
+
+	cdromSchema := Schema()
+	currentCDROMList := []any{
+		map[string]any{
+			MkCDROMInterface: "scsi3",
+			MkCDROMFileID:    "none",
+		},
+		map[string]any{
+			MkCDROMInterface: "ide2",
+			MkCDROMFileID:    "cdrom",
+		},
+	}
+
+	cdromMedia := "cdrom"
+	deviceObjects := vms.CustomStorageDevices{
+		"ide2": {
+			FileVolume: "cdrom",
+			Media:      &cdromMedia,
+		},
+		"scsi3": {
+			FileVolume: "none",
+			Media:      &cdromMedia,
+		},
+	}
+
+	const iterations = 5
+	results := make([][]any, 0, iterations)
+
+	for range iterations {
+		resourceData := schema.TestResourceDataRaw(t, cdromSchema, map[string]any{
+			MkCDROM: currentCDROMList,
+		})
+
+		diags := Read(resourceData, deviceObjects, false)
+		require.Empty(t, diags)
+
+		results = append(results, resourceData.Get(MkCDROM).([]any))
+	}
+
+	expected := results[0]
+	for i, result := range results {
+		require.True(t, reflect.DeepEqual(expected, result), "iteration %d differed from expected ordering", i)
+	}
+}
+
+func TestBuildStateDefaultsFileIDToCDROM(t *testing.T) {
+	t.Parallel()
+
+	cdromMedia := "cdrom"
+	deviceObjects := vms.CustomStorageDevices{
+		"ide2": {
+			FileVolume: DefaultFileID,
+			Media:      &cdromMedia,
+		},
+	}
+
+	cdromList := BuildState([]any{
+		map[string]any{
+			MkCDROMInterface: "ide2",
+			MkCDROMFileID:    DefaultFileID,
+		},
+	}, deviceObjects, false)
+
+	require.Len(t, cdromList, 1)
+	require.Equal(t, DefaultFileID, cdromList[0].(map[string]any)[MkCDROMFileID])
+}
+
+func TestOrderedInterfaces(t *testing.T) {
+	t.Parallel()
+
+	deviceObjects := vms.CustomStorageDevices{
+		"ide2":  {},
+		"sata3": {},
+		"scsi5": {},
+	}
+
+	ordered := OrderedInterfaces([]any{
+		map[string]any{
+			MkCDROMInterface: "sata3",
+		},
+		map[string]any{
+			MkCDROMInterface: "ide2",
+		},
+	}, deviceObjects)
+
+	require.Equal(t, []string{"sata3", "ide2", "scsi5"}, ordered)
+}
+
+// Validation.
+
+func TestValidateInterfacesForMachine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		machineType string
+		cdrom       []any
+		wantErr     string
+	}{
+		{
+			name:        "non q35 allows ide3",
+			machineType: "pc",
+			cdrom:       []any{map[string]any{MkCDROMInterface: "ide3"}},
+		},
+		{
+			name:        "q35 allows ide0 and ide2",
+			machineType: "q35",
+			cdrom: []any{
+				map[string]any{MkCDROMInterface: "ide0"},
+				map[string]any{MkCDROMInterface: "ide2"},
+			},
+		},
+		{
+			name:        "q35 allows sata and scsi",
+			machineType: "pc-q35-9.0+pve1",
+			cdrom: []any{
+				map[string]any{MkCDROMInterface: "sata3"},
+				map[string]any{MkCDROMInterface: "scsi5"},
+			},
+		},
+		{
+			name:        "q35 rejects ide1",
+			machineType: "q35,viommu=virtio",
+			cdrom:       []any{map[string]any{MkCDROMInterface: "ide1"}},
+			wantErr:     `cdrom interface "ide1" is invalid for q35 machine type: only ide0 and ide2 are supported on the IDE bus`,
+		},
+		{
+			name:        "q35 rejects ide3",
+			machineType: "pc-q35-8.1",
+			cdrom:       []any{map[string]any{MkCDROMInterface: "ide3"}},
+			wantErr:     `cdrom interface "ide3" is invalid for q35 machine type: only ide0 and ide2 are supported on the IDE bus`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateInterfacesForMachine(tt.machineType, tt.cdrom)
+
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.EqualError(t, err, tt.wantErr)
+		})
+	}
+}

--- a/proxmoxtf/resource/vm/cdrom/schema.go
+++ b/proxmoxtf/resource/vm/cdrom/schema.go
@@ -1,0 +1,77 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package cdrom
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/validators"
+	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/structure"
+)
+
+const (
+	DefaultEnabled = false
+	DefaultFileID  = "cdrom"
+
+	MkCDROM          = "cdrom"
+	MkCDROMEnabled   = "enabled"
+	MkCDROMFileID    = "file_id"
+	MkCDROMInterface = "interface"
+)
+
+func InterfaceValidator() schema.SchemaValidateDiagFunc {
+	return validation.ToDiagFunc(validation.StringMatch(
+		regexp.MustCompile(`^(ide[0-3]|sata[0-5]|scsi([0-9]|1[0-3]))$`),
+		"must be one of `ide[0-3]`, `sata[0-5]`, `scsi[0-13]`",
+	))
+}
+
+func Schema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		MkCDROM: {
+			Type:        schema.TypeList,
+			Description: "The CDROM drive",
+			Optional:    true,
+			DiffSuppressFunc: structure.SuppressIfListsOfMapsAreEqualIgnoringOrderByKey(
+				MkCDROMInterface,
+			),
+			DiffSuppressOnRefresh: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					MkCDROMEnabled: {
+						Type:        schema.TypeBool,
+						Description: "Whether to enable the CDROM drive",
+						Optional:    true,
+						Default:     DefaultEnabled,
+						Deprecated: "Remove this attribute's configuration as it is no longer used and the attribute will " +
+							"be removed in the next version of the provider. Set `file_id` to `none` to leave the CDROM drive empty.",
+					},
+					MkCDROMFileID: {
+						Type:        schema.TypeString,
+						Description: "The file id",
+						Optional:    true,
+						Default:     DefaultFileID,
+						ValidateDiagFunc: validation.AnyDiag(
+							validation.ToDiagFunc(validation.StringInSlice([]string{"none", "cdrom"}, false)),
+							validators.FileID(),
+						),
+					},
+					MkCDROMInterface: {
+						Type:             schema.TypeString,
+						Description:      "The CDROM interface",
+						Required:         true,
+						ValidateDiagFunc: InterfaceValidator(),
+					},
+				},
+			},
+			MinItems: 0,
+		},
+	}
+}

--- a/proxmoxtf/resource/vm/validators.go
+++ b/proxmoxtf/resource/vm/validators.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	vmcdrom "github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/cdrom"
 )
 
 // VMIDValidator returns a schema validation function for a VM ID.
@@ -301,12 +303,9 @@ func SCSIHardwareValidator() schema.SchemaValidateDiagFunc {
 	}, false))
 }
 
-// CDROMInterfaceValidator is a schema validation function for IDE interfaces.
+// CDROMInterfaceValidator is a schema validation function for CD-ROM-capable storage interfaces.
 func CDROMInterfaceValidator() schema.SchemaValidateDiagFunc {
-	return validation.ToDiagFunc(validation.StringMatch(
-		regexp.MustCompile(`^(ide[0-3]|sata[0-5]|scsi([0-9]|1[0-3]))$`),
-		"must be one of `ide[0-3]`, `sata[0-5]`, `scsi[0-13]`",
-	))
+	return vmcdrom.InterfaceValidator()
 }
 
 // VirtiofsCacheValidator is a schema validation function for virtiofs cache configs.

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -37,6 +38,7 @@ import (
 	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/validators"
+	vmcdrom "github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/cdrom"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/disk"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/network"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/structure"
@@ -61,9 +63,6 @@ const (
 	dvAudioDeviceDriver   = "spice"
 	dvAudioDeviceEnabled  = true
 	dvBIOS                = "seabios"
-	dvCDROMEnabled        = false
-	dvCDROMFileID         = ""
-	dvCDROMInterface      = "ide3"
 	dvCloneDatastoreID    = ""
 	dvCloneNodeName       = ""
 	dvCloneFull           = true
@@ -182,10 +181,10 @@ const (
 	mkAudioDeviceDriver   = "driver"
 	mkAudioDeviceEnabled  = "enabled"
 	mkBIOS                = "bios"
-	mkCDROM               = "cdrom"
-	mkCDROMEnabled        = "enabled"
-	mkCDROMFileID         = "file_id"
-	mkCDROMInterface      = "interface"
+	mkCDROM               = vmcdrom.MkCDROM
+	mkCDROMEnabled        = vmcdrom.MkCDROMEnabled
+	mkCDROMFileID         = vmcdrom.MkCDROMFileID
+	mkCDROMInterface      = vmcdrom.MkCDROMInterface
 	mkClone               = "clone"
 	mkCloneRetries        = "retries"
 	mkCloneDatastoreID    = "datastore_id"
@@ -536,50 +535,7 @@ func VM() *schema.Resource {
 			Default:          dvBIOS,
 			ValidateDiagFunc: BIOSValidator(),
 		},
-		mkCDROM: {
-			Type:        schema.TypeList,
-			Description: "The CDROM drive",
-			Optional:    true,
-			DefaultFunc: func() (any, error) {
-				return []any{
-					map[string]any{
-						mkCDROMFileID:    dvCDROMFileID,
-						mkCDROMInterface: dvCDROMInterface,
-					},
-				}, nil
-			},
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					mkCDROMEnabled: {
-						Type:        schema.TypeBool,
-						Description: "Whether to enable the CDROM drive",
-						Optional:    true,
-						Default:     dvCDROMEnabled,
-						Deprecated: "Remove this attribute's configuration as it is no longer used and the attribute will " +
-							"be removed in the next version of the provider. Set `file_id` to `none` to leave the CDROM drive empty.",
-					},
-					mkCDROMFileID: {
-						Type:        schema.TypeString,
-						Description: "The file id",
-						Optional:    true,
-						Default:     dvCDROMFileID,
-						ValidateDiagFunc: validation.AnyDiag(
-							validation.ToDiagFunc(validation.StringInSlice([]string{"none", "cdrom"}, false)),
-							validators.FileID(),
-						),
-					},
-					mkCDROMInterface: {
-						Type:             schema.TypeString,
-						Description:      "The CDROM interface",
-						Optional:         true,
-						Default:          dvCDROMInterface,
-						ValidateDiagFunc: CDROMInterfaceValidator(),
-					},
-				},
-			},
-			MaxItems: 1,
-			MinItems: 0,
-		},
+		mkCDROM: vmcdrom.Schema()[mkCDROM],
 		mkClone: {
 			Type:        schema.TypeList,
 			Description: "The cloning configuration",
@@ -1747,6 +1703,7 @@ func VM() *schema.Resource {
 		DeleteContext: vmDelete,
 		CustomizeDiff: customdiff.All(
 			customdiff.All(network.CustomizeDiff()...),
+			validateCDROMInterfacesForMachineType,
 			customdiff.ForceNewIf(
 				mkVMID,
 				func(_ context.Context, d *schema.ResourceDiff, _ any) bool {
@@ -1792,6 +1749,13 @@ func VM() *schema.Resource {
 			},
 		},
 	}
+}
+
+func validateCDROMInterfacesForMachineType(_ context.Context, d *schema.ResourceDiff, _ any) error {
+	machineType, _ := d.Get(mkMachine).(string)
+	cdromDevices, _ := d.Get(mkCDROM).([]any)
+
+	return vmcdrom.ValidateInterfacesForMachine(machineType, cdromDevices)
 }
 
 func forceNewOnTPMVersionChange(ctx context.Context, d *schema.ResourceDiff, _ any) error {
@@ -1934,16 +1898,6 @@ func findExistingCloudInitDrive(vmConfig *vms.GetResponseData, vmID int, default
 	}
 
 	return defaultValue, nil
-}
-
-// Return a pointer to the storage device configuration based on a name. The device name is assumed to be a
-// valid ide, sata, or scsi interface name.
-func getStorageDevice(vmConfig *vms.GetResponseData, deviceName string) *vms.CustomStorageDevice {
-	if dev, ok := vmConfig.StorageDevices[deviceName]; ok {
-		return dev
-	}
-
-	return nil
 }
 
 // Delete IDE interfaces that can then be used for CloudInit. The first interface will always
@@ -2551,23 +2505,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m any) diag.Diag
 		updateBody.SCSIHardware = &scsiHardware
 	}
 
-	if len(cdrom) > 0 && cdrom[0] != nil {
-		cdromBlock := cdrom[0].(map[string]any)
-
-		cdromFileID := cdromBlock[mkCDROMFileID].(string)
-		cdromInterface := cdromBlock[mkCDROMInterface].(string)
-
-		if cdromFileID == "" {
-			cdromFileID = "cdrom"
-		}
-
-		cdromMedia := "cdrom"
-
-		ideDevices[cdromInterface] = &vms.CustomStorageDevice{
-			FileVolume: cdromFileID,
-			Media:      &cdromMedia,
-		}
-	}
+	vmcdrom.MergeCloneDevices(vmcdrom.GetCDROMDeviceObjects(cdrom), ideDevices)
 
 	if len(cpu) > 0 && cpu[0] != nil {
 		cpuBlock := cpu[0].(map[string]any)
@@ -2669,7 +2607,7 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m any) diag.Diag
 		updateBody.USBDevices = vmGetHostUSBDeviceObjects(d)
 	}
 
-	if len(cdrom) > 0 || len(initialization) > 0 {
+	if len(ideDevices) > 0 || len(initialization) > 0 {
 		for iface, dev := range ideDevices {
 			updateBody.AddCustomStorageDevice(iface, *dev)
 		}
@@ -3017,19 +2955,8 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 
 	bios := d.Get(mkBIOS).(string)
 
-	cdromFileID := ""
-	cdromInterface := ""
-
 	cdrom := d.Get(mkCDROM).([]any)
-	if len(cdrom) > 0 {
-		cdromBlock := cdrom[0].(map[string]any)
-		cdromFileID = cdromBlock[mkCDROMFileID].(string)
-		cdromInterface = cdromBlock[mkCDROMInterface].(string)
-
-		if cdromFileID == "" {
-			cdromFileID = "cdrom"
-		}
-	}
+	cdromDeviceObjects := vmcdrom.GetCDROMDeviceObjects(cdrom)
 
 	initializationFileVolume := ""
 	initializationInterface := ""
@@ -3198,9 +3125,7 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 	bootOrder := d.Get(mkBootOrder).([]any)
 
 	if len(bootOrder) == 0 {
-		if cdromInterface != "" {
-			bootOrderConverted = []string{cdromInterface}
-		}
+		bootOrderConverted = append(bootOrderConverted, vmcdrom.OrderedInterfaces(cdrom, cdromDeviceObjects)...)
 
 		if _, ok := diskDeviceObjects["ide0"]; ok {
 			bootOrderConverted = append(bootOrderConverted, "ide0")
@@ -3233,8 +3158,6 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		cpuFlagsConverted[fi] = flag.(string)
 	}
 
-	cdromMedia := "cdrom"
-
 	if initializationInterface != "" {
 		device := &vms.CustomStorageDevice{
 			FileVolume: initializationFileVolume,
@@ -3247,12 +3170,7 @@ func vmCreateCustom(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 		diskDeviceObjects[initializationInterface] = device
 	}
 
-	if cdromInterface != "" {
-		diskDeviceObjects[cdromInterface] = &vms.CustomStorageDevice{
-			FileVolume: cdromFileID,
-			Media:      &cdromMedia,
-		}
-	}
+	maps.Copy(diskDeviceObjects, cdromDeviceObjects)
 
 	var memorySharedObject *vms.CustomSharedMemory
 
@@ -4479,42 +4397,7 @@ func vmReadCustom(
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
-	// Compare the IDE devices to the CD-ROM configurations stored in the state.
-	currentInterface := dvCDROMInterface
-
-	currentCDROM := d.Get(mkCDROM).([]any)
-	if len(currentCDROM) > 0 && currentCDROM[0] != nil {
-		currentBlock := currentCDROM[0].(map[string]any)
-		currentInterface = currentBlock[mkCDROMInterface].(string)
-	}
-
-	cdromIDEDevice := getStorageDevice(vmConfig, currentInterface)
-
-	if cdromIDEDevice != nil {
-		cdrom := make([]any, 1)
-		cdromBlock := map[string]any{}
-
-		if len(clone) == 0 || len(currentCDROM) > 0 {
-			cdromBlock[mkCDROMFileID] = cdromIDEDevice.FileVolume
-			cdromBlock[mkCDROMInterface] = currentInterface
-
-			if len(currentCDROM) > 0 && currentCDROM[0] != nil {
-				currentBlock := currentCDROM[0].(map[string]any)
-
-				if currentBlock[mkCDROMFileID] == "" {
-					cdromBlock[mkCDROMFileID] = ""
-				}
-			}
-
-			cdrom[0] = cdromBlock
-
-			err := d.Set(mkCDROM, cdrom)
-			diags = append(diags, diag.FromErr(err)...)
-		}
-	} else {
-		err := d.Set(mkCDROM, []any{})
-		diags = append(diags, diag.FromErr(err)...)
-	}
+	diags = append(diags, vmcdrom.Read(d, vmcdrom.GetCDROMStorageDevices(vmConfig), len(clone) > 0)...)
 
 	// Compare the CPU configuration to the one stored in the state.
 	cpu := map[string]any{}
@@ -5982,49 +5865,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 
 	// Prepare the new CD-ROM configuration.
 
-	if d.HasChange(mkCDROM) {
-		cdromBlock, err := structure.GetSchemaBlock(
-			resource,
-			d,
-			[]string{mkCDROM},
-			0,
-			true,
-		)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-
-		cdromFileID := cdromBlock[mkCDROMFileID].(string)
-		cdromInterface := cdromBlock[mkCDROMInterface].(string)
-
-		old, _ := d.GetChange(mkCDROM)
-
-		if len(old.([]any)) > 0 && old.([]any)[0] != nil {
-			oldList := old.([]any)[0]
-			oldBlock := oldList.(map[string]any)
-
-			// If the interface is not set, use the default, for backward compatibility.
-			oldInterface, ok := oldBlock[mkCDROMInterface].(string)
-			if !ok || oldInterface == "" {
-				oldInterface = dvCDROMInterface
-			}
-
-			if oldInterface != cdromInterface {
-				del = append(del, oldInterface)
-			}
-		}
-
-		if cdromFileID == "" {
-			cdromFileID = "cdrom"
-		}
-
-		cdromMedia := "cdrom"
-
-		updateBody.AddCustomStorageDevice(cdromInterface, vms.CustomStorageDevice{
-			FileVolume: cdromFileID,
-			Media:      &cdromMedia,
-		})
-	}
+	del = vmcdrom.Update(d, updateBody, del)
 
 	// Prepare the new CPU configuration.
 

--- a/proxmoxtf/resource/vm/vm_test.go
+++ b/proxmoxtf/resource/vm/vm_test.go
@@ -128,14 +128,19 @@ func TestVMSchema(t *testing.T) {
 
 	cdromSchema := test.AssertNestedSchemaExistence(t, s, mkCDROM)
 
+	test.AssertRequiredArguments(t, cdromSchema, []string{
+		mkCDROMInterface,
+	})
+
 	test.AssertOptionalArguments(t, cdromSchema, []string{
 		mkCDROMEnabled,
 		mkCDROMFileID,
 	})
 
 	test.AssertValueTypes(t, cdromSchema, map[string]schema.ValueType{
-		mkCDROMEnabled: schema.TypeBool,
-		mkCDROMFileID:  schema.TypeString,
+		mkCDROMEnabled:   schema.TypeBool,
+		mkCDROMFileID:    schema.TypeString,
+		mkCDROMInterface: schema.TypeString,
 	})
 
 	cloneSchema := test.AssertNestedSchemaExistence(t, s, mkClone)


### PR DESCRIPTION
### What does this PR do?
Refactor VM CD-ROM handling into a dedicated package and manage CD-ROMs as repeatable interface-keyed blocks in the SDK VM resource.

Behavior changes:
- support configuring multiple `cdrom` blocks on a VM
- require `cdrom.interface` instead of relying on a default slot
- preserve CD-ROM interfaces correctly during import and refresh
- validate q35 IDE CD-ROM slots in the provider (`ide0`/`ide2` only)
- keep disk/CD-ROM interface mappings stable after import

I was trying to see how #2285 could be cleanly fixed (and noticed that it might already be fixed?). I then noticed that one issue is that a cdrom can be defined on interface ide2 for example, but after an import, it will only check ide3. Then I noticed that the provider currently only allows to define one cdrom for a VM, even though multiple are allowed, potentially breaking other imports as well. I found #718 requesting support to define multiple cd drives.

Therefore, I oriented at the implementation of the disk block to also allow defining multiple cdrom blocks. This way, during import, we can, similarly to how disks are imported, key the storage devices by interface, filter out disks and map them correctly to terraform state. I also added quite a few acceptance tests and unit tests to cover the cases I could think of. Imports should now be more reliable. :)

Of course this is a breaking change also changing the schema of the VM resource, so this is up to you if you want this or not. ;)
Until you tell me, I will mark this as draft.


The examples run through for me and I selected a few acceptance test suites to run. There was only one failure, but it was unrelated to my changes:
```
./testacc TestAccResourceVMDisks
Running single test: TestAccResourceVMDisks
Found test in: ./fwprovider/test/resource_vm_disks_test.go
Package: github.com/bpg/terraform-provider-proxmox/fwprovider/test

--- FAIL: TestAccResourceVMDisks (16.72s)
    resource_vm_disks_test.go:1248: skipping: PROXMOX_VE_ACC_ZFS_DATASTORE_ID is not set
    --- FAIL: TestAccResourceVMDisks/clone_with_moving_disk_to_ZFS_storage (0.16s)
panic: test executed panic(nil) or runtime.Goexit

goroutine 93 [running]:
testing.tRunner.func1.2({0x152dd40, 0x25dc530})
        /usr/lib64/go/1.25/src/testing/testing.go:1872 +0x237
testing.tRunner.func1()
        /usr/lib64/go/1.25/src/testing/testing.go:1875 +0x35b
runtime.Goexit()
        /usr/lib64/go/1.25/src/runtime/panic.go:615 +0x5e
testing.(*common).SkipNow(0xc0000d7a40)
        /usr/lib64/go/1.25/src/testing/testing.go:1250 +0x45
testing.(*common).Skip(0xc0000d7a40, {0xc000739728?, 0x0?, 0x2634a60?})
        /usr/lib64/go/1.25/src/testing/testing.go:1226 +0x4f
github.com/bpg/terraform-provider-proxmox/fwprovider/test.TestAccResourceVMDisks.func3()
        /home/deck/Dokumente/opentofu/bpg-terraform-provider-proxmox/fwprovider/test/resource_vm_disks_test.go:1248 +0x49
github.com/hashicorp/terraform-plugin-testing/helper/resource.runNewTest({0x1aac420, 0xc00167e2d0}, {0x1acabc0, 0xc000602c40}, {0x0, 0x0, {0x0, 0x0, 0x0}, 0x0, ...}, ...)
        /home/deck/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.15.0/helper/resource/testing_new.go:171 +0xbb5
github.com/hashicorp/terraform-plugin-testing/helper/resource.Test({0x1acabc0, 0xc000602c40}, {0x0, 0x0, {0x0, 0x0, 0x0}, 0x0, 0x0, 0xc000359d70, ...})
        /home/deck/go/pkg/mod/github.com/hashicorp/terraform-plugin-testing@v1.15.0/helper/resource/testing.go:1013 +0x68e
github.com/bpg/terraform-provider-proxmox/fwprovider/test.TestAccResourceVMDisks.func4(0xc000602c40)
        /home/deck/Dokumente/opentofu/bpg-terraform-provider-proxmox/fwprovider/test/resource_vm_disks_test.go:1421 +0x9b
testing.tRunner(0xc000602c40, 0xc0004bcc00)
        /usr/lib64/go/1.25/src/testing/testing.go:1934 +0xea
created by testing.(*T).Run in goroutine 8
        /usr/lib64/go/1.25/src/testing/testing.go:1997 +0x465
FAIL    github.com/bpg/terraform-provider-proxmox/fwprovider/test       14.633s
FAIL
```

### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [x] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

#### ⚠ BREAKING CHANGES
- support configuring multiple `cdrom` blocks on a VM
- require `cdrom.interface` instead of relying on a default slot


### Proof of Work
```
./testacc TestAccResourceVMCDROM
Running single test: TestAccResourceVMCDROM
Found test in: ./fwprovider/test/resource_vm_cdrom_test.go
Package: github.com/bpg/terraform-provider-proxmox/fwprovider/test

ok      github.com/bpg/terraform-provider-proxmox/fwprovider/test       8.592s
📦[deck@tumbleweed bpg-terraform-provider-proxmox]$ ./testacc TestAccResourceVMDiskImportKeepsInterfaceMapping
Running single test: TestAccResourceVMDiskImportKeepsInterfaceMapping
Found test in: ./fwprovider/test/resource_vm_disks_test.go
Package: github.com/bpg/terraform-provider-proxmox/fwprovider/test

ok      github.com/bpg/terraform-provider-proxmox/fwprovider/test       6.556s
📦[deck@tumbleweed bpg-terraform-provider-proxmox]$ ./testacc TestAccResourceVMDiskImportKeepsDiskAndCDROMMappings
Running single test: TestAccResourceVMDiskImportKeepsDiskAndCDROMMappings
Found test in: ./fwprovider/test/resource_vm_disks_test.go
Package: github.com/bpg/terraform-provider-proxmox/fwprovider/test

ok      github.com/bpg/terraform-provider-proxmox/fwprovider/test       9.299s
📦[deck@tumbleweed bpg-terraform-provider-proxmox]$ ./testacc TestAccResourceVMCDROMRejectsInvalidQ35IDEInterface
Running single test: TestAccResourceVMCDROMRejectsInvalidQ35IDEInterface
Found test in: ./fwprovider/test/resource_vm_cdrom_test.go
Package: github.com/bpg/terraform-provider-proxmox/fwprovider/test


ok      github.com/bpg/terraform-provider-proxmox/fwprovider/test       0.214s
📦[deck@tumbleweed bpg-terraform-provider-proxmox]$ ./testacc TestAccResourceVMDiskCDROMNotInDiskBlock
Running single test: TestAccResourceVMDiskCDROMNotInDiskBlock
Found test in: ./fwprovider/test/resource_vm_disks_test.go
Package: github.com/bpg/terraform-provider-proxmox/fwprovider/test

ok      github.com/bpg/terraform-provider-proxmox/fwprovider/test       3.658s
```

The test failing on the current main branch is at least:
```
./testacc TestAccResourceVMDiskImportKeepsInterfaceMapping
Running single test: TestAccResourceVMDiskImportKeepsInterfaceMapping
Found test in: ./fwprovider/test/resource_vm_disks_test.go
Package: github.com/bpg/terraform-provider-proxmox/fwprovider/test

--- FAIL: TestAccResourceVMDiskImportKeepsInterfaceMapping (5.71s)
    testing_new_import_state.go:270: expected cdrom.0.interface = ide2 after import, got 
FAIL
FAIL    github.com/bpg/terraform-provider-proxmox/fwprovider/test       5.728s
FAIL
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #718 | Closes #2285 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
