### PR TITLE
fix(vm): treat missing disk volume as not-found during read

### DIFF
--- a/proxmox/api/client.go
+++ b/proxmox/api/client.go
@@ -368,7 +368,8 @@ func validateResponseCode(res *http.Response) error {
 				(strings.Contains(res.Status, "does not exist") ||
 					strings.Contains(msg, "does not exist") ||
 					strings.Contains(msg, "no such resource") ||
-					strings.Contains(msg, "no such ha"))) {
+					strings.Contains(msg, "no such ha") ||
+					strings.Contains(msg, "No such file or directory"))) {
 			return errors.Join(ErrResourceDoesNotExist, httpError)
 		}
 

--- a/proxmox/api/client_test.go
+++ b/proxmox/api/client_test.go
@@ -73,6 +73,11 @@ func TestClientDoRequest(t *testing.T) {
 				Message: "create sdn zone object failed: 400 Parameter verification failed. (ipam: ipam-simple not existing)",
 			},
 		},
+		{
+			name:    "not exists - 500 status with rbd ENOENT",
+			status:  "500 rbd error: rbd: error opening image vm-97854-disk-0: (2) No such file or directory",
+			wantErr: ErrResourceDoesNotExist,
+		},
 	}
 
 	for _, tt := range tests {

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/ssh"
@@ -414,12 +415,21 @@ func Read(
 				// disk format may not be returned by config API if it is default for the storage, and that may be different
 				// from the default qcow2, so we need to read it from the storage API to make sure we have the correct value
 				volume, e := client.Node(nodeName).Storage(datastoreID).GetDatastoreFile(ctx, dd.FileVolume)
-				if e != nil {
+
+				switch {
+				case errors.Is(e, api.ErrResourceDoesNotExist):
+					// Underlying volume is gone (e.g. interrupted destroy left an orphan disk reference).
+					// Skip the format lookup so plan/destroy can proceed instead of fataling.
+					tflog.Warn(ctx, "disk volume not found in storage, skipping format lookup", map[string]any{
+						"datastore": datastoreID,
+						"volume":    dd.FileVolume,
+					})
+				case e != nil:
 					diags = append(diags, diag.FromErr(e)...)
 					continue
+				default:
+					disk[mkDiskFileFormat] = volume.FileFormat
 				}
-
-				disk[mkDiskFileFormat] = volume.FileFormat
 			}
 		} else {
 			disk[mkDiskFileFormat] = dd.Format

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -4737,9 +4737,18 @@ func vmReadCustom(
 			// disk format may not be returned by config API if it is default for the storage, and that may be different
 			// from the default qcow2, so we need to read it from the storage API to make sure we have the correct value
 			volume, err := client.Node(nodeName).Storage(fileIDParts[0]).GetDatastoreFile(ctx, vmConfig.EFIDisk.FileVolume)
-			if err != nil {
+
+			switch {
+			case errors.Is(err, api.ErrResourceDoesNotExist):
+				// Underlying volume is gone (e.g. interrupted destroy left an orphan disk reference).
+				// Skip the format lookup so plan/destroy can proceed instead of fataling.
+				tflog.Warn(ctx, "EFI disk volume not found in storage, skipping format lookup", map[string]any{
+					"datastore": fileIDParts[0],
+					"volume":    vmConfig.EFIDisk.FileVolume,
+				})
+			case err != nil:
 				diags = append(diags, diag.FromErr(err)...)
-			} else {
+			default:
 				efiDisk[mkEFIDiskFileFormat] = volume.FileFormat
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

When a VM's disk image no longer exists in storage (e.g. an `rbd` image removed by an interrupted destroy), the VM's `Read` calls `GET /nodes/{node}/storage/{store}/content/{volid}` to fetch the disk format. Proxmox returns HTTP 500 with `rbd error: ... (2) No such file or directory`, which the SDK provider currently wraps with `diag.FromErr`, aborting `terraform plan` and `terraform destroy` and forcing users to `terraform state rm` to recover.

This PR fixes the issue at two layers:

1. **API client mapper** (`proxmox/api/client.go`) — the existing 500 → `ErrResourceDoesNotExist` heuristic now also matches `No such file or directory`, alongside the existing `does not exist`, `no such resource`, and `no such ha` patterns. This covers `rbd` ENOENT plus equivalent file-based / qemu-img ENOENT messages.
2. **VM disk and EFI-disk read sites** (`proxmoxtf/resource/vm/disk/disk.go`, `proxmoxtf/resource/vm/vm.go`) — when `GetDatastoreFile` returns `ErrResourceDoesNotExist`, log a `tflog.Warn` and skip the format lookup instead of fataling. The disk stays in state (the VM config still references it), so `plan` / `destroy` proceeds without manual state surgery.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

> **Note on acceptance tests:** reproducing this requires deleting a disk image out-of-band (e.g. `rbd rm`, `lvremove`) while the VM config still references it. Wiring that into `./testacc` would mean adding SSH-to-PVE volume manipulation just for one defensive error-mapping fix. Instead, the fix is covered by a unit test at the API-client layer (RED → GREEN verified) and a manual reproduction recipe in the Proof of Work section below. Happy to flesh out an acceptance variant if you'd prefer.

### Proof of Work

#### Unit test (API-client mapper)

```bash
go test -count=1 -run "TestClientDoRequest" ./proxmox/api/ -v
```

```text
--- PASS: TestClientDoRequest (0.00s)
    --- PASS: TestClientDoRequest/no_error (0.00s)
    --- PASS: TestClientDoRequest/not_exists_-_500_status_with_rbd_ENOENT (0.00s)
    --- PASS: TestClientDoRequest/not_exists_-_500_status (0.00s)
    --- PASS: TestClientDoRequest/500_status (0.00s)
    --- PASS: TestClientDoRequest/not_exists_-_404_status (0.00s)
    --- PASS: TestClientDoRequest/500_status_with_body (0.00s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/proxmox/api	0.368s
```

The new sub-case `not_exists_-_500_status_with_rbd_ENOENT` feeds the exact HTTP status from the issue
report (`500 rbd error: rbd: error opening image vm-97854-disk-0: (2) No such file or directory`)
through `validateResponseCode` and asserts `errors.Is(err, ErrResourceDoesNotExist)`. With the mapper
change reverted, the case fails — the error is returned as a plain `*HTTPError` and the call sites
treat it as fatal. With the change applied, it passes, which is precisely what the disk/EFI Read
branches need to detect "volume gone" via `errors.Is`.

`make build`, `make test`, and `make lint` all pass on the branch.

#### Manual reproduction recipe

A full acceptance test would need to delete the underlying volume out-of-band, so we documented the
manual steps to verify the fix end-to-end:

```hcl
resource "proxmox_virtual_environment_vm" "repro" {
  name      = "issue-2808-repro"
  node_name = "pve"

  disk {
    datastore_id = "local-lvm"
    interface    = "virtio0"
    size         = 8
    file_format  = "raw"
  }
}
```

1. `terraform apply` — VM created; verify the volume exists with `pvesm list <datastore> | grep vm-<id>-disk-0`.
2. SSH to the PVE host and remove the underlying volume out-of-band (analogous to the `rbd` failure path on Ceph):

   ```sh
   lvremove -y /dev/<vg>/vm-<id>-disk-0
   ```

3. `terraform plan`:
   - **Before this fix:** plan aborts with
     `Error: error get file local-lvm:vm-<id>-disk-0 from datastore local-lvm: received an HTTP 500 response - Reason: ... No such file or directory`.
   - **After this fix:** plan completes; with `TF_LOG=WARN` the provider emits
     `disk volume not found in storage, skipping format lookup`. The disk stays in state.
4. `terraform destroy` succeeds — previously aborted at the same Read step.

#### Notes on scope

- `mkDiskFileFormat` is `Optional+Computed`, so when the skip-set branch runs the disk map omits the
  key and state ends up with empty string. Users who don't set `file_format` in config (the common
  case) keep clean plans because the field is computed. Users who do set it may see a transient
  `"raw" -> ""` diff on the affected disk — acceptable in the destroy context the issue describes,
  and matches the existing `datastoreID == ""` early-return path.
- The mapper match is intentionally `No such file or directory` (not `(2) No such file or directory`)
  so it covers file-based storage where qemu-img omits the errno wrapper, while still being a strict
  ENOENT signal.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

Closes #2808

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.7). All changes have been reviewed and verified by a human.*
