### PR TITLE
feat(vm): wait for guest agent readiness before reboot

### DIFF
--- a/fwprovider/test/resource_vm_reboot_after_creation_test.go
+++ b/fwprovider/test/resource_vm_reboot_after_creation_test.go
@@ -1,0 +1,110 @@
+//go:build acceptance || all
+
+//testacc:tier=heavy
+//testacc:resource=vm
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccResourceVMRebootAfterCreationWithAgent verifies that a VM with
+// guest-agent enabled and reboot=true can be created successfully.
+// This reproduces the issue where the provider attempts to reboot the VM
+// immediately after starting it, before the guest agent is ready, causing
+// 'qmp command guest-ping failed - got timeout'.
+func TestAccResourceVMRebootAfterCreationWithAgent(t *testing.T) {
+	t.Parallel()
+
+	te := InitEnvironment(t)
+	imageFileID := te.DownloadCloudImage()
+	te.AddTemplateVars(map[string]any{"ImageFileID": imageFileID})
+
+	var vmID string
+
+	resourceName := "proxmox_virtual_environment_vm.test_reboot_creation_agent"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_file" "cloud_config_reboot" {
+						content_type = "snippets"
+						datastore_id = "local"
+						node_name    = "{{.NodeName}}"
+						overwrite    = true
+						source_raw {
+							data = <<-EOF
+							#cloud-config
+							runcmd:
+							  - apt-get update
+							  - apt-get install -y qemu-guest-agent
+							  - systemctl enable qemu-guest-agent
+							  - systemctl start qemu-guest-agent
+							EOF
+							file_name = "cloud-config-reboot-agent.yaml"
+						}
+					}
+
+					resource "proxmox_virtual_environment_vm" "test_reboot_creation_agent" {
+						node_name       = "{{.NodeName}}"
+						name            = "test-reboot-creation-agent"
+						started         = true
+						stop_on_destroy = true
+						reboot          = true
+
+						agent {
+							enabled = true
+						}
+
+						cpu {
+							cores = 2
+						}
+
+						memory {
+							dedicated = 2048
+						}
+
+						disk {
+							datastore_id = "local-lvm"
+							file_format  = "raw"
+							file_id      = "{{.ImageFileID}}"
+							interface    = "scsi0"
+							discard      = "on"
+							size         = 20
+						}
+
+						initialization {
+							interface    = "scsi1"
+							datastore_id = "local-lvm"
+							ip_config {
+								ipv4 {
+									address = "dhcp"
+								}
+							}
+							user_data_file_id = proxmox_virtual_environment_file.cloud_config_reboot.id
+						}
+
+						network_device {
+							bridge = "vmbr0"
+						}
+					}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					captureVMID(resourceName, &vmID),
+					checkVMStatus(te, &vmID, "running"),
+				),
+			},
+		},
+	})
+}

--- a/proxmox/nodes/vms/vms.go
+++ b/proxmox/nodes/vms/vms.go
@@ -500,7 +500,9 @@ func (c *Client) UpdateVMAsync(ctx context.Context, d *UpdateRequestBody) (*stri
 
 // isAgentNotReadyError checks if an HTTP error indicates the agent is not ready yet.
 // This includes HTTP 500 errors with messages like "QEMU guest agent is not running"
-// which can occur with certain SCSI controller types (e.g., virtio-scsi-single).
+// which can occur with certain SCSI controller types (e.g., virtio-scsi-single),
+// and "qmp command 'guest-ping' failed - got timeout" which occurs when the QMP socket
+// is connected but the guest agent process hasn't fully initialized yet.
 func isAgentNotReadyError(err error) bool {
 	var httpError *api.HTTPError
 	if !errors.As(err, &httpError) {
@@ -514,10 +516,16 @@ func isAgentNotReadyError(err error) bool {
 	if httpError.Code == http.StatusInternalServerError {
 		msg := strings.ToLower(httpError.Message)
 
-		return strings.Contains(msg, "qemu guest agent") &&
+		if strings.Contains(msg, "qemu guest agent") &&
 			(strings.Contains(msg, "not running") ||
 				strings.Contains(msg, "not available") ||
-				strings.Contains(msg, "not ready"))
+				strings.Contains(msg, "not ready")) {
+			return true
+		}
+
+		if strings.Contains(msg, "got timeout") {
+			return true
+		}
 	}
 
 	return false

--- a/proxmox/nodes/vms/vms.go
+++ b/proxmox/nodes/vms/vms.go
@@ -523,6 +523,30 @@ func isAgentNotReadyError(err error) bool {
 	return false
 }
 
+// WaitForAgentReady waits for the QEMU guest agent to become responsive by polling the agent/ping endpoint.
+// This should be called before any operation that requires the guest agent (e.g., reboot via agent),
+// because the agent may not be ready immediately after VM start — the guest OS needs time to boot
+// and start the qemu-guest-agent service.
+func (c *Client) WaitForAgentReady(ctx context.Context) error {
+	op := retry.NewPollOperation("VM agent ready",
+		retry.WithRetryIf(isAgentNotReadyError),
+	)
+
+	err := op.DoPoll(ctx, func() error {
+		return c.DoRequest(ctx, http.MethodPost, c.ExpandPath("agent/ping"), nil, nil)
+	})
+
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return fmt.Errorf("timeout while waiting for the QEMU agent on VM %d to become ready", c.VMID)
+	}
+
+	if err != nil {
+		return fmt.Errorf("error waiting for QEMU agent on VM %d: %w", c.VMID, err)
+	}
+
+	return nil
+}
+
 // WaitForNetworkInterfacesFromVMAgent waits for a virtual machine's QEMU agent to publish the network interfaces.
 func (c *Client) WaitForNetworkInterfacesFromVMAgent(
 	ctx context.Context,

--- a/proxmox/nodes/vms/vms_agent_test.go
+++ b/proxmox/nodes/vms/vms_agent_test.go
@@ -55,6 +55,12 @@ func TestIsAgentNotReadyError(t *testing.T) {
 			comment: "Case-insensitive matching should work",
 		},
 		{
+			name:    "HTTP 500 with 'qmp command guest-ping failed - got timeout'",
+			err:     &api.HTTPError{Code: http.StatusInternalServerError, Message: "qmp command 'guest-ping' failed - got timeout"},
+			want:    true,
+			comment: "HTTP 500 with QMP ping timeout should be retried",
+		},
+		{
 			name:    "HTTP 500 with different error message",
 			err:     &api.HTTPError{Code: http.StatusInternalServerError, Message: "Internal Server Error"},
 			want:    false,

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -2131,7 +2131,16 @@ func vmRestartRunning(
 	if agentEnabled {
 		rebootTimeoutSec := d.Get(mkTimeoutReboot).(int)
 
-		rebootDiags := sdkresource.TaskResultDiags(vmAPI.RebootVMAndWaitForRunning(ctx, rebootTimeoutSec), "VM reboot")
+		rebootCtx, cancel := context.WithTimeout(ctx, time.Duration(rebootTimeoutSec)*time.Second)
+		defer cancel()
+
+		tflog.Debug(ctx, "Waiting for QEMU guest agent to become ready before reboot")
+
+		if err := vmAPI.WaitForAgentReady(rebootCtx); err != nil {
+			return diag.FromErr(err)
+		}
+
+		rebootDiags := sdkresource.TaskResultDiags(vmAPI.RebootVMAndWaitForRunning(rebootCtx, rebootTimeoutSec), "VM reboot")
 		if rebootDiags.HasError() {
 			return rebootDiags
 		}

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -2140,7 +2140,7 @@ func vmRestartRunning(
 			return diag.FromErr(err)
 		}
 
-		rebootDiags := sdkresource.TaskResultDiags(vmAPI.RebootVMAndWaitForRunning(rebootCtx, rebootTimeoutSec), "VM reboot")
+		rebootDiags := sdkresource.TaskResultDiags(vmAPI.RebootVMAndWaitForRunning(ctx, rebootTimeoutSec), "VM reboot")
 		if rebootDiags.HasError() {
 			return rebootDiags
 		}


### PR DESCRIPTION
### What does this PR do?

When a VM is created with `reboot = true` and `agent { enabled = true }`, the provider immediately attempts to reboot it via the Proxmox `POST /status/reboot` endpoint. This endpoint requires the QEMU guest agent to be responsive, but the agent hasn't started yet because the guest OS is still booting. The result is a `qmp command 'guest-ping' failed - got timeout` error that hangs until the reboot timeout expires.

This PR adds a `WaitForAgentReady` method that polls the `agent/ping` endpoint before attempting the reboot. This uses condition-based waiting (the same retry/poll pattern used by `WaitForNetworkInterfacesFromVMAgent`) instead of an arbitrary sleep, so it adapts to actual agent startup time. The total wait is bounded by the existing `timeout_reboot` setting.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

**New acceptance test** — creates a VM with cloud-init (installs qemu-guest-agent), `reboot = true`, and `agent { enabled = true }`. Without the fix, the provider hangs on `POST /status/reboot` because the agent isn't ready. With the fix, the provider polls `agent/ping` until the agent responds, then reboots successfully.

```
$ ./testacc TestAccResourceVMRebootAfterCreationWithAgent -- -v

=== RUN   TestAccResourceVMRebootAfterCreationWithAgent
=== PAUSE TestAccResourceVMRebootAfterCreationWithAgent
=== CONT  TestAccResourceVMRebootAfterCreationWithAgent
--- PASS: TestAccResourceVMRebootAfterCreationWithAgent (59.92s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	60.578s
```

**Regression tests** — all existing `reboot_after_update` tests pass:

```
--- PASS: TestAccResourceVMRebootAfterUpdateTPMStatePolicy (35.42s)
--- PASS: TestAccResourceVMRebootAfterUpdateTemplatePolicy (37.08s)
--- PASS: TestAccResourceVMRebootAfterUpdateDiskResizePolicy (37.95s)
--- PASS: TestAccResourceVMRebootAfterUpdateDiskMovePolicy (44.08s)
--- PASS: TestAccResourceVMRebootAfterUpdateCloudInitMovePolicy (33.42s)
```

**Investigation confirmation** — SSH to Proxmox host verified that `qm agent <vmid> ping` returns "QEMU guest agent is not running" immediately after VM start, confirming the race condition.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a :+1: [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

Closes #2029

---

*This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.6). All changes have been reviewed and verified by a human.*
