### PR TITLE
fix(vm): stop re-emitting `format=` on existing `import_from` disks

### DIFF
--- a/fwprovider/test/resource_vm_disks_test.go
+++ b/fwprovider/test/resource_vm_disks_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -1496,6 +1497,186 @@ func TestAccResourceVMDiskCloneNFSResize(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccResourceVMDiskAddDoesNotMutateImportedDisks is a regression test for
+// https://github.com/bpg/terraform-provider-proxmox/issues/2813. When a new
+// disk is added to a VM that already has an `import_from` disk on file-based
+// storage, the existing disk's stored config must not be silently rewritten.
+//
+// The bug: CustomStorageDevice.Equals() compared ImportFrom, but PVE never
+// echoes import-from back in its config response. After the initial create the
+// freshly-read disk has ImportFrom=nil while the plan disk still has it set,
+// so Equals returned false and Update routed the unchanged imported disk
+// through the update path, re-emitting `format=qcow2` derived from the .qcow2
+// file extension. PVE then persisted the qualifier on the existing volume,
+// even though the Terraform plan only mentioned the new disk.
+//
+// Requires NFS (or any file-based) storage so the imported volume has a
+// `.qcow2` extension, which is what makes the bug observable in the raw config.
+func TestAccResourceVMDiskAddDoesNotMutateImportedDisks(t *testing.T) {
+	nfsDatastoreID := utils.GetAnyStringEnv("PROXMOX_VE_ACC_NFS_DATASTORE_ID")
+	if nfsDatastoreID == "" {
+		t.Skip("NFS storage is not available")
+	}
+
+	t.Parallel()
+
+	te := InitEnvironment(t)
+	te.AddTemplateVars(map[string]any{"NFSDatastoreID": nfsDatastoreID})
+
+	var beforeScsi0 string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create VM with one import_from disk on NFS.
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_download_file" "test_image_2813" {
+					content_type        = "import"
+					datastore_id        = "local"
+					node_name           = "{{.NodeName}}"
+					url                 = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
+					file_name           = "{{.TestName}}-2813-image.img.raw"
+					overwrite_unmanaged = true
+				}
+				resource "proxmox_virtual_environment_vm" "test_2813" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-disk-add-2813"
+
+					disk {
+						datastore_id = "{{.NFSDatastoreID}}"
+						import_from  = proxmox_virtual_environment_download_file.test_image_2813.id
+						interface    = "scsi0"
+						file_format  = "qcow2"
+						size         = 6
+					}
+				}`),
+				Check: func(s *terraform.State) error {
+					vmID, err := vmIDFromState(s, "proxmox_virtual_environment_vm.test_2813")
+					if err != nil {
+						return err
+					}
+
+					raw, err := fetchRawStorageDevices(t.Context(), te, vmID)
+					if err != nil {
+						return fmt.Errorf("fetching raw config (before): %w", err)
+					}
+
+					beforeScsi0 = raw["scsi0"]
+					if beforeScsi0 == "" {
+						return fmt.Errorf("scsi0 missing from raw config: %v", raw)
+					}
+
+					return nil
+				},
+			},
+			{
+				// Step 2: Add scsi1. The plan must show scsi1 added; the
+				// stored config of scsi0 must remain byte-identical.
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_download_file" "test_image_2813" {
+					content_type        = "import"
+					datastore_id        = "local"
+					node_name           = "{{.NodeName}}"
+					url                 = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
+					file_name           = "{{.TestName}}-2813-image.img.raw"
+					overwrite_unmanaged = true
+				}
+				resource "proxmox_virtual_environment_vm" "test_2813" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-disk-add-2813"
+
+					disk {
+						datastore_id = "{{.NFSDatastoreID}}"
+						import_from  = proxmox_virtual_environment_download_file.test_image_2813.id
+						interface    = "scsi0"
+						file_format  = "qcow2"
+						size         = 6
+					}
+
+					disk {
+						datastore_id = "{{.NFSDatastoreID}}"
+						interface    = "scsi1"
+						file_format  = "qcow2"
+						size         = 1
+					}
+				}`),
+				Check: func(s *terraform.State) error {
+					vmID, err := vmIDFromState(s, "proxmox_virtual_environment_vm.test_2813")
+					if err != nil {
+						return err
+					}
+
+					raw, err := fetchRawStorageDevices(t.Context(), te, vmID)
+					if err != nil {
+						return fmt.Errorf("fetching raw config (after): %w", err)
+					}
+
+					if afterScsi0 := raw["scsi0"]; afterScsi0 != beforeScsi0 {
+						return fmt.Errorf(
+							"scsi0 stored config was mutated by adding sibling scsi1\n  before: %q\n  after:  %q",
+							beforeScsi0, afterScsi0,
+						)
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func vmIDFromState(s *terraform.State, name string) (int, error) {
+	rs, ok := s.RootModule().Resources[name]
+	if !ok {
+		return 0, fmt.Errorf("resource %s not found in state", name)
+	}
+
+	vmID, err := strconv.Atoi(rs.Primary.Attributes["vm_id"])
+	if err != nil {
+		return 0, fmt.Errorf("parsing vm_id: %w", err)
+	}
+
+	return vmID, nil
+}
+
+// fetchRawStorageDevices issues a low-level GET against
+// /nodes/{node}/qemu/{vmid}/config and returns the raw scsi*/virtio*/sata*/ide*
+// strings as PVE persists them, bypassing the provider's CustomStorageDevices
+// parsing. This is the only way to detect the issue #2813 symptom — the
+// parsed struct's Format field is `"qcow2"` regardless of whether the
+// qualifier was explicit (`format=qcow2`) or merely derived from the
+// `.qcow2` file extension.
+func fetchRawStorageDevices(ctx context.Context, te *Environment, vmID int) (map[string]string, error) {
+	vm := te.NodeClient().VM(vmID)
+
+	var resBody struct {
+		Data map[string]any `json:"data,omitempty"`
+	}
+
+	if err := vm.DoRequest(ctx, http.MethodGet, vm.ExpandPath("config"), nil, &resBody); err != nil {
+		return nil, err
+	}
+
+	raw := map[string]string{}
+
+	for k, v := range resBody.Data {
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+
+		if strings.HasPrefix(k, "scsi") || strings.HasPrefix(k, "virtio") ||
+			strings.HasPrefix(k, "sata") || strings.HasPrefix(k, "ide") {
+			raw[k] = s
+		}
+	}
+
+	return raw, nil
 }
 
 func TestAccResourceVMDiskRemovalReuseIssue2218(t *testing.T) {

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -395,6 +395,14 @@ func (d CustomStorageDevices) EncodeValues(_ string, v *url.Values) error {
 
 // Equals compares two CustomStorageDevice instances to determine if they are equal.
 // It compares all fields that could trigger an update.
+//
+// ImportFrom is intentionally excluded: PVE does not echo back the import-from
+// qualifier in its config response, so a freshly-read disk always has
+// ImportFrom=nil while the plan disk still carries the user's value. Comparing
+// it would mark every unchanged imported disk as "changed" on subsequent
+// applies and route it through the update path, silently re-emitting other
+// fields PVE had normalised away (e.g. format=qcow2 derived from the file
+// extension). See https://github.com/bpg/terraform-provider-proxmox/issues/2813.
 func (d *CustomStorageDevice) Equals(other *CustomStorageDevice) bool {
 	if d == nil || other == nil {
 		return false
@@ -408,7 +416,6 @@ func (d *CustomStorageDevice) Equals(other *CustomStorageDevice) bool {
 		ptr.Eq(d.Cache, other.Cache) &&
 		ptr.Eq(d.DatastoreID, other.DatastoreID) &&
 		ptr.Eq(d.Discard, other.Discard) &&
-		ptr.Eq(d.ImportFrom, other.ImportFrom) &&
 		ptr.Eq(d.IOThread, other.IOThread) &&
 		ptr.Eq(d.IopsRead, other.IopsRead) &&
 		ptr.Eq(d.IopsWrite, other.IopsWrite) &&

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -636,6 +636,13 @@ func Update(
 				}
 				// update existing disk
 				tmp = currentDisks[iface]
+				// Never re-emit format= for an existing volume. UnmarshalJSON
+				// derives Format from the file extension when PVE omits the
+				// qualifier (which it does for normalised volumes), so leaving
+				// it set would persist `format=qcow2` onto the stored config
+				// and produce out-of-plan changes whenever this disk is routed
+				// through the update path for any reason — see issue #2813.
+				tmp.Format = nil
 			default:
 				// something went wrong
 				diags = append(diags, diag.FromErr(fmt.Errorf("missing device %s", iface))...)

--- a/proxmoxtf/resource/vm/disk/disk_test.go
+++ b/proxmoxtf/resource/vm/disk/disk_test.go
@@ -252,7 +252,11 @@ func TestDiskDevicesEqual(t *testing.T) {
 	}
 	require.False(t, disk1.Equals(disk2SizeChanged))
 
-	// Test different ImportFrom values
+	// ImportFrom is excluded from Equals because PVE does not echo it back in
+	// its config response. Two disks that differ only in ImportFrom (including
+	// the common case where one side reflects the API and has nil) must be
+	// treated as equal, otherwise unchanged imported disks get re-emitted on
+	// every subsequent apply. See issue #2813.
 	importFrom2Changed := "local:import/test2.qcow2"
 	disk2ImportFromChanged := &vms.CustomStorageDevice{
 		AIO:         &aio2,
@@ -261,7 +265,15 @@ func TestDiskDevicesEqual(t *testing.T) {
 		ImportFrom:  &importFrom2Changed,
 		DatastoreID: &datastore2,
 	}
-	require.False(t, disk1.Equals(disk2ImportFromChanged))
+	require.True(t, disk1.Equals(disk2ImportFromChanged))
+
+	disk2ImportFromNil := &vms.CustomStorageDevice{
+		AIO:         &aio2,
+		Cache:       &cache2,
+		Size:        size2,
+		DatastoreID: &datastore2,
+	}
+	require.True(t, disk1.Equals(disk2ImportFromNil))
 }
 
 // TestDiskUpdateSkipsUnchangedDisks tests that the Update function only updates changed disks.


### PR DESCRIPTION
### What does this PR do?

When a VM has an existing disk created with `import_from` on file-based storage and the user adds a sibling disk in a later apply, Proxmox would silently rewrite the existing disk's stored config to add a `format=qcow2` qualifier — even though the Terraform plan only mentioned the new disk. The user-visible symptom is short orange "pending change" lines in the PVE GUI on disks the user did not touch.

Two-part fix in the SDK VM disk path:

1. **`proxmox/nodes/vms/custom_storage_device.go`** — drop `ImportFrom` from `CustomStorageDevice.Equals()`. PVE never echoes `import-from=` back in its config response (it is a one-shot import source, not persisted state), so plan-vs-API comparison is permanently asymmetric for imported disks. Comparing `ImportFrom` made every unchanged imported disk look "changed" forever, routing it through the update path on every apply.
2. **`proxmoxtf/resource/vm/disk/disk.go:Update()`** — defence in depth: when picking `tmp = currentDisks[iface]` for an existing-disk update, set `tmp.Format = nil`. `UnmarshalJSON` derives `Format` from the file extension (`.qcow2`) when PVE omits the qualifier, so leaving it set re-emits `format=qcow2` on the wire and persists it onto PVE's stored config. Mirrors the existing `tmp.Size = nil` pattern (resize has its own endpoint, so size is intentionally excluded from the update body for the same reason).

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

New regression test (`TestAccResourceVMDiskAddDoesNotMutateImportedDisks`) issues a low-level `GET /api2/json/nodes/{node}/qemu/{vmid}/config` against PVE before and after adding a sibling disk, and asserts the raw `scsi0` string is byte-identical. This catches the bug at the level of PVE's stored config, not just provider state.

Pre-fix the test fails with the exact reported symptom:

```text
=== RUN   TestAccResourceVMDiskAddDoesNotMutateImportedDisks
    resource_vm_disks_test.go:1530: Step 2/2 error: Check failed: scsi0 stored config was mutated by adding sibling scsi1
      before: "nfs:100/vm-100-disk-0.qcow2,aio=io_uring,backup=1,cache=none,discard=ignore,iothread=0,replicate=1,size=6G,ssd=0"
      after:  "nfs:100/vm-100-disk-0.qcow2,aio=io_uring,backup=1,cache=none,discard=ignore,format=qcow2,iothread=0,replicate=1,size=6G,ssd=0"
--- FAIL: TestAccResourceVMDiskAddDoesNotMutateImportedDisks (22.08s)
```

Post-fix:

```text
$ ./testacc TestAccResourceVMDiskAddDoesNotMutateImportedDisks -- -v
=== RUN   TestAccResourceVMDiskAddDoesNotMutateImportedDisks
=== PAUSE TestAccResourceVMDiskAddDoesNotMutateImportedDisks
=== CONT  TestAccResourceVMDiskAddDoesNotMutateImportedDisks
--- PASS: TestAccResourceVMDiskAddDoesNotMutateImportedDisks (20.47s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	20.977s
```

The full `TestAccResourceVMDisks` regression suite (17 sub-tests, including the existing `update_single_disk_without_affecting_boot_disk_with_import_from` and `resize_boot_disk_with_import_from_should_not_trigger_re-import` regression tests for #2385) plus adjacent disk tests all pass:

```text
--- PASS: TestAccResourceVMDisks/update_single_disk_without_affecting_boot_disk_with_import_from (27.97s)
--- PASS: TestAccResourceVMDisks/resize_boot_disk_with_import_from_should_not_trigger_re-import (27.37s)
--- PASS: TestAccResourceVMDisks/import_disk_from_an_image (21.16s)
--- PASS: TestAccResourceVMDisks/clone_with_adding_disk (0.29s)
--- PASS: TestAccResourceVMDisks/multiple_disks (9.54s)
--- PASS: TestAccResourceVMDisks/disk_ordering_consistency (21.22s)
--- PASS: TestAccResourceVMDisks/issue_#2172_exact_bug_scenario (31.60s)
--- PASS: TestAccResourceVMDisks/clone_with_moving_disk_to_ZFS_storage (30.29s)
--- PASS: TestAccResourceVMDisks/clone_with_disk_resize (15.21s)
--- PASS: TestAccResourceVMDisks/clone_with_updating_disk_attributes (19.16s)
--- PASS: TestAccResourceVMDisks/create_disk_from_an_image (11.54s)
--- PASS: TestAccResourceVMDisks/clone_default_disk_without_overrides (13.99s)
--- PASS: TestAccResourceVMDisks/clone_disk_with_overrides (0.30s)
--- PASS: TestAccResourceVMDisks/efi_disk_parameter_change_issue_1515 (6.40s)
--- PASS: TestAccResourceVMDisks/add_efi_disk_to_existing_vm_without_replacement (4.43s)
--- PASS: TestAccResourceVMDisks/ide_disks (8.74s)
--- PASS: TestAccResourceVMDisks/removing_disks (10.80s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	96.223s

--- PASS: TestAccResourceVMDiskRemoval (7.23s)
--- PASS: TestAccResourceVMDiskSpeedPerDisk (5.64s)
--- PASS: TestAccResourceVMDiskSpeedUpdate (4.25s)
--- PASS: TestAccResourceVMDiskResizeWithOptionChange (31.51s)
--- PASS: TestAccResourceVMDiskCDROMNotInDiskBlock (3.50s)
```

Unit test `TestDiskDevicesEqual` was updated to lock in the new `Equals()` symmetry (two disks differing only in `ImportFrom`, including the common nil-vs-non-nil case, are now equal). Unit suite passes:

```text
ok  	github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms	(cached)
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/disk	0.422s
```

`make lint` — 0 issues. `make build` passes. The acceptance test directly compares raw PVE config strings, so a separate mitmproxy capture is not necessary — the symptom IS a stored-config mutation.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2813

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.7). All changes have been reviewed and verified by a human.*


<!---
BEGIN_COMMIT_OVERRIDE
fix(vm): stop re-emitting `format=` on existing `import_from` disks (#2822)
END_COMMIT_OVERRIDE
--->