### PR TITLE
feat(vm): add `upgrade` attribute to cloud-init initialization block

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -430,6 +430,8 @@ output "ubuntu_vm_public_key" {
         all vendor data passed to the VM via cloud-init.
     - `meta_data_file_id` - (Optional) The identifier for a file containing
         all meta data passed to the VM via cloud-init.
+    - `upgrade` - (Optional) Whether to do an automatic package upgrade after
+        the first boot (defaults to `true`).
 - `keyboard_layout` - (Optional) The keyboard layout (defaults to `en-us`).
     - `da` - Danish.
     - `de` - German.

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -432,6 +432,7 @@ output "ubuntu_vm_public_key" {
         all meta data passed to the VM via cloud-init.
     - `upgrade` - (Optional) Whether to do an automatic package upgrade after
         the first boot (defaults to `true`).
+        Setting this is only allowed for `root@pam` authenticated user.
 - `keyboard_layout` - (Optional) The keyboard layout (defaults to `en-us`).
     - `da` - Danish.
     - `de` - German.

--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -1117,6 +1117,40 @@ func TestAccResourceVMInitialization(t *testing.T) {
 				"initialization.0.upgrade": "true",
 			}),
 		}}},
+		// Verifies that updating other initialization fields without setting upgrade
+		// does not spuriously send ciupgrade to the API (which would cause HTTP 500
+		// for non-root users).
+		{"cloud-init update other fields without upgrade set", []resource.TestStep{{
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm_cloudinit_no_upgrade" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					initialization {
+						dns {
+							servers = ["1.1.1.1"]
+						}
+					}
+				}`),
+			Check: ResourceAttributes("proxmox_virtual_environment_vm.test_vm_cloudinit_no_upgrade", map[string]string{
+				"initialization.0.upgrade":         "true",
+				"initialization.0.dns.0.servers.0": "1.1.1.1",
+			}),
+		}, {
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm_cloudinit_no_upgrade" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					initialization {
+						dns {
+							servers = ["8.8.8.8"]
+						}
+					}
+				}`),
+			Check: ResourceAttributes("proxmox_virtual_environment_vm.test_vm_cloudinit_no_upgrade", map[string]string{
+				"initialization.0.upgrade":         "true",
+				"initialization.0.dns.0.servers.0": "8.8.8.8",
+			}),
+		}}},
 	}
 
 	for _, tt := range tests {

--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -1056,6 +1056,67 @@ func TestAccResourceVMInitialization(t *testing.T) {
 				"initialization.0.dns.0.servers.0": "1.1.1.1",
 			}),
 		}}},
+		{"cloud-init upgrade disabled", []resource.TestStep{{
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm_cloudinit_upgrade" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					initialization {
+						upgrade = false
+					}
+				}`),
+			Check: ResourceAttributes("proxmox_virtual_environment_vm.test_vm_cloudinit_upgrade", map[string]string{
+				"initialization.0.upgrade": "false",
+			}),
+		}}},
+		{"cloud-init upgrade default is true", []resource.TestStep{{
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm_cloudinit_upgrade_default" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					initialization {}
+				}`),
+			Check: ResourceAttributes("proxmox_virtual_environment_vm.test_vm_cloudinit_upgrade_default", map[string]string{
+				"initialization.0.upgrade": "true",
+			}),
+		}}},
+		{"cloud-init upgrade update", []resource.TestStep{{
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm_cloudinit_upgrade_update" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					initialization {
+						upgrade = true
+					}
+				}`),
+			Check: ResourceAttributes("proxmox_virtual_environment_vm.test_vm_cloudinit_upgrade_update", map[string]string{
+				"initialization.0.upgrade": "true",
+			}),
+		}, {
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm_cloudinit_upgrade_update" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					initialization {
+						upgrade = false
+					}
+				}`),
+			Check: ResourceAttributes("proxmox_virtual_environment_vm.test_vm_cloudinit_upgrade_update", map[string]string{
+				"initialization.0.upgrade": "false",
+			}),
+		}, {
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm_cloudinit_upgrade_update" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					initialization {
+						upgrade = true
+					}
+				}`),
+			Check: ResourceAttributes("proxmox_virtual_environment_vm.test_vm_cloudinit_upgrade_update", map[string]string{
+				"initialization.0.upgrade": "true",
+			}),
+		}}},
 	}
 
 	for _, tt := range tests {

--- a/proxmox/nodes/vms/custom_cloud_init.go
+++ b/proxmox/nodes/vms/custom_cloud_init.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 )
 
 // CustomCloudInitConfig handles QEMU cloud-init parameters.
@@ -22,9 +24,8 @@ type CustomCloudInitConfig struct {
 	SearchDomain *string                   `json:"searchdomain,omitempty" url:"searchdomain,omitempty"`
 	SSHKeys      *CustomCloudInitSSHKeys   `json:"sshkeys,omitempty"      url:"sshkeys,omitempty"`
 	Type         *string                   `json:"citype,omitempty"       url:"citype,omitempty"`
-	// Can't be reliably set, it is TRUE by default in PVE
-	// Upgrade      *types.CustomBool         `json:"ciupgrade,omitempty"    url:"ciupgrade,omitempty,int"`
-	Username *string `json:"ciuser,omitempty" url:"ciuser,omitempty"`
+	Upgrade      *types.CustomBool         `json:"ciupgrade,omitempty"    url:"ciupgrade,omitempty,int"`
+	Username     *string                   `json:"ciuser,omitempty"       url:"ciuser,omitempty"`
 }
 
 // CustomCloudInitFiles handles QEMU cloud-init custom files parameters.
@@ -121,6 +122,14 @@ func (r CustomCloudInitConfig) EncodeValues(_ string, v *url.Values) error {
 
 	if r.Type != nil {
 		v.Add("citype", *r.Type)
+	}
+
+	if r.Upgrade != nil {
+		if *r.Upgrade {
+			v.Add("ciupgrade", "1")
+		} else {
+			v.Add("ciupgrade", "0")
+		}
 	}
 
 	if r.Username != nil {

--- a/proxmox/nodes/vms/custom_cloud_init_test.go
+++ b/proxmox/nodes/vms/custom_cloud_init_test.go
@@ -1,0 +1,63 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package vms
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
+)
+
+func TestCustomCloudInitConfig_EncodeValues_Upgrade(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		config        CustomCloudInitConfig
+		wantCiupgrade string // expected value, or "" if key should be absent
+		wantPresent   bool   // whether ciupgrade key should be present at all
+	}{
+		{
+			name:        "upgrade nil does not send ciupgrade",
+			config:      CustomCloudInitConfig{},
+			wantPresent: false,
+		},
+		{
+			name:          "upgrade false sends ciupgrade=0",
+			config:        CustomCloudInitConfig{Upgrade: types.CustomBool(false).Pointer()},
+			wantCiupgrade: "0",
+			wantPresent:   true,
+		},
+		{
+			name:          "upgrade true sends ciupgrade=1",
+			config:        CustomCloudInitConfig{Upgrade: types.CustomBool(true).Pointer()},
+			wantCiupgrade: "1",
+			wantPresent:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			values := &url.Values{}
+			err := tt.config.EncodeValues("", values)
+			require.NoError(t, err)
+
+			if tt.wantPresent {
+				require.Equal(t, tt.wantCiupgrade, values.Get("ciupgrade"),
+					"ciupgrade should be %q", tt.wantCiupgrade)
+			} else {
+				require.False(t, values.Has("ciupgrade"),
+					"ciupgrade should not be sent when Upgrade is nil (non-root users cannot set it)")
+			}
+		})
+	}
+}

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -3696,10 +3696,22 @@ func vmGetCloudInitConfig(d *schema.ResourceData) *vms.CustomCloudInitConfig {
 		initializationConfig.Type = &initializationType
 	}
 
-	//nolint:staticcheck
-	if v, ok := d.GetOkExists(fmt.Sprintf("%s.0.%s", mkInitialization, mkInitializationUpgrade)); ok {
-		upgrade := types.CustomBool(v.(bool))
-		initializationConfig.Upgrade = &upgrade
+	if d.IsNewResource() {
+		// Create: GetOkExists correctly detects "user never set this" because state is empty.
+		//nolint:staticcheck
+		if v, ok := d.GetOkExists(fmt.Sprintf("%s.0.%s", mkInitialization, mkInitializationUpgrade)); ok {
+			upgrade := types.CustomBool(v.(bool))
+			initializationConfig.Upgrade = &upgrade
+		}
+	} else {
+		// Update: only send ciupgrade when the upgrade field itself changed, not when other
+		// initialization fields change. This protects non-root users from HTTP 500 errors
+		// caused by spurious ciupgrade=1 being sent due to the Read-path default.
+		upgradePath := fmt.Sprintf("%s.0.%s", mkInitialization, mkInitializationUpgrade)
+		if d.HasChange(upgradePath) {
+			upgrade := types.CustomBool(d.Get(upgradePath).(bool))
+			initializationConfig.Upgrade = &upgrade
+		}
 	}
 
 	return initializationConfig

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -96,6 +96,7 @@ const (
 	dvInitializationIPConfigIPv4Gateway = ""
 	dvInitializationIPConfigIPv6Address = ""
 	dvInitializationIPConfigIPv6Gateway = ""
+	dvInitializationUpgrade             = true
 	dvInitializationUserAccountPassword = ""
 	dvKeyboardLayout                    = "en-us"
 	dvKVMArguments                      = ""
@@ -245,6 +246,7 @@ const (
 	mkInitializationIPConfigIPv6Address = "address"
 	mkInitializationIPConfigIPv6Gateway = "gateway"
 	mkInitializationType                = "type"
+	mkInitializationUpgrade             = "upgrade"
 	mkInitializationUserAccount         = "user_account"
 	mkInitializationUserAccountKeys     = "keys"
 	mkInitializationUserAccountPassword = "password"
@@ -1021,6 +1023,12 @@ func VM() *schema.Resource {
 						Computed:         true,
 						ForceNew:         true,
 						ValidateDiagFunc: CloudInitTypeValidator(),
+					},
+					mkInitializationUpgrade: {
+						Type:        schema.TypeBool,
+						Description: "Whether to do an automatic package upgrade after the first boot",
+						Optional:    true,
+						Default:     dvInitializationUpgrade,
 					},
 				},
 			},
@@ -3687,6 +3695,9 @@ func vmGetCloudInitConfig(d *schema.ResourceData) *vms.CustomCloudInitConfig {
 		initializationConfig.Type = &initializationType
 	}
 
+	upgrade := types.CustomBool(initializationBlock[mkInitializationUpgrade].(bool))
+	initializationConfig.Upgrade = &upgrade
+
 	return initializationConfig
 }
 
@@ -5128,6 +5139,13 @@ func vmReadCustom(
 		initialization[mkInitializationType] = *vmConfig.CloudInitType
 	} else if len(initialization) > 0 {
 		initialization[mkInitializationType] = ""
+	}
+
+	if vmConfig.CloudInitUpgrade != nil {
+		initialization[mkInitializationUpgrade] = bool(*vmConfig.CloudInitUpgrade)
+	} else if len(initialization) > 0 {
+		// Default to true, matching Proxmox default behavior
+		initialization[mkInitializationUpgrade] = dvInitializationUpgrade
 	}
 
 	currentInitialization := d.Get(mkInitialization).([]any)

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -96,7 +96,6 @@ const (
 	dvInitializationIPConfigIPv4Gateway = ""
 	dvInitializationIPConfigIPv6Address = ""
 	dvInitializationIPConfigIPv6Gateway = ""
-	dvInitializationUpgrade             = true
 	dvInitializationUserAccountPassword = ""
 	dvKeyboardLayout                    = "en-us"
 	dvKVMArguments                      = ""
@@ -1025,10 +1024,12 @@ func VM() *schema.Resource {
 						ValidateDiagFunc: CloudInitTypeValidator(),
 					},
 					mkInitializationUpgrade: {
-						Type:        schema.TypeBool,
-						Description: "Whether to do an automatic package upgrade after the first boot",
-						Optional:    true,
-						Default:     dvInitializationUpgrade,
+						Type: schema.TypeBool,
+						Description: "Whether to do an automatic package upgrade after the first boot" +
+							" (defaults to `true` in Proxmox)." +
+							" Setting this is only allowed for `root@pam` authenticated user.",
+						Optional: true,
+						Computed: true,
 					},
 				},
 			},
@@ -3695,8 +3696,11 @@ func vmGetCloudInitConfig(d *schema.ResourceData) *vms.CustomCloudInitConfig {
 		initializationConfig.Type = &initializationType
 	}
 
-	upgrade := types.CustomBool(initializationBlock[mkInitializationUpgrade].(bool))
-	initializationConfig.Upgrade = &upgrade
+	//nolint:staticcheck
+	if v, ok := d.GetOkExists(fmt.Sprintf("%s.0.%s", mkInitialization, mkInitializationUpgrade)); ok {
+		upgrade := types.CustomBool(v.(bool))
+		initializationConfig.Upgrade = &upgrade
+	}
 
 	return initializationConfig
 }
@@ -5145,7 +5149,7 @@ func vmReadCustom(
 		initialization[mkInitializationUpgrade] = bool(*vmConfig.CloudInitUpgrade)
 	} else if len(initialization) > 0 {
 		// Default to true, matching Proxmox default behavior
-		initialization[mkInitializationUpgrade] = dvInitializationUpgrade
+		initialization[mkInitializationUpgrade] = true
 	}
 
 	currentInitialization := d.Get(mkInitialization).([]any)

--- a/proxmoxtf/resource/vm/vm_test.go
+++ b/proxmoxtf/resource/vm/vm_test.go
@@ -205,6 +205,7 @@ func TestVMSchema(t *testing.T) {
 		mkInitializationFileFormat,
 		mkInitializationDNS,
 		mkInitializationIPConfig,
+		mkInitializationUpgrade,
 		mkInitializationUserAccount,
 	})
 
@@ -214,6 +215,7 @@ func TestVMSchema(t *testing.T) {
 		mkInitializationFileFormat:  schema.TypeString,
 		mkInitializationDNS:         schema.TypeList,
 		mkInitializationIPConfig:    schema.TypeList,
+		mkInitializationUpgrade:     schema.TypeBool,
 		mkInitializationUserAccount: schema.TypeList,
 	})
 


### PR DESCRIPTION
### What does this PR do?

Adds an `upgrade` boolean attribute to the `initialization` block of `proxmox_virtual_environment_vm`, exposing the Proxmox `ciupgrade` parameter. This controls whether cloud-init upgrades packages on first boot. It defaults to `true` (matching PVE's default), and can be set to `false` to disable automatic package upgrades — useful when external tools like Ansible manage packages and the default causes dpkg lock contention.

**History:** This was previously added in #1203 and removed in #1295 because the old implementation unconditionally sent `ciupgrade=1`, which caused `HTTP 500: only root can set 'ciupgrade' config` for non-root API tokens (#1291). This implementation fixes that by only sending `ciupgrade` to the API when the user explicitly sets the attribute.

**Non-root safety:** On Create, `GetOkExists` correctly detects whether the user set the field (empty state has no false positives). On Update, `HasChange` on the specific `upgrade` field ensures `ciupgrade` is only sent when the user actually changes it — not when other initialization fields (DNS, username, etc.) are modified. This prevents spurious `ciupgrade=1` from being sent due to the Read-path default of `true` leaking through `GetOkExists` on subsequent updates.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

**Acceptance tests** (4 upgrade-specific cases, 10 total subtests in TestAccResourceVMInitialization):

```text
$ ./testacc TestAccResourceVMInitialization -- -v

--- PASS: TestAccResourceVMInitialization (114.77s)
    --- PASS: TestAccResourceVMInitialization/cloud-init_upgrade_disabled (3.26s)
    --- PASS: TestAccResourceVMInitialization/cloud-init_upgrade_default_is_true (3.45s)
    --- PASS: TestAccResourceVMInitialization/cloud-init_upgrade_update (5.00s)
    --- PASS: TestAccResourceVMInitialization/cloud-init_update_other_fields_without_upgrade_set (4.03s)
PASS
ok  github.com/bpg/terraform-provider-proxmox/fwprovider/test  115.336s
```

**Mitmproxy API verification** (`--flow-detail 4`):

Explicit upgrade changes send ciupgrade correctly:

| Step | Request | ciupgrade sent |
|------|---------|---------------|
| Update to false | `PUT /nodes/pve/qemu/101/config` | `ciupgrade: '0'` |
| Update back to true | `PUT /nodes/pve/qemu/101/config` | `ciupgrade: '1'` |

Updating other init fields (DNS) does NOT send ciupgrade:

```text
PUT /nodes/pve/qemu/101/config
  Body: delete=name&nameserver=8.8.8.8
  (no ciupgrade parameter — non-root users safe)
```

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #1079
Relates #1291

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.6). All changes have been reviewed and verified by a human.*