### PR TITLE
fix(lxc)!: use computed `cpu.units` value instead of hardcoded 1024

### DIFF
--- a/docs/guides/upgrade.md
+++ b/docs/guides/upgrade.md
@@ -37,6 +37,27 @@ This guide documents breaking changes across provider versions and the recommend
 
 -> **Tip:** Upgrade one minor version at a time when crossing multiple breaking changes. This makes it easier to isolate issues.
 
+## v0.102.0
+
+### LXC `cpu.units` no longer defaults to 1024
+
+The `cpu.units` attribute on `proxmox_virtual_environment_container` no longer defaults to `1024`. Instead, the Proxmox server's own default is used (`100` on cgroup2, `1024` on cgroup1).
+
+**Before:** When `cpu.units` was not specified, the provider always sent `cpuunits=1024` to the API, overriding the server default.
+
+**After:** When `cpu.units` is not specified, the provider does not send `cpuunits` at all, letting the server use its own default.
+
+**Action required:** If you rely on `cpu.units = 1024` and are on a cgroup2 system, explicitly set it in your configuration:
+
+```terraform
+resource "proxmox_virtual_environment_container" "example" {
+  # ...
+  cpu {
+    units = 1024
+  }
+}
+```
+
 ## v0.101.0
 
 ### VM datasources error on not-found

--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -2320,22 +2320,9 @@ func TestAccResourceContainerCPUUnitsDefault(t *testing.T) {
 						type             = "alpine"
 					}
 				}`, WithRootUser()),
-				Check: resource.ComposeTestCheckFunc(
-					ResourceAttributes(accTestContainerName, map[string]string{
-						"cpu.0.units": "512",
-					}),
-					func(*terraform.State) error {
-						ct := te.NodeClient().Container(accTestContainerID)
-
-						ctInfo, err := ct.GetContainer(t.Context())
-						require.NoError(te.t, err, "failed to get container")
-						require.NotNil(te.t, ctInfo.CPUUnits, "cpu units should be set")
-						require.Equal(te.t, 512, *ctInfo.CPUUnits,
-							"cpu.units should be 512 as explicitly set")
-
-						return nil
-					},
-				),
+				Check: ResourceAttributes(accTestContainerName, map[string]string{
+					"cpu.0.units": "512",
+				}),
 			},
 		},
 	})

--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -2227,6 +2227,120 @@ func TestAccResourceContainerEntrypoint(t *testing.T) {
 	})
 }
 
+func TestAccResourceContainerCPUUnitsDefault(t *testing.T) {
+	te := InitEnvironment(t)
+	accTestContainerID := 100000 + rand.Intn(99999)
+	imageFileName := fmt.Sprintf("%d-alpine-3.22-default_20250617_amd64.tar.xz", time.Now().UnixMicro())
+
+	testAccDownloadContainerTemplate(t, te, imageFileName)
+
+	te.AddTemplateVars(map[string]interface{}{
+		"ImageFileName":   imageFileName,
+		"TestContainerID": accTestContainerID,
+	})
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create without specifying cpu.units — should use server default (100 on cgroup2),
+				// NOT the hardcoded 1024.
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_container" "test_container" {
+					node_name    = "{{.NodeName}}"
+					vm_id        = {{.TestContainerID}}
+					unprivileged = true
+					disk {
+						datastore_id = "local-lvm"
+						size         = 4
+					}
+					initialization {
+						hostname = "test-cpu-units"
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_interface {
+						name = "vmbr0"
+					}
+					operating_system {
+						template_file_id = "local:vztmpl/{{.ImageFileName}}"
+						type             = "alpine"
+					}
+				}`, WithRootUser()),
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						ct := te.NodeClient().Container(accTestContainerID)
+
+						ctInfo, err := ct.GetContainer(t.Context())
+						require.NoError(te.t, err, "failed to get container")
+
+						// When cpu.units is not specified, the provider should NOT send
+						// cpuunits=1024 to the API. The API either returns nil (server
+						// uses its internal default) or the actual server default (100
+						// on cgroup2). Either way, it must NOT be 1024.
+						if ctInfo.CPUUnits != nil {
+							require.NotEqual(te.t, 1024, *ctInfo.CPUUnits,
+								"cpu.units should use server default, not hardcoded 1024")
+						}
+
+						return nil
+					},
+				),
+			},
+			{
+				// Step 2: explicitly set cpu.units — should take effect.
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_container" "test_container" {
+					node_name    = "{{.NodeName}}"
+					vm_id        = {{.TestContainerID}}
+					unprivileged = true
+					cpu {
+						units = 512
+					}
+					disk {
+						datastore_id = "local-lvm"
+						size         = 4
+					}
+					initialization {
+						hostname = "test-cpu-units"
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_interface {
+						name = "vmbr0"
+					}
+					operating_system {
+						template_file_id = "local:vztmpl/{{.ImageFileName}}"
+						type             = "alpine"
+					}
+				}`, WithRootUser()),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"cpu.0.units": "512",
+					}),
+					func(*terraform.State) error {
+						ct := te.NodeClient().Container(accTestContainerID)
+
+						ctInfo, err := ct.GetContainer(t.Context())
+						require.NoError(te.t, err, "failed to get container")
+						require.NotNil(te.t, ctInfo.CPUUnits, "cpu units should be set")
+						require.Equal(te.t, 512, *ctInfo.CPUUnits,
+							"cpu.units should be 512 as explicitly set")
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func testAccDownloadContainerTemplate(t *testing.T, te *Environment, imageFileName string) {
 	t.Helper()
 	err := te.NodeStorageClient().DownloadFileByURL(context.Background(), &storage.DownloadURLPostRequestBody{

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -57,7 +57,7 @@ const (
 	dvCPUArchitecture                   = "amd64"
 	dvCPUCores                          = 1
 	dvCPULimit                          = float64(0)
-	dvCPUUnits                          = 1024
+	dvCPUUnits                          = 0
 	dvDescription                       = ""
 	dvDevicePassthroughMode             = "0660"
 	dvDiskACL                           = false
@@ -351,9 +351,9 @@ func Container() *schema.Resource {
 							Type:        schema.TypeInt,
 							Description: "The CPU units",
 							Optional:    true,
-							Default:     dvCPUUnits,
+							Computed:    true,
 							ValidateDiagFunc: validation.ToDiagFunc(
-								validation.IntBetween(0, 500000),
+								validation.IntBetween(1, 500000),
 							),
 						},
 					},
@@ -1380,7 +1380,9 @@ func containerCreateClone(ctx context.Context, d *schema.ResourceData, m any) di
 			updateBody.Delete = append(updateBody.Delete, "cpulimit")
 		}
 
-		updateBody.CPUUnits = &cpuUnits
+		if cpuUnits > 0 {
+			updateBody.CPUUnits = &cpuUnits
+		}
 	}
 
 	hookScript := d.Get(mkHookScriptFileID).(string)
@@ -2134,7 +2136,6 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m any) d
 		CPUArchitecture:      &cpuArchitecture,
 		CPUCores:             &cpuCores,
 		CPULimit:             &cpuLimit,
-		CPUUnits:             &cpuUnits,
 		DatastoreID:          &diskDatastoreID,
 		DedicatedMemory:      &memoryDedicated,
 		PassthroughDevices:   passthroughDevices,
@@ -2153,6 +2154,10 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m any) d
 		TTY:                  &consoleTTYCount,
 		Unprivileged:         &unprivileged,
 		VMID:                 &vmID,
+	}
+
+	if cpuUnits > 0 {
+		createBody.CPUUnits = &cpuUnits
 	}
 
 	if description != "" {
@@ -2665,8 +2670,7 @@ func containerRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diag
 	if containerConfig.CPUUnits != nil {
 		cpu[mkCPUUnits] = *containerConfig.CPUUnits
 	} else {
-		// Default value of "cpuunits" is "1024" according to the API documentation.
-		cpu[mkCPUUnits] = 1024
+		cpu[mkCPUUnits] = 0
 	}
 
 	currentCPU := d.Get(mkCPU).([]any)
@@ -3413,7 +3417,9 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 			updateBody.Delete = append(updateBody.Delete, "cpulimit")
 		}
 
-		updateBody.CPUUnits = &cpuUnits
+		if cpuUnits > 0 {
+			updateBody.CPUUnits = &cpuUnits
+		}
 	}
 
 	if d.HasChange(mkDisk) {


### PR DESCRIPTION
### What does this PR do?

The LXC container resource hardcoded `cpu.units` to a default of `1024`, which is incorrect on cgroup2 systems where the Proxmox default is `100`. This PR makes `cpu.units` `Computed: true` (with no provider-side default) so the server's own default is used when the user doesn't specify a value. This is the same fix applied to the VM resource in #2402 and #2353.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

#### ⚠ BREAKING CHANGES

`cpu.units` for `proxmox_virtual_environment_container` no longer defaults to `1024`. Instead, the Proxmox server's own default is used (cgroup2: `100`, cgroup1: `1024`).

**Who is affected:** Users on cgroup2 systems who do not explicitly set `cpu.units` and relied on the provider's implicit `1024` default.

**Migration:** To preserve the previous behavior, explicitly set the value in your configuration:

```hcl
resource "proxmox_virtual_environment_container" "example" {
  # ...
  cpu {
    units = 1024
  }
}
```

### Proof of Work

#### Acceptance Tests

New test `TestAccResourceContainerCPUUnitsDefault` — verified the test **fails without the fix** (`Should not be: 1024`) and **passes with the fix**.

```
./testacc TestAccResourceContainerCPUUnitsDefault -- -v

=== RUN   TestAccResourceContainerCPUUnitsDefault
--- PASS: TestAccResourceContainerCPUUnitsDefault (16.15s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	16.613s
```

#### Regression Check

```
./testacc TestAccResourceContainer -- -count=1

=== RUN   TestAccResourceContainer
--- PASS: TestAccResourceContainer (29.99s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	30.469s
```

#### Mitmproxy Verification

Test run through mitmproxy (`--flow-detail 4`) to inspect raw API traffic.

**POST /nodes/pve/lxc (CREATE — no cpu.units in config):**

```
arch: amd64
cmode: tty
console: '1'
cores: '1'
cpulimit: '0'
hostname: test-cpu-units
memory: '512'
...
vmid: '138334'
```

`cpuunits` is **absent** from the create request — confirmed the provider does NOT send the hardcoded 1024 default.

**PUT /nodes/pve/lxc/138334/config (UPDATE — cpu.units = 512):**

```
arch: amd64
cores: '1'
cpuunits: '512'
delete: cpulimit
```

`cpuunits=512` is correctly sent when explicitly specified.

**GET /nodes/pve/lxc/138334/config responses:** Return `"cpuunits": 512` after the update, confirming the value persists.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

Closes #2632

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.6). All changes have been reviewed and verified by a human.*
