### PR TITLE
feat(lxc): add `host_managed` option for container networking

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -235,6 +235,9 @@ output "ubuntu_container_public_key" {
         to `true`).
     - `firewall` - (Optional) Whether this interface's firewall rules should be
         used (defaults to `false`).
+    - `host_managed` - (Optional) Whether the host runs DHCP on this interface's
+        behalf (defaults to `false`). Required for application containers that
+        do not include a DHCP client.
     - `mac_address` - (Optional) The MAC address.
     - `mtu` - (Optional) Maximum transfer unit of the interface. Cannot be
         larger than the bridge's MTU.

--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -236,8 +236,8 @@ output "ubuntu_container_public_key" {
     - `firewall` - (Optional) Whether this interface's firewall rules should be
         used (defaults to `false`).
     - `host_managed` - (Optional) Whether the host runs DHCP on this interface's
-        behalf (defaults to `false`). Required for application containers that
-        do not include a DHCP client.
+        behalf (defaults to `false`). Requires Proxmox VE 9.0+. Required for
+        application containers that do not include a DHCP client.
     - `mac_address` - (Optional) The MAC address.
     - `mtu` - (Optional) Maximum transfer unit of the interface. Cannot be
         larger than the bridge's MTU.

--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -2328,6 +2328,120 @@ func TestAccResourceContainerCPUUnitsDefault(t *testing.T) {
 	})
 }
 
+// TestAccResourceContainerHostManaged covers create-with-true and the true→false toggle on update.
+// The toggle step is the regression check: it only converges if the provider sends `host-managed=0`.
+// Requires Proxmox VE 9.0+.
+func TestAccResourceContainerHostManaged(t *testing.T) {
+	te := InitEnvironment(t)
+	imageFileName := fmt.Sprintf("%d-alpine-3.22-default_20250617_amd64.tar.xz", time.Now().UnixMicro())
+	testAccDownloadContainerTemplate(t, te, imageFileName)
+
+	accTestContainerID := 100000 + rand.Intn(99999)
+
+	te.AddTemplateVars(map[string]interface{}{
+		"ImageFileName":   imageFileName,
+		"TestContainerID": accTestContainerID,
+	})
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_container" "test_container" {
+					node_name    = "{{.NodeName}}"
+					vm_id        = {{.TestContainerID}}
+					unprivileged = true
+					disk {
+						datastore_id = "local-lvm"
+						size         = 4
+					}
+					initialization {
+						hostname = "test-host-managed"
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_interface {
+						name         = "eth0"
+						bridge       = "vmbr0"
+						host_managed = true
+					}
+					operating_system {
+						template_file_id = "local:vztmpl/{{.ImageFileName}}"
+						type             = "alpine"
+					}
+				}`, WithRootUser()),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"network_interface.0.host_managed": "true",
+					}),
+					func(*terraform.State) error {
+						ctInfo, err := te.NodeClient().Container(accTestContainerID).GetContainer(t.Context())
+						require.NoError(te.t, err, "failed to get container")
+
+						net0, ok := ctInfo.NetworkInterfaces["net0"]
+						require.True(te.t, ok, `"net0" interface not found`)
+						require.NotNil(te.t, net0.HostManaged, "host-managed should be present on the API after create")
+						require.True(te.t, bool(*net0.HostManaged), "host-managed should be 1 on the API after create")
+
+						return nil
+					},
+				),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_container" "test_container" {
+					node_name    = "{{.NodeName}}"
+					vm_id        = {{.TestContainerID}}
+					unprivileged = true
+					disk {
+						datastore_id = "local-lvm"
+						size         = 4
+					}
+					initialization {
+						hostname = "test-host-managed"
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_interface {
+						name         = "eth0"
+						bridge       = "vmbr0"
+						host_managed = false
+					}
+					operating_system {
+						template_file_id = "local:vztmpl/{{.ImageFileName}}"
+						type             = "alpine"
+					}
+				}`, WithRootUser()),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"network_interface.0.host_managed": "false",
+					}),
+					func(*terraform.State) error {
+						ctInfo, err := te.NodeClient().Container(accTestContainerID).GetContainer(t.Context())
+						require.NoError(te.t, err, "failed to get container")
+
+						net0, ok := ctInfo.NetworkInterfaces["net0"]
+						require.True(te.t, ok, `"net0" interface not found`)
+						// PVE <9 omits the key entirely; only assert when present.
+						if net0.HostManaged != nil {
+							require.False(te.t, bool(*net0.HostManaged), "host-managed should be 0 on the API after toggle to false")
+						}
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func testAccDownloadContainerTemplate(t *testing.T, te *Environment, imageFileName string) {
 	t.Helper()
 	err := te.NodeStorageClient().DownloadFileByURL(context.Background(), &storage.DownloadURLPostRequestBody{

--- a/proxmox/nodes/containers/containers_types.go
+++ b/proxmox/nodes/containers/containers_types.go
@@ -124,20 +124,21 @@ type CustomMountPoints map[string]*CustomMountPoint
 
 // CustomNetworkInterface contains the values for the "net[n]" properties.
 type CustomNetworkInterface struct {
-	Bridge      *string           `json:"bridge,omitempty"   url:"bridge,omitempty"`
-	Enabled     bool              `json:"-"                  url:"-"`
-	Firewall    *types.CustomBool `json:"firewall,omitempty" url:"firewall,omitempty,int"`
-	IPv4Address *string           `json:"ip,omitempty"       url:"ip,omitempty"`
-	IPv4Gateway *string           `json:"gw,omitempty"       url:"gw,omitempty"`
-	IPv6Address *string           `json:"ip6,omitempty"      url:"ip6,omitempty"`
-	IPv6Gateway *string           `json:"gw6,omitempty"      url:"gw6,omitempty"`
-	MACAddress  *string           `json:"hwaddr,omitempty"   url:"hwaddr,omitempty"`
-	MTU         *int              `json:"mtu,omitempty"      url:"mtu,omitempty"`
-	Name        string            `json:"name"               url:"name"`
-	RateLimit   *float64          `json:"rate,omitempty"     url:"rate,omitempty"`
-	Tag         *int              `json:"tag,omitempty"      url:"tag,omitempty"`
-	Trunks      *[]int            `json:"trunks,omitempty"   url:"trunks,omitempty"`
-	Type        *string           `json:"type,omitempty"     url:"type,omitempty"`
+	Bridge      *string           `json:"bridge,omitempty"       url:"bridge,omitempty"`
+	Enabled     bool              `json:"-"                      url:"-"`
+	Firewall    *types.CustomBool `json:"firewall,omitempty"     url:"firewall,omitempty,int"`
+	HostManaged *types.CustomBool `json:"host-managed,omitempty" url:"host-managed,omitempty,int"`
+	IPv4Address *string           `json:"ip,omitempty"           url:"ip,omitempty"`
+	IPv4Gateway *string           `json:"gw,omitempty"           url:"gw,omitempty"`
+	IPv6Address *string           `json:"ip6,omitempty"          url:"ip6,omitempty"`
+	IPv6Gateway *string           `json:"gw6,omitempty"          url:"gw6,omitempty"`
+	MACAddress  *string           `json:"hwaddr,omitempty"       url:"hwaddr,omitempty"`
+	MTU         *int              `json:"mtu,omitempty"          url:"mtu,omitempty"`
+	Name        string            `json:"name"                   url:"name"`
+	RateLimit   *float64          `json:"rate,omitempty"         url:"rate,omitempty"`
+	Tag         *int              `json:"tag,omitempty"          url:"tag,omitempty"`
+	Trunks      *[]int            `json:"trunks,omitempty"       url:"trunks,omitempty"`
+	Type        *string           `json:"type,omitempty"         url:"type,omitempty"`
 }
 
 // CustomPassthroughDevices is a map of CustomPassthroughDevice per passthrough device ID (i.e. `dev0`).
@@ -575,6 +576,14 @@ func (r *CustomNetworkInterface) EncodeValues(
 		}
 	}
 
+	if r.HostManaged != nil {
+		if *r.HostManaged {
+			values = append(values, "host-managed=1")
+		} else {
+			values = append(values, "host-managed=0")
+		}
+	}
+
 	if r.IPv4Address != nil {
 		values = append(values, fmt.Sprintf("ip=%s", *r.IPv4Address))
 	}
@@ -919,6 +928,8 @@ func (r *CustomNetworkInterface) UnmarshalJSON(b []byte) error {
 				r.Bridge = &v[1]
 			case "firewall":
 				r.Firewall = types.CustomBool(v[1] == "1").Pointer()
+			case "host-managed":
+				r.HostManaged = types.CustomBool(v[1] == "1").Pointer()
 			case "gw":
 				r.IPv4Gateway = &v[1]
 			case "gw6":

--- a/proxmox/nodes/containers/containers_types_test.go
+++ b/proxmox/nodes/containers/containers_types_test.go
@@ -8,10 +8,14 @@ package containers
 
 import (
 	"encoding/json"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
 )
 
 func TestCustomLXCConfig_UnmarshalJSON(t *testing.T) {
@@ -156,4 +160,46 @@ func TestGetResponseData_UnmarshalJSON_WithIDMaps(t *testing.T) {
 	assert.Equal(t, 100000, data.LXCConfig.IDMaps[1].HostID)
 	assert.Equal(t, 65536, data.LXCConfig.IDMaps[1].Size)
 	require.Len(t, data.LXCConfig.Raw, 2)
+}
+
+func TestCustomNetworkInterface_HostManaged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  *bool // nil = absent, else expected value
+	}{
+		{"host-managed=1", `"name=eth0,bridge=vmbr0,host-managed=1"`, ptr.Ptr(true)},
+		{"host-managed=0", `"name=eth0,bridge=vmbr0,host-managed=0"`, ptr.Ptr(false)},
+		{"flag absent", `"name=eth0,bridge=vmbr0"`, nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var ni CustomNetworkInterface
+			require.NoError(t, json.Unmarshal([]byte(tc.input), &ni))
+
+			if tc.want == nil {
+				assert.Nil(t, ni.HostManaged)
+				return
+			}
+
+			require.NotNil(t, ni.HostManaged)
+			assert.Equal(t, *tc.want, bool(*ni.HostManaged))
+
+			v := url.Values{}
+			require.NoError(t, ni.EncodeValues("net0", &v))
+			encoded := v.Get("net0")
+
+			expected := "host-managed=0"
+			if *tc.want {
+				expected = "host-managed=1"
+			}
+			assert.True(t, strings.Contains(encoded, expected),
+				"expected EncodeValues output %q to contain %q", encoded, expected)
+		})
+	}
 }

--- a/proxmox/nodes/containers/containers_types_test.go
+++ b/proxmox/nodes/containers/containers_types_test.go
@@ -9,13 +9,10 @@ package containers
 import (
 	"encoding/json"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
 )
 
 func TestCustomLXCConfig_UnmarshalJSON(t *testing.T) {
@@ -170,8 +167,8 @@ func TestCustomNetworkInterface_HostManaged(t *testing.T) {
 		input string
 		want  *bool // nil = absent, else expected value
 	}{
-		{"host-managed=1", `"name=eth0,bridge=vmbr0,host-managed=1"`, ptr.Ptr(true)},
-		{"host-managed=0", `"name=eth0,bridge=vmbr0,host-managed=0"`, ptr.Ptr(false)},
+		{"host-managed=1", `"name=eth0,bridge=vmbr0,host-managed=1"`, new(true)},
+		{"host-managed=0", `"name=eth0,bridge=vmbr0,host-managed=0"`, new(false)},
 		{"flag absent", `"name=eth0,bridge=vmbr0"`, nil},
 	}
 
@@ -198,7 +195,8 @@ func TestCustomNetworkInterface_HostManaged(t *testing.T) {
 			if *tc.want {
 				expected = "host-managed=1"
 			}
-			assert.True(t, strings.Contains(encoded, expected),
+
+			assert.Contains(t, encoded, expected,
 				"expected EncodeValues output %q to contain %q", encoded, expected)
 		})
 	}

--- a/proxmox/version/capabilities.go
+++ b/proxmox/version/capabilities.go
@@ -24,3 +24,9 @@ func (v *ProxmoxVersion) SupportImportContentType() bool {
 func (v *ProxmoxVersion) SupportModernAptSources() bool {
 	return v.GreaterThanOrEqual(version.Must(version.NewVersion("9.0.0")))
 }
+
+// SupportContainerHostManaged checks if the Proxmox version supports the `host-managed` flag on LXC network interfaces.
+// PVE 9.0+ accepts the flag; older releases reject the unknown sub-key.
+func (v *ProxmoxVersion) SupportContainerHostManaged() bool {
+	return v.GreaterThanOrEqual(version.Must(version.NewVersion("9.0.0")))
+}

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -930,7 +930,7 @@ func Container() *schema.Resource {
 						},
 						mkNetworkInterfaceHostManaged: {
 							Type:        schema.TypeBool,
-							Description: "Whether the host runs DHCP on this interface's behalf.",
+							Description: "Whether the host runs DHCP on this interface's behalf. Requires Proxmox VE 9.0+.",
 							Optional:    true,
 							Default:     dvNetworkInterfaceHostManaged,
 						},

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -82,6 +82,7 @@ const (
 	dvNetworkInterfaceBridge            = "vmbr0"
 	dvNetworkInterfaceEnabled           = true
 	dvNetworkInterfaceFirewall          = false
+	dvNetworkInterfaceHostManaged       = false
 	dvNetworkInterfaceRateLimit         = 0
 	dvNetworkInterfaceVLANID            = 0
 	dvNetworkInterfaceMTU               = 0
@@ -181,6 +182,7 @@ const (
 	mkNetworkInterfaceBridge            = "bridge"
 	mkNetworkInterfaceEnabled           = "enabled"
 	mkNetworkInterfaceFirewall          = "firewall"
+	mkNetworkInterfaceHostManaged       = "host_managed"
 	mkNetworkInterfaceMACAddress        = "mac_address"
 	mkNetworkInterfaceName              = "name"
 	mkNetworkInterfaceRateLimit         = "rate_limit"
@@ -925,6 +927,12 @@ func Container() *schema.Resource {
 							Optional:    true,
 							Default:     dvNetworkInterfaceFirewall,
 						},
+						mkNetworkInterfaceHostManaged: {
+							Type:        schema.TypeBool,
+							Description: "Whether the host runs DHCP on this interface's behalf.",
+							Optional:    true,
+							Default:     dvNetworkInterfaceHostManaged,
+						},
 						mkNetworkInterfaceMACAddress: {
 							Type:        schema.TypeString,
 							Description: "The MAC address",
@@ -1580,6 +1588,7 @@ func containerCreateClone(ctx context.Context, d *schema.ResourceData, m any) di
 		firewall := types.CustomBool(
 			networkInterfaceMap[mkNetworkInterfaceFirewall].(bool),
 		)
+		hostManaged := networkInterfaceMap[mkNetworkInterfaceHostManaged].(bool)
 		macAddress := networkInterfaceMap[mkNetworkInterfaceMACAddress].(string)
 		name := networkInterfaceMap[mkNetworkInterfaceName].(string)
 		rateLimit := networkInterfaceMap[mkNetworkInterfaceRateLimit].(float64)
@@ -1592,6 +1601,10 @@ func containerCreateClone(ctx context.Context, d *schema.ResourceData, m any) di
 
 		networkInterfaceObject.Enabled = enabled
 		networkInterfaceObject.Firewall = &firewall
+
+		if hostManaged {
+			networkInterfaceObject.HostManaged = types.CustomBool(hostManaged).Pointer()
+		}
 
 		if len(initializationIPConfigIPv4Address) > ni {
 			if initializationIPConfigIPv4Address[ni] != "" {
@@ -2028,6 +2041,7 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m any) d
 		vlanID := networkInterfaceMap[mkNetworkInterfaceVLANID].(int)
 		mtu := networkInterfaceMap[mkNetworkInterfaceMTU].(int)
 		firewall := networkInterfaceMap[mkNetworkInterfaceFirewall].(bool)
+		hostManaged := networkInterfaceMap[mkNetworkInterfaceHostManaged].(bool)
 
 		if bridge != "" {
 			networkInterfaceObject.Bridge = &bridge
@@ -2056,6 +2070,10 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m any) d
 
 		if firewall {
 			networkInterfaceObject.Firewall = types.CustomBool(firewall).Pointer()
+		}
+
+		if hostManaged {
+			networkInterfaceObject.HostManaged = types.CustomBool(hostManaged).Pointer()
 		}
 
 		if macAddress != "" {
@@ -2309,6 +2327,8 @@ func containerGetExistingNetworkInterface(
 		} else {
 			networkInterface[mkNetworkInterfaceFirewall] = false
 		}
+
+		networkInterface[mkNetworkInterfaceHostManaged] = nv.HostManaged != nil && *nv.HostManaged
 
 		if nv.MACAddress != nil {
 			networkInterface[mkNetworkInterfaceMACAddress] = *nv.MACAddress
@@ -3023,6 +3043,8 @@ func containerRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diag
 		} else {
 			networkInterface[mkNetworkInterfaceFirewall] = false
 		}
+
+		networkInterface[mkNetworkInterfaceHostManaged] = nv.HostManaged != nil && *nv.HostManaged
 
 		if nv.MACAddress != nil {
 			networkInterface[mkNetworkInterfaceMACAddress] = *nv.MACAddress
@@ -3753,6 +3775,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 			firewall := types.CustomBool(
 				networkInterfaceMap[mkNetworkInterfaceFirewall].(bool),
 			)
+			hostManaged := networkInterfaceMap[mkNetworkInterfaceHostManaged].(bool)
 			macAddress := networkInterfaceMap[mkNetworkInterfaceMACAddress].(string)
 			name := networkInterfaceMap[mkNetworkInterfaceName].(string)
 			rateLimit := networkInterfaceMap[mkNetworkInterfaceRateLimit].(float64)
@@ -3765,6 +3788,10 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 
 			networkInterfaceObject.Enabled = enabled
 			networkInterfaceObject.Firewall = &firewall
+
+			if hostManaged {
+				networkInterfaceObject.HostManaged = types.CustomBool(hostManaged).Pointer()
+			}
 
 			if len(initializationIPConfigIPv4Address) > ni {
 				if initializationIPConfigIPv4Address[ni] != "" {

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -2344,7 +2344,11 @@ func containerGetExistingNetworkInterface(
 			networkInterface[mkNetworkInterfaceFirewall] = false
 		}
 
-		networkInterface[mkNetworkInterfaceHostManaged] = nv.HostManaged != nil && *nv.HostManaged
+		if nv.HostManaged != nil && *nv.HostManaged {
+			networkInterface[mkNetworkInterfaceHostManaged] = true
+		} else {
+			networkInterface[mkNetworkInterfaceHostManaged] = false
+		}
 
 		if nv.MACAddress != nil {
 			networkInterface[mkNetworkInterfaceMACAddress] = *nv.MACAddress
@@ -3060,7 +3064,11 @@ func containerRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diag
 			networkInterface[mkNetworkInterfaceFirewall] = false
 		}
 
-		networkInterface[mkNetworkInterfaceHostManaged] = nv.HostManaged != nil && *nv.HostManaged
+		if nv.HostManaged != nil && *nv.HostManaged {
+			networkInterface[mkNetworkInterfaceHostManaged] = true
+		} else {
+			networkInterface[mkNetworkInterfaceHostManaged] = false
+		}
 
 		if nv.MACAddress != nil {
 			networkInterface[mkNetworkInterfaceMACAddress] = *nv.MACAddress

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -30,6 +30,7 @@ import (
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/tasks"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/ssh"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/version"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf"
 	sdkresource "github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/validators"
@@ -1579,6 +1580,8 @@ func containerCreateClone(ctx context.Context, d *schema.ResourceData, m any) di
 		len(networkInterface),
 	)
 
+	hostManagedSupported := supportContainerHostManaged(ctx, client)
+
 	for ni, nv := range networkInterface {
 		networkInterfaceMap := nv.(map[string]any)
 		networkInterfaceObject := containers.CustomNetworkInterface{}
@@ -1602,7 +1605,7 @@ func containerCreateClone(ctx context.Context, d *schema.ResourceData, m any) di
 		networkInterfaceObject.Enabled = enabled
 		networkInterfaceObject.Firewall = &firewall
 
-		if hostManaged {
+		if hostManagedSupported || hostManaged {
 			networkInterfaceObject.HostManaged = types.CustomBool(hostManaged).Pointer()
 		}
 
@@ -2029,6 +2032,8 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m any) d
 	networkInterface := d.Get(mkNetworkInterface).([]any)
 	networkInterfaces := make(containers.CustomNetworkInterfaces, len(networkInterface))
 
+	hostManagedSupported := supportContainerHostManaged(ctx, client)
+
 	for ni, nv := range networkInterface {
 		networkInterfaceMap := nv.(map[string]any)
 		networkInterfaceObject := containers.CustomNetworkInterface{}
@@ -2072,7 +2077,7 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m any) d
 			networkInterfaceObject.Firewall = types.CustomBool(firewall).Pointer()
 		}
 
-		if hostManaged {
+		if hostManagedSupported || hostManaged {
 			networkInterfaceObject.HostManaged = types.CustomBool(hostManaged).Pointer()
 		}
 
@@ -2282,6 +2287,17 @@ func containerCreateStart(ctx context.Context, d *schema.ResourceData, m any) di
 	}
 
 	return append(diags, containerRead(ctx, d, m)...)
+}
+
+// supportContainerHostManaged probes the cluster version to gate the host-managed flag (PVE 9.0+).
+// On older releases callers must elide host-managed=0 because the API rejects the unknown sub-key.
+func supportContainerHostManaged(ctx context.Context, client proxmox.Client) bool {
+	ver := version.MinimumProxmoxVersion
+	if versionResp, err := client.Version().Version(ctx); err == nil {
+		ver = versionResp.Version
+	}
+
+	return ver.SupportContainerHostManaged()
 }
 
 func containerGetEnvironmentVariables(d *schema.ResourceData) *containers.CustomEnvironmentVariables {
@@ -3766,6 +3782,8 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 			len(networkInterface),
 		)
 
+		hostManagedSupported := supportContainerHostManaged(ctx, client)
+
 		for ni, nv := range networkInterface {
 			networkInterfaceMap := nv.(map[string]any)
 			networkInterfaceObject := containers.CustomNetworkInterface{}
@@ -3789,7 +3807,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 			networkInterfaceObject.Enabled = enabled
 			networkInterfaceObject.Firewall = &firewall
 
-			if hostManaged {
+			if hostManagedSupported || hostManaged {
 				networkInterfaceObject.HostManaged = types.CustomBool(hostManaged).Pointer()
 			}
 


### PR DESCRIPTION
### What does this PR do?

The provider is missing `host-managed` flag on network interfaces for containers. This flag indicates that the host should run DHCP on behalf of an "application container" which cannot configure its own networking.

Proxmox auto-enables `host-managed=1` at container creation time for containers whose entrypoint != `/sbin/init`:

https://github.com/proxmox/pve-container/blob/8cbf1a3c912ff424711e9a1ad2dd88e2ea574054/src/PVE/LXC/Create.pm#L752-L762

However, [`CustomNetworkInterface`](https://github.com/bpg/terraform-provider-proxmox/blob/7ff591e49150998b32f7dc40c192f879875676c5/proxmox/nodes/containers/containers_types.go#L126-L141) lacks the corresponding field, so when the network interface is re-serialized on a subsequent update, the field is dropped.

This PR adds support for the flag and plumbs it through.


### Backwards Compatibility

For backwards compatibility with Proxmox 9.0 and below, the flag is only serialized when set to true.

This creates an edge case where if the OCI container creation path automatically sets `host-managed=1`, the user cannot force it off on the next update because `host-managed=0` is elided rather than sent.

To fix this we would need a version check. However, I do not expect this would be common.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

### Proof of Work
<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

I evaluated the changes against my test server to ensure that `host-managed=1` is kept across an edit to an existing application container.

I did not test it against Proxmox 9.0.

I added a unit test but did not add a new acceptance test for this feature.

<details>
<summary>Test resource configuration</summary>

  ```hcl                                                                                                                                      
  resource "proxmox_oci_image" "nginx" {                                                                                                      
    datastore_id = "local"                                                                                                                    
    node_name    = "hetzner-pve"                                                                                                              
    reference    = "docker.io/library/nginx:1.27-alpine"                                                                                      
    overwrite    = true                                  
  }                                                                                                                                           
                                                         
  resource "proxmox_virtual_environment_container" "hello_4" {
    node_name    = "hetzner-pve"                                                                                                              
    unprivileged = true                                                                                                                       
    started      = true                                                                                                                       
                                                                                                                                              
    lifecycle {                                          
      ignore_changes = [environment_variables, console, initialization[0].entrypoint]
    }                                                                                                                                         
  
    cpu    { cores = 1 }                                                                                                                      
    memory { dedicated = 128 }                           
    disk   { datastore_id = "local-lvm", size = 1 }                                                                                           
                                                                                                                                              
    operating_system {                                                                                                                        
      template_file_id = proxmox_oci_image.nginx.id                                                                                           
      type             = "alpine"                                                                                                             
    }
                                                                                                                                              
    network_interface {                                  
      name         = "eth0"
      bridge       = "vnet0"
      host_managed = true                                                                                                                     
    }
                                                                                                                                              
    initialization {                                     
      hostname = "hello-4"
      dns { servers = ["1.1.1.1", "9.9.9.9"] }                                                                                                
      ip_config {                                                                                                                             
        ipv4 { address = "dhcp" }                                                                                                             
      }                                                                                                                                       
    }                                                    
  }                                                                                                                                           
  ```              
</summary>


### AI Use Disclosure

I used Claude Code (Opus 4.7, 1M context, xhigh effort) to identify the issue, analyze the root cause, and write the patch. I reviewed the code changes, suggested ways to simplify some changes, and shortened some overly-verbose strings.


<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000 | Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
