### PR TITLE
feat(cluster): refactoring and improving `proxmox_metrics_server`

### DIFF
--- a/docs/guides/upgrade.md
+++ b/docs/guides/upgrade.md
@@ -39,6 +39,16 @@ This guide documents breaking changes across provider versions and the recommend
 
 ## v0.102.0
 
+### `proxmox_metrics_server.disable` now defaults to `false`
+
+The `disable` attribute on `proxmox_metrics_server` (and its alias `proxmox_virtual_environment_metrics_server`) now has a schema default of `false`. The Proxmox API omits `disable` from GET responses when the value is `false`, and the resource now reads state back from the API after Create and Update — so the default is required to keep state consistent.
+
+**Before:** When `disable` was not set in configuration, it was stored as null in state.
+
+**After:** When `disable` is not set in configuration, it is stored as `false` in state. This matches the Proxmox server default (metrics servers are enabled by default).
+
+**Action required:** None. On the first `terraform apply` after upgrading, Terraform may show a one-time diff of `disable: null -> false` for existing metrics server resources that did not set `disable`. The apply is a no-op against the Proxmox API.
+
 ### LXC `cpu.units` no longer defaults to 1024
 
 The `cpu.units` attribute on `proxmox_virtual_environment_container` no longer defaults to `1024`. Instead, the Proxmox server's own default is used (`100` on cgroup2, `1024` on cgroup1).

--- a/docs/resources/metrics_server.md
+++ b/docs/resources/metrics_server.md
@@ -50,7 +50,7 @@ resource "proxmox_metrics_server" "opentelemetry_server" {
 
 ### Optional
 
-- `disable` (Boolean) Set this to `true` to disable this metric server.
+- `disable` (Boolean) Set this to `true` to disable this metric server. Defaults to `false`.
 - `graphite_path` (String) Root graphite path (ex: `proxmox.mycluster.mykey`).
 - `graphite_proto` (String) Protocol to send graphite data. Choice is between `udp` | `tcp`. If not set, PVE default is `udp`.
 - `influx_api_path_prefix` (String) An API path prefix inserted between `<host>:<port>/` and `/api2/`. Can be useful if the InfluxDB service runs behind a reverse proxy.
@@ -59,7 +59,7 @@ resource "proxmox_metrics_server" "opentelemetry_server" {
 - `influx_max_body_size` (Number) InfluxDB max-body-size in bytes. Requests are batched up to this size. If not set, PVE default is `25000000`.
 - `influx_organization` (String) The InfluxDB organization. Only necessary when using the http v2 api. Has no meaning when using v2 compatibility api.
 - `influx_token` (String, Sensitive) The InfluxDB access token. Only necessary when using the http v2 api. If the v2 compatibility api is used, use `user:password` instead.
-- `influx_verify` (Boolean) Set to `false` to disable certificate verification for https endpoints.
+- `influx_verify` (Boolean) Set to `false` to disable certificate verification for https endpoints. If not set, PVE default is `true`.
 - `mtu` (Number) MTU (maximum transmission unit) for metrics transmission over UDP. If not set, PVE default is `1500` (allowed `512` - `65536`).
 - `opentelemetry_compression` (String) OpenTelemetry compression algorithm for requests. Choice is between `none` | `gzip`. If not set, PVE default is `gzip`.
 - `opentelemetry_headers` (String, Sensitive) OpenTelemetry custom HTTP headers as JSON, base64 encoded.

--- a/docs/resources/virtual_environment_metrics_server.md
+++ b/docs/resources/virtual_environment_metrics_server.md
@@ -52,7 +52,7 @@ resource "proxmox_virtual_environment_metrics_server" "opentelemetry_server" {
 
 ### Optional
 
-- `disable` (Boolean) Set this to `true` to disable this metric server.
+- `disable` (Boolean) Set this to `true` to disable this metric server. Defaults to `false`.
 - `graphite_path` (String) Root graphite path (ex: `proxmox.mycluster.mykey`).
 - `graphite_proto` (String) Protocol to send graphite data. Choice is between `udp` | `tcp`. If not set, PVE default is `udp`.
 - `influx_api_path_prefix` (String) An API path prefix inserted between `<host>:<port>/` and `/api2/`. Can be useful if the InfluxDB service runs behind a reverse proxy.
@@ -61,7 +61,7 @@ resource "proxmox_virtual_environment_metrics_server" "opentelemetry_server" {
 - `influx_max_body_size` (Number) InfluxDB max-body-size in bytes. Requests are batched up to this size. If not set, PVE default is `25000000`.
 - `influx_organization` (String) The InfluxDB organization. Only necessary when using the http v2 api. Has no meaning when using v2 compatibility api.
 - `influx_token` (String, Sensitive) The InfluxDB access token. Only necessary when using the http v2 api. If the v2 compatibility api is used, use `user:password` instead.
-- `influx_verify` (Boolean) Set to `false` to disable certificate verification for https endpoints.
+- `influx_verify` (Boolean) Set to `false` to disable certificate verification for https endpoints. If not set, PVE default is `true`.
 - `mtu` (Number) MTU (maximum transmission unit) for metrics transmission over UDP. If not set, PVE default is `1500` (allowed `512` - `65536`).
 - `opentelemetry_compression` (String) OpenTelemetry compression algorithm for requests. Choice is between `none` | `gzip`. If not set, PVE default is `gzip`.
 - `opentelemetry_headers` (String, Sensitive) OpenTelemetry custom HTTP headers as JSON, base64 encoded.

--- a/fwprovider/cluster/metrics/datasource_metrics_server.go
+++ b/fwprovider/cluster/metrics/datasource_metrics_server.go
@@ -8,6 +8,7 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -16,6 +17,7 @@ import (
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/attribute"
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/config"
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/migration"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/cluster/metrics"
 )
 
@@ -149,18 +151,22 @@ func (r *metricsServerDatasource) Read(
 
 	data, err := r.client.GetServer(ctx, state.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Refresh Resource",
-			"An unexpected error occurred while attempting to refresh datasource state. "+
-				"Please retry the operation or report this issue to the provider developers.\n\n"+
-				"Error: "+err.Error(),
-		)
+		if errors.Is(err, api.ErrResourceDoesNotExist) {
+			resp.Diagnostics.AddError(
+				"Metrics Server Not Found",
+				fmt.Sprintf("Metrics server with ID %q was not found", state.ID.ValueString()),
+			)
+
+			return
+		}
+
+		resp.Diagnostics.AddError("Unable to Read Metrics Server", err.Error())
 
 		return
 	}
 
 	readModel := &metricsServerDatasourceModel{}
-	readModel.importFromAPI(state.ID.ValueString(), data)
+	readModel.fromAPI(state.ID.ValueString(), data)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, readModel)...)
 }

--- a/fwprovider/cluster/metrics/model_metrics_server.go
+++ b/fwprovider/cluster/metrics/model_metrics_server.go
@@ -9,6 +9,7 @@ package metrics
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	"github.com/bpg/terraform-provider-proxmox/fwprovider/attribute"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/cluster/metrics"
 	proxmoxtypes "github.com/bpg/terraform-provider-proxmox/proxmox/types"
 )
@@ -108,29 +109,29 @@ func (m *metricsServerModel) toAPI() *metrics.ServerRequestData {
 
 	data.ID = m.Name.ValueString()
 
-	data.Disable = proxmoxtypes.CustomBoolPtr(m.Disable.ValueBoolPointer())
-	data.MTU = m.MTU.ValueInt64Pointer()
+	data.Disable = attribute.CustomBoolPtrFromValue(m.Disable)
+	data.MTU = attribute.Int64PtrFromValue(m.MTU)
 	data.Port = m.Port.ValueInt64()
 	data.Server = m.Server.ValueString()
-	data.Timeout = m.Timeout.ValueInt64Pointer()
-	data.Type = m.Type.ValueStringPointer()
-	data.APIPathPrefix = m.InfluxAPIPathPrefix.ValueStringPointer()
-	data.Bucket = m.InfluxBucket.ValueStringPointer()
-	data.InfluxDBProto = m.InfluxDBProto.ValueStringPointer()
-	data.MaxBodySize = m.InfluxMaxBodySize.ValueInt64Pointer()
-	data.Organization = m.InfluxOrganization.ValueStringPointer()
-	data.Token = m.InfluxToken.ValueStringPointer()
-	data.Verify = proxmoxtypes.CustomBoolPtr(m.InfluxVerify.ValueBoolPointer())
-	data.Path = m.GraphitePath.ValueStringPointer()
-	data.Proto = m.GraphiteProto.ValueStringPointer()
-	data.OTelProto = m.OTelProto.ValueStringPointer()
-	data.OTelPath = m.OTelPath.ValueStringPointer()
-	data.OTelTimeout = m.OTelTimeout.ValueInt64Pointer()
-	data.OTelHeaders = m.OTelHeaders.ValueStringPointer()
-	data.OTelVerifySSL = proxmoxtypes.CustomBoolPtr(m.OTelVerifySSL.ValueBoolPointer())
-	data.OTelMaxBodySize = m.OTelMaxBodySize.ValueInt64Pointer()
-	data.OTelResourceAttributes = m.OTelResourceAttributes.ValueStringPointer()
-	data.OTelCompression = m.OTelCompression.ValueStringPointer()
+	data.Timeout = attribute.Int64PtrFromValue(m.Timeout)
+	data.Type = attribute.StringPtrFromValue(m.Type)
+	data.APIPathPrefix = attribute.StringPtrFromValue(m.InfluxAPIPathPrefix)
+	data.Bucket = attribute.StringPtrFromValue(m.InfluxBucket)
+	data.InfluxDBProto = attribute.StringPtrFromValue(m.InfluxDBProto)
+	data.MaxBodySize = attribute.Int64PtrFromValue(m.InfluxMaxBodySize)
+	data.Organization = attribute.StringPtrFromValue(m.InfluxOrganization)
+	data.Token = attribute.StringPtrFromValue(m.InfluxToken)
+	data.Verify = attribute.CustomBoolPtrFromValue(m.InfluxVerify)
+	data.Path = attribute.StringPtrFromValue(m.GraphitePath)
+	data.Proto = attribute.StringPtrFromValue(m.GraphiteProto)
+	data.OTelProto = attribute.StringPtrFromValue(m.OTelProto)
+	data.OTelPath = attribute.StringPtrFromValue(m.OTelPath)
+	data.OTelTimeout = attribute.Int64PtrFromValue(m.OTelTimeout)
+	data.OTelHeaders = attribute.StringPtrFromValue(m.OTelHeaders)
+	data.OTelVerifySSL = attribute.CustomBoolPtrFromValue(m.OTelVerifySSL)
+	data.OTelMaxBodySize = attribute.Int64PtrFromValue(m.OTelMaxBodySize)
+	data.OTelResourceAttributes = attribute.StringPtrFromValue(m.OTelResourceAttributes)
+	data.OTelCompression = attribute.StringPtrFromValue(m.OTelCompression)
 
 	return data
 }

--- a/fwprovider/cluster/metrics/model_metrics_server.go
+++ b/fwprovider/cluster/metrics/model_metrics_server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox/cluster/metrics"
+	proxmoxtypes "github.com/bpg/terraform-provider-proxmox/proxmox/types"
 )
 
 type metricsServerModel struct {
@@ -40,45 +41,20 @@ type metricsServerModel struct {
 	OTelCompression        types.String `tfsdk:"opentelemetry_compression"`
 }
 
-func boolToInt64Ptr(boolPtr *bool) *int64 {
-	if boolPtr != nil {
-		var result int64
-
-		if *boolPtr {
-			result = int64(1)
-		} else {
-			result = int64(0)
-		}
-
-		return &result
-	}
-
-	return nil
-}
-
-func int64ToBoolPtr(int64ptr *int64) *bool {
-	if int64ptr != nil {
-		var result bool
-
-		if *int64ptr == 0 {
-			result = false
-		} else {
-			result = true
-		}
-
-		return &result
-	}
-
-	return nil
-}
-
-// importFromAPI takes data from metrics server PVE API response and set fields based on it.
-// Note: API response does not contain name so it must be passed directly.
-func (m *metricsServerModel) importFromAPI(name string, data *metrics.ServerData) {
+// fromAPI populates the model from a metrics server PVE API response.
+// The API response does not contain the name, so it must be passed directly.
+func (m *metricsServerModel) fromAPI(name string, data *metrics.ServerData) {
 	m.ID = types.StringValue(name)
 	m.Name = types.StringValue(name)
 
-	m.Disable = types.BoolPointerValue(int64ToBoolPtr(data.Disable))
+	// `disable` has a schema Default of false; the API omits it when false, so
+	// normalize here. `verify-certificate` and `otel-verify-ssl` are type-specific
+	// and the caller preserves plan/state values; map API-provided values through
+	// and leave null otherwise so the caller's override path stays straightforward.
+	m.Disable = boolOrDefault(data.Disable, false)
+	m.InfluxVerify = types.BoolPointerValue(data.Verify.PointerBool())
+	m.OTelVerifySSL = types.BoolPointerValue(data.OTelVerifySSL.PointerBool())
+
 	m.MTU = types.Int64PointerValue(data.MTU)
 	m.Port = types.Int64Value(data.Port)
 	m.Server = types.StringValue(data.Server)
@@ -90,26 +66,49 @@ func (m *metricsServerModel) importFromAPI(name string, data *metrics.ServerData
 	m.InfluxMaxBodySize = types.Int64PointerValue(data.MaxBodySize)
 	m.InfluxOrganization = types.StringPointerValue(data.Organization)
 	m.InfluxToken = types.StringPointerValue(data.Token)
-	m.InfluxVerify = types.BoolPointerValue(int64ToBoolPtr(data.Verify))
 	m.GraphitePath = types.StringPointerValue(data.Path)
 	m.GraphiteProto = types.StringPointerValue(data.Proto)
 	m.OTelProto = types.StringPointerValue(data.OTelProto)
 	m.OTelPath = types.StringPointerValue(data.OTelPath)
 	m.OTelTimeout = types.Int64PointerValue(data.OTelTimeout)
 	m.OTelHeaders = types.StringPointerValue(data.OTelHeaders)
-	m.OTelVerifySSL = types.BoolPointerValue(int64ToBoolPtr(data.OTelVerifySSL))
 	m.OTelMaxBodySize = types.Int64PointerValue(data.OTelMaxBodySize)
 	m.OTelResourceAttributes = types.StringPointerValue(data.OTelResourceAttributes)
 	m.OTelCompression = types.StringPointerValue(data.OTelCompression)
 }
 
-// toAPIRequestBody creates metrics server request data for PUT and POST requests.
-func (m *metricsServerModel) toAPIRequestBody() *metrics.ServerRequestData {
+// boolOrDefault returns the value pointed to by b, falling back to def when nil.
+// Used for API fields that the server omits when they equal the default.
+func boolOrDefault(b *proxmoxtypes.CustomBool, def bool) types.Bool {
+	if v := b.PointerBool(); v != nil {
+		return types.BoolValue(*v)
+	}
+
+	return types.BoolValue(def)
+}
+
+// preserveTypeSpecificBools copies InfluxVerify and OTelVerifySSL from src onto dst
+// when dst has null values. PVE omits these fields from GET responses when they equal
+// the server default, so the caller's plan (Create/Update) or prior state (Read) is
+// the authoritative source. A universal schema Default would leak the value into
+// toAPI for non-matching server types, which PVE rejects.
+func preserveTypeSpecificBools(dst, src *metricsServerModel) {
+	if dst.InfluxVerify.IsNull() {
+		dst.InfluxVerify = src.InfluxVerify
+	}
+
+	if dst.OTelVerifySSL.IsNull() {
+		dst.OTelVerifySSL = src.OTelVerifySSL
+	}
+}
+
+// toAPI converts the Terraform model to a metrics server request body used for both POST and PUT.
+func (m *metricsServerModel) toAPI() *metrics.ServerRequestData {
 	data := &metrics.ServerRequestData{}
 
 	data.ID = m.Name.ValueString()
 
-	data.Disable = boolToInt64Ptr(m.Disable.ValueBoolPointer())
+	data.Disable = proxmoxtypes.CustomBoolPtr(m.Disable.ValueBoolPointer())
 	data.MTU = m.MTU.ValueInt64Pointer()
 	data.Port = m.Port.ValueInt64()
 	data.Server = m.Server.ValueString()
@@ -121,14 +120,14 @@ func (m *metricsServerModel) toAPIRequestBody() *metrics.ServerRequestData {
 	data.MaxBodySize = m.InfluxMaxBodySize.ValueInt64Pointer()
 	data.Organization = m.InfluxOrganization.ValueStringPointer()
 	data.Token = m.InfluxToken.ValueStringPointer()
-	data.Verify = boolToInt64Ptr(m.InfluxVerify.ValueBoolPointer())
+	data.Verify = proxmoxtypes.CustomBoolPtr(m.InfluxVerify.ValueBoolPointer())
 	data.Path = m.GraphitePath.ValueStringPointer()
 	data.Proto = m.GraphiteProto.ValueStringPointer()
 	data.OTelProto = m.OTelProto.ValueStringPointer()
 	data.OTelPath = m.OTelPath.ValueStringPointer()
 	data.OTelTimeout = m.OTelTimeout.ValueInt64Pointer()
 	data.OTelHeaders = m.OTelHeaders.ValueStringPointer()
-	data.OTelVerifySSL = boolToInt64Ptr(m.OTelVerifySSL.ValueBoolPointer())
+	data.OTelVerifySSL = proxmoxtypes.CustomBoolPtr(m.OTelVerifySSL.ValueBoolPointer())
 	data.OTelMaxBodySize = m.OTelMaxBodySize.ValueInt64Pointer()
 	data.OTelResourceAttributes = m.OTelResourceAttributes.ValueStringPointer()
 	data.OTelCompression = m.OTelCompression.ValueStringPointer()
@@ -153,13 +152,16 @@ type metricsServerDatasourceModel struct {
 	OTelCompression        types.String `tfsdk:"opentelemetry_compression"`
 }
 
-// importFromAPI takes data from metrics server PVE API response and set fields based on it.
-// Note: API response does not contain name so it must be passed directly.
-func (m *metricsServerDatasourceModel) importFromAPI(name string, data *metrics.ServerData) {
+// fromAPI populates the datasource model from a metrics server PVE API response.
+// The API response does not contain the name, so it must be passed directly.
+func (m *metricsServerDatasourceModel) fromAPI(name string, data *metrics.ServerData) {
 	m.ID = types.StringValue(name)
 	m.Name = types.StringValue(name)
 
-	m.Disable = types.BoolPointerValue(int64ToBoolPtr(data.Disable))
+	// `disable` is omitted when false; the rest pass through directly.
+	m.Disable = boolOrDefault(data.Disable, false)
+	m.OTelVerifySSL = types.BoolPointerValue(data.OTelVerifySSL.PointerBool())
+
 	m.Port = types.Int64Value(data.Port)
 	m.Server = types.StringValue(data.Server)
 	m.Type = types.StringPointerValue(data.Type)
@@ -167,7 +169,6 @@ func (m *metricsServerDatasourceModel) importFromAPI(name string, data *metrics.
 	m.OTelPath = types.StringPointerValue(data.OTelPath)
 	m.OTelTimeout = types.Int64PointerValue(data.OTelTimeout)
 	m.OTelHeaders = types.StringPointerValue(data.OTelHeaders)
-	m.OTelVerifySSL = types.BoolPointerValue(int64ToBoolPtr(data.OTelVerifySSL))
 	m.OTelMaxBodySize = types.Int64PointerValue(data.OTelMaxBodySize)
 	m.OTelResourceAttributes = types.StringPointerValue(data.OTelResourceAttributes)
 	m.OTelCompression = types.StringPointerValue(data.OTelCompression)

--- a/fwprovider/cluster/metrics/resource_metrics_server.go
+++ b/fwprovider/cluster/metrics/resource_metrics_server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -90,9 +91,10 @@ func (r *metricsServerResource) Schema(
 				},
 			},
 			"disable": schema.BoolAttribute{
-				Description: "Set this to `true` to disable this metric server.",
+				Description: "Set this to `true` to disable this metric server. Defaults to `false`.",
 				Optional:    true,
-				Default:     nil,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 			},
 			"mtu": schema.Int64Attribute{
 				Description: "MTU (maximum transmission unit) for metrics transmission over UDP. " +
@@ -162,9 +164,8 @@ func (r *metricsServerResource) Schema(
 			},
 			"influx_verify": schema.BoolAttribute{
 				Description: "Set to `false` to disable certificate verification for https " +
-					"endpoints.",
+					"endpoints. If not set, PVE default is `true`.",
 				Optional: true,
-				Default:  nil,
 			},
 			"graphite_path": schema.StringAttribute{
 				Description: "Root graphite path (ex: `proxmox.mycluster.mykey`).",
@@ -208,7 +209,6 @@ func (r *metricsServerResource) Schema(
 				Description: "OpenTelemetry verify SSL certificates. " +
 					"If not set, PVE default is `true`.",
 				Optional: true,
-				Default:  nil,
 			},
 			"opentelemetry_max_body_size": schema.Int64Attribute{
 				Description: "OpenTelemetry maximum request body size in bytes. " +
@@ -255,18 +255,16 @@ func (r *metricsServerResource) Read(
 			return
 		}
 
-		resp.Diagnostics.AddError(
-			"Unable to Refresh Resource",
-			"An unexpected error occurred while attempting to refresh resource state. "+
-				"Please retry the operation or report this issue to the provider developers.\n\n"+
-				"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError("Unable to Read Metrics Server", err.Error())
 
 		return
 	}
 
 	readModel := &metricsServerModel{}
-	readModel.importFromAPI(state.ID.ValueString(), data)
+	readModel.fromAPI(state.ID.ValueString(), data)
+	// PVE omits verify-certificate / otel-verify-ssl from GET responses when they equal
+	// the server default; preserve the prior state so we don't churn them to null.
+	preserveTypeSpecificBools(readModel, &state)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, readModel)...)
 }
@@ -284,22 +282,25 @@ func (r *metricsServerResource) Create(
 		return
 	}
 
-	reqData := plan.toAPIRequestBody()
-
-	err := r.client.CreateServer(ctx, reqData)
+	err := r.client.CreateServer(ctx, plan.toAPI())
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Create Resource",
-			"An unexpected error occurred while creating the resource create request.\n\n"+
-				"Error: "+err.Error(),
-		)
-
+		resp.Diagnostics.AddError("Unable to Create Metrics Server", err.Error())
 		return
 	}
 
-	plan.ID = plan.Name
+	data, err := r.client.GetServer(ctx, plan.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to Read Metrics Server After Creation", err.Error())
+		return
+	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	readModel := &metricsServerModel{}
+	readModel.fromAPI(plan.Name.ValueString(), data)
+	// PVE omits verify-certificate / otel-verify-ssl from GET responses when they equal
+	// the server default; preserve the plan so explicit values survive the round-trip.
+	preserveTypeSpecificBools(readModel, &plan)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, readModel)...)
 }
 
 func (r *metricsServerResource) Update(
@@ -341,21 +342,28 @@ func (r *metricsServerResource) Update(
 	attribute.CheckDelete(plan.OTelResourceAttributes, state.OTelResourceAttributes, &toDelete, "otel-resource-attributes")
 	attribute.CheckDelete(plan.OTelCompression, state.OTelCompression, &toDelete, "otel-compression")
 
-	reqData := plan.toAPIRequestBody()
+	reqData := plan.toAPI()
 	reqData.Delete = toDelete
 
 	err := r.client.UpdateServer(ctx, reqData)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Update Resource",
-			"An unexpected error occurred while creating the resource update request.\n\n"+
-				"Error: "+err.Error(),
-		)
-
+		resp.Diagnostics.AddError("Unable to Update Metrics Server", err.Error())
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	data, err := r.client.GetServer(ctx, plan.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to Read Metrics Server After Update", err.Error())
+		return
+	}
+
+	readModel := &metricsServerModel{}
+	readModel.fromAPI(plan.Name.ValueString(), data)
+	// PVE omits verify-certificate / otel-verify-ssl from GET responses when they equal
+	// the server default; preserve the plan so explicit values survive the round-trip.
+	preserveTypeSpecificBools(readModel, &plan)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, readModel)...)
 }
 
 func (r *metricsServerResource) Delete(
@@ -372,18 +380,8 @@ func (r *metricsServerResource) Delete(
 	}
 
 	err := r.client.DeleteServer(ctx, state.ID.ValueString())
-	if err != nil {
-		if errors.Is(err, api.ErrResourceDoesNotExist) {
-			return
-		}
-
-		resp.Diagnostics.AddError(
-			"Unable to Delete Resource",
-			"An unexpected error occurred while creating the resource delete request.\n\n"+
-				"Error: "+err.Error(),
-		)
-
-		return
+	if err != nil && !errors.Is(err, api.ErrResourceDoesNotExist) {
+		resp.Diagnostics.AddError("Unable to Delete Metrics Server", err.Error())
 	}
 }
 
@@ -396,25 +394,20 @@ func (r *metricsServerResource) ImportState(
 	if err != nil {
 		if errors.Is(err, api.ErrResourceDoesNotExist) {
 			resp.Diagnostics.AddError(
-				"Resource does not exist",
-				"Resource you try to import does not exist.\n\n"+
-					"Error: "+err.Error(),
+				"Metrics Server Not Found",
+				fmt.Sprintf("Metrics server with ID %q was not found", req.ID),
 			)
 
 			return
 		}
 
-		resp.Diagnostics.AddError(
-			"Unable to Import Resource",
-			"An unexpected error occurred while attempting to import resource state.\n\n"+
-				"Error: "+err.Error(),
-		)
+		resp.Diagnostics.AddError("Unable to Import Metrics Server", err.Error())
 
 		return
 	}
 
 	readModel := &metricsServerModel{}
-	readModel.importFromAPI(req.ID, data)
+	readModel.fromAPI(req.ID, data)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, readModel)...)
 }

--- a/fwprovider/cluster/metrics/resource_metrics_server_test.go
+++ b/fwprovider/cluster/metrics/resource_metrics_server_test.go
@@ -38,15 +38,15 @@ func TestAccResourceMetricsServer(t *testing.T) {
 				  }`),
 				Check: resource.ComposeTestCheckFunc(
 					test.ResourceAttributes("proxmox_metrics_server.acc_influxdb_server", map[string]string{
-						"id":     "acc_example_influxdb_server",
-						"name":   "acc_example_influxdb_server",
-						"mtu":    "1000",
-						"port":   "18089",
-						"server": "192.168.3.2",
-						"type":   "influxdb",
+						"id":      "acc_example_influxdb_server",
+						"name":    "acc_example_influxdb_server",
+						"mtu":     "1000",
+						"port":    "18089",
+						"server":  "192.168.3.2",
+						"type":    "influxdb",
+						"disable": "false",
 					}),
 					test.NoResourceAttributesSet("proxmox_metrics_server.acc_influxdb_server", []string{
-						"disable",
 						"timeout",
 						"influx_api_path_prefix",
 						"influx_bucket",
@@ -81,9 +81,9 @@ func TestAccResourceMetricsServer(t *testing.T) {
 						"server":        "192.168.3.2",
 						"type":          "influxdb",
 						"influx_bucket": "xxxxx",
+						"disable":       "false",
 					}),
 					test.NoResourceAttributesSet("proxmox_metrics_server.acc_influxdb_server", []string{
-						"disable",
 						"timeout",
 						"influx_api_path_prefix",
 						"influx_db_proto",
@@ -115,9 +115,9 @@ func TestAccResourceMetricsServer(t *testing.T) {
 						"server":        "192.168.3.2",
 						"type":          "influxdb",
 						"influx_bucket": "xxxxx",
+						"disable":       "false",
 					}),
 					test.NoResourceAttributesSet("proxmox_metrics_server.acc_influxdb_server", []string{
-						"disable",
 						"timeout",
 						"mtu",
 						"influx_api_path_prefix",
@@ -132,6 +132,49 @@ func TestAccResourceMetricsServer(t *testing.T) {
 						"opentelemetry_path",
 					}),
 				),
+			},
+		}},
+		{"create disabled influxdb server with verify toggle & round-trip bools", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_metrics_server" "acc_influxdb_bools" {
+					name           = "acc_example_influxdb_bools"
+					server         = "192.168.3.2"
+					port           = 18090
+					type           = "influxdb"
+					disable        = true
+					influx_verify  = false
+				  }`),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_metrics_server.acc_influxdb_bools", map[string]string{
+						"disable":       "true",
+						"influx_verify": "false",
+						"port":          "18090",
+						"type":          "influxdb",
+					}),
+				),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_metrics_server" "acc_influxdb_bools" {
+					name           = "acc_example_influxdb_bools"
+					server         = "192.168.3.2"
+					port           = 18090
+					type           = "influxdb"
+					disable        = false
+					influx_verify  = true
+				  }`),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_metrics_server.acc_influxdb_bools", map[string]string{
+						"disable":       "false",
+						"influx_verify": "true",
+					}),
+				),
+			},
+			{
+				ResourceName:      "proxmox_metrics_server.acc_influxdb_bools",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		}},
 		{"create graphite udp metrics server & import it", []resource.TestStep{

--- a/proxmox/cluster/metrics/server.go
+++ b/proxmox/cluster/metrics/server.go
@@ -75,7 +75,7 @@ func (c *Client) CreateServer(ctx context.Context, data *ServerRequestData) erro
 func (c *Client) DeleteServer(ctx context.Context, id string) error {
 	err := c.DoRequest(ctx, http.MethodDelete, c.ExpandPath(id), nil, nil)
 	if err != nil {
-		return fmt.Errorf("error updating metrics server: %w", err)
+		return fmt.Errorf("error deleting metrics server: %w", err)
 	}
 
 	return nil

--- a/proxmox/cluster/metrics/server_types.go
+++ b/proxmox/cluster/metrics/server_types.go
@@ -6,38 +6,42 @@
 
 package metrics
 
+import (
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
+)
+
 // ServerData contains the data from a metrics server response.
 type ServerData struct {
-	Disable *int64  `json:"disable,omitempty" url:"disable,omitempty"`
-	ID      string  `json:"id,omitempty"      url:"id,omitempty"`
-	MTU     *int64  `json:"mtu"               url:"mtu,omitempty"`
-	Port    int64   `json:"port"              url:"port"`
-	Server  string  `json:"server"            url:"server"`
-	Timeout *int64  `json:"timeout,omitempty" url:"timeout,omitempty"`
-	Type    *string `json:"type,omitempty"    url:"type,omitempty"`
+	Disable *types.CustomBool `json:"disable,omitempty" url:"disable,omitempty,int"`
+	ID      string            `json:"id,omitempty"      url:"id,omitempty"`
+	MTU     *int64            `json:"mtu"               url:"mtu,omitempty"`
+	Port    int64             `json:"port"              url:"port"`
+	Server  string            `json:"server"            url:"server"`
+	Timeout *int64            `json:"timeout,omitempty" url:"timeout,omitempty"`
+	Type    *string           `json:"type,omitempty"    url:"type,omitempty"`
 
 	// influxdb only options
-	APIPathPrefix *string `json:"api-path-prefix,omitempty"    url:"api-path-prefix,omitempty"`
-	Bucket        *string `json:"bucket,omitempty"             url:"bucket,omitempty"`
-	InfluxDBProto *string `json:"influxdbproto,omitempty"      url:"influxdbproto,omitempty"`
-	MaxBodySize   *int64  `json:"max-body-size,omitempty"      url:"max-body-size,omitempty"`
-	Organization  *string `json:"organization,omitempty"       url:"organization,omitempty"`
-	Token         *string `json:"token,omitempty"              url:"token,omitempty"`
-	Verify        *int64  `json:"verify-certificate,omitempty" url:"verify-certificate,omitempty"`
+	APIPathPrefix *string           `json:"api-path-prefix,omitempty"    url:"api-path-prefix,omitempty"`
+	Bucket        *string           `json:"bucket,omitempty"             url:"bucket,omitempty"`
+	InfluxDBProto *string           `json:"influxdbproto,omitempty"      url:"influxdbproto,omitempty"`
+	MaxBodySize   *int64            `json:"max-body-size,omitempty"      url:"max-body-size,omitempty"`
+	Organization  *string           `json:"organization,omitempty"       url:"organization,omitempty"`
+	Token         *string           `json:"token,omitempty"              url:"token,omitempty"`
+	Verify        *types.CustomBool `json:"verify-certificate,omitempty" url:"verify-certificate,omitempty,int"`
 
 	// graphite only options
 	Path  *string `json:"path,omitempty"  url:"path,omitempty"`
 	Proto *string `json:"proto,omitempty" url:"proto,omitempty"`
 
 	// opentelemetry only options
-	OTelProto              *string `json:"otel-protocol,omitempty"            url:"otel-protocol,omitempty"`
-	OTelPath               *string `json:"otel-path,omitempty"                url:"otel-path,omitempty"`
-	OTelTimeout            *int64  `json:"otel-timeout,omitempty"             url:"otel-timeout,omitempty"`
-	OTelHeaders            *string `json:"otel-headers,omitempty"             url:"otel-headers,omitempty"`
-	OTelVerifySSL          *int64  `json:"otel-verify-ssl,omitempty"          url:"otel-verify-ssl,omitempty"`
-	OTelMaxBodySize        *int64  `json:"otel-max-body-size,omitempty"       url:"otel-max-body-size,omitempty"`
-	OTelResourceAttributes *string `json:"otel-resource-attributes,omitempty" url:"otel-resource-attributes,omitempty"`
-	OTelCompression        *string `json:"otel-compression,omitempty"         url:"otel-compression,omitempty"`
+	OTelProto              *string           `json:"otel-protocol,omitempty"            url:"otel-protocol,omitempty"`
+	OTelPath               *string           `json:"otel-path,omitempty"                url:"otel-path,omitempty"`
+	OTelTimeout            *int64            `json:"otel-timeout,omitempty"             url:"otel-timeout,omitempty"`
+	OTelHeaders            *string           `json:"otel-headers,omitempty"             url:"otel-headers,omitempty"`
+	OTelVerifySSL          *types.CustomBool `json:"otel-verify-ssl,omitempty"          url:"otel-verify-ssl,omitempty,int"`
+	OTelMaxBodySize        *int64            `json:"otel-max-body-size,omitempty"       url:"otel-max-body-size,omitempty"`
+	OTelResourceAttributes *string           `json:"otel-resource-attributes,omitempty" url:"otel-resource-attributes,omitempty"`
+	OTelCompression        *string           `json:"otel-compression,omitempty"         url:"otel-compression,omitempty"`
 }
 
 // ServerResponseBody contains the body from a metrics server response.


### PR DESCRIPTION
### What does this PR do?

Brings `proxmox_metrics_server` in line with the Framework consistency audit findings from #2769 and with the conventions codified in ADR-003/004/005. Concretely:

- **API read-back after Create and Update** — prior code saved plan data directly to state, so server-computed defaults and API-side transformations were never captured. The resource now calls `GetServer` after each mutation and builds state from the response (mirrors the VNet gold-standard pattern).
- **Canonical model methods** — `importFromAPI` / `toAPIRequestBody` renamed to `fromAPI` / `toAPI` per ADR-004 ("Model-API Conversion"). Local `boolToInt64Ptr` / `int64ToBoolPtr` helpers removed; API types now use `*proxmoxtypes.CustomBool` with the `,int` url-tag modifier (matches `proxmox/cluster/sdn/vnets/vnets_types.go`).
- **Error messages** — replaced generic "Unable to Create/Refresh/Update/Delete/Import Resource" with "Unable to {Verb} Metrics Server", removed boilerplate detail strings in favor of plain `err.Error()`, and replaced the import-not-found "Resource does not exist" with "Metrics Server Not Found" (ADR-005).
- **Datasource** — added `ErrResourceDoesNotExist` handling ("Metrics Server Not Found") and updated error text; no behavioral regression.
- **Domain client fix** — `DeleteServer` error message now says "error deleting" instead of "error updating" (copy-paste bug, also in #2735).
- **`disable` default** — `disable` is now `Optional+Computed+Default(false)`. PVE omits `disable` from GET responses when it's `false`, and the read-back pattern requires a schema default to stay consistent with Terraform's plan ↔ state invariant. This mirrors the `disable` handling in Replication (see `docs/adr/reference-examples.md` §fromAPI quirks).

The two type-specific bool fields (`influx_verify`, `opentelemetry_verify_ssl`) have the same "omit when equals server default" API quirk, but a universal schema default would leak the value into `toAPI` for non-matching server types (PVE returns `500: unexpected property`). They're handled instead by a small `preserveTypeSpecificBools` helper that restores the plan (Create/Update) or prior state (Read) after read-back.

### Usage Example

No UX change for existing configurations. Example exercising the refactored behavior:

```hcl
resource "proxmox_metrics_server" "influxdb" {
  name          = "my-influxdb"
  server        = "192.168.3.2"
  port          = 18089
  type          = "influxdb"
  disable       = false    # now round-trips cleanly; see upgrade guide
  influx_bucket = "proxmox"
  influx_verify = false    # type-specific; preserved across read-back
}
```

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation — schema description for `disable` regenerated via `make docs`; upgrade guide entry added.
- [x] I have added / updated acceptance tests — new `create disabled influxdb server with verify toggle & round-trip bools` scenario exercises the `CustomBool` serialization and bool preservation paths; existing scenarios updated to reflect the new `disable = false` default.
- [x] I have considered backward compatibility — no schema field removals or type changes affecting config; see compatibility note below.
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md). (N/A — existing resource.)
- [ ] I have run `make example` to verify the change works. (N/A — no SDK / provider config changes.)

#### Compatibility Note

`proxmox_metrics_server.disable` (and its alias) now has a schema default of `false`. Configs that don't set `disable` will see a one-time `disable: null -> false` diff on the first `terraform plan` after upgrading. No config changes required; the apply is a no-op against the Proxmox API (both representations map to "not disabled"). Documented in `docs/guides/upgrade.md` for discoverability.

### Proof of Work

Full checklist results and evidence in `.dev/2769_REPORT.md`.

**Acceptance test run:**

```text
$ ./testacc TestAccResourceMetricsServer -- -v

=== RUN   TestAccResourceMetricsServer
=== RUN   TestAccResourceMetricsServer/create_influxdb_udp_server_&_update_it_&_again_to_default_mtu
=== RUN   TestAccResourceMetricsServer/create_disabled_influxdb_server_with_verify_toggle_&_round-trip_bools
=== RUN   TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_import_it
=== RUN   TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_test_datasource
=== RUN   TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_import_it
=== RUN   TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_test_datasource
--- PASS: TestAccResourceMetricsServer (0.00s)
    --- PASS: TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_test_datasource (1.73s)
    --- PASS: TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_import_it (1.85s)
    --- PASS: TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_test_datasource (0.12s)
    --- PASS: TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_import_it (0.12s)
    --- PASS: TestAccResourceMetricsServer/create_disabled_influxdb_server_with_verify_toggle_&_round-trip_bools (2.84s)
    --- PASS: TestAccResourceMetricsServer/create_influxdb_udp_server_&_update_it_&_again_to_default_mtu (3.40s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/metrics	4.019s
```

Two `opentelemetry_*` scenarios skip via their existing `SkipFunc` — pre-existing gap; OTel acceptance requires a local collector. Not in scope for this refactor.

**Test coverage of the behavioral changes (Strong):**

- The new `create disabled influxdb server with verify toggle & round-trip bools` scenario creates a server with `disable = true, influx_verify = false`, updates to `disable = false, influx_verify = true`, and import-verifies — directly exercising the `CustomBool` URL encoding (`0`/`1`), the `disable` read-back normalization, and the `preserveTypeSpecificBools` path. A regression in any of these would fail this scenario.
- Existing `influxdb` and `graphite` scenarios verify that type-specific bools not being sent for non-matching server types still works (no regressions from the API type changes).

**Checklist results:**

| Step                                      | Status                             |
| ----------------------------------------- | ---------------------------------- |
| `make build`                              | PASSED                             |
| `make lint`                               | PASSED (0 issues)                  |
| `make test` (unit)                        | PASSED                             |
| `./testacc TestAccResourceMetricsServer`  | PASSED                             |
| `make docs`                               | PASSED (regenerated)               |
| Markdown lint                             | PASSED                             |
| Upgrade guide                             | UPDATED (`disable` default entry)  |

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2769

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.7). All changes have been reviewed and verified by a human.*
