### PR TITLE
fix(lxc): apply disk acl/quota/replicate on container create

### DIFF
--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -2442,6 +2442,154 @@ func TestAccResourceContainerHostManaged(t *testing.T) {
 	})
 }
 
+// TestAccResourceContainerDiskOptionsAtCreate verifies that `acl`, `quota`, and `replicate`
+// from the `disk` block are sent on the initial create, not silently dropped and only repaired
+// by a subsequent update. Regression test for issue #2742.
+//
+// Uses a privileged container because `quota=1` is rejected by PVE on unprivileged containers.
+//
+//nolint:paralleltest
+func TestAccResourceContainerDiskOptionsAtCreate(t *testing.T) {
+	te := InitEnvironment(t)
+	imageFileName := fmt.Sprintf("%d-alpine-3.22-default_20250617_amd64.tar.xz", time.Now().UnixMicro())
+	testAccDownloadContainerTemplate(t, te, imageFileName)
+
+	accTestContainerID := 100000 + rand.Intn(99999)
+
+	te.AddTemplateVars(map[string]interface{}{
+		"ImageFileName":   imageFileName,
+		"TestContainerID": accTestContainerID,
+	})
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_container" "test_container" {
+					node_name = "{{.NodeName}}"
+					vm_id     = {{.TestContainerID}}
+					disk {
+						datastore_id = "local-lvm"
+						size         = 8
+						acl          = true
+						quota        = true
+						replicate    = true
+					}
+					initialization {
+						hostname = "test-disk-options"
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_interface {
+						name = "vmbr0"
+					}
+					operating_system {
+						template_file_id = "local:vztmpl/{{.ImageFileName}}"
+						type             = "alpine"
+					}
+				}`, WithRootUser()),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"disk.0.acl":       "true",
+						"disk.0.quota":     "true",
+						"disk.0.replicate": "true",
+						"disk.0.size":      "8",
+					}),
+					func(*terraform.State) error {
+						ctInfo, err := te.NodeClient().Container(accTestContainerID).GetContainer(t.Context())
+						require.NoError(te.t, err, "failed to get container")
+						require.NotNil(te.t, ctInfo.RootFS, "rootfs should not be nil")
+
+						require.NotNil(te.t, ctInfo.RootFS.ACL, "rootfs.acl should be set on the API after create")
+						require.True(te.t, bool(*ctInfo.RootFS.ACL), "rootfs.acl should be true on the API after create")
+
+						require.NotNil(te.t, ctInfo.RootFS.Quota, "rootfs.quota should be set on the API after create")
+						require.True(te.t, bool(*ctInfo.RootFS.Quota), "rootfs.quota should be true on the API after create")
+
+						require.NotNil(te.t, ctInfo.RootFS.Replicate, "rootfs.replicate should be set on the API after create")
+						require.True(te.t, bool(*ctInfo.RootFS.Replicate), "rootfs.replicate should be true on the API after create")
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestAccResourceContainerDiskACLOnlyAtCreate verifies that `acl=true` is sent on create
+// even when `size` is the schema default and no mount points or mount options are set.
+// Catches the gating-condition bug in container.go where rootFS was only constructed when
+// `size != default || len(mountPoints) > 0 || len(diskMountOptions) > 0`. Regression test
+// for issue #2742.
+//
+//nolint:paralleltest
+func TestAccResourceContainerDiskACLOnlyAtCreate(t *testing.T) {
+	te := InitEnvironment(t)
+	imageFileName := fmt.Sprintf("%d-alpine-3.22-default_20250617_amd64.tar.xz", time.Now().UnixMicro())
+	testAccDownloadContainerTemplate(t, te, imageFileName)
+
+	accTestContainerID := 100000 + rand.Intn(99999)
+
+	te.AddTemplateVars(map[string]interface{}{
+		"ImageFileName":   imageFileName,
+		"TestContainerID": accTestContainerID,
+	})
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_container" "test_container" {
+					node_name    = "{{.NodeName}}"
+					vm_id        = {{.TestContainerID}}
+					unprivileged = true
+					disk {
+						datastore_id = "local-lvm"
+						acl          = true
+					}
+					initialization {
+						hostname = "test-disk-acl-only"
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_interface {
+						name = "vmbr0"
+					}
+					operating_system {
+						template_file_id = "local:vztmpl/{{.ImageFileName}}"
+						type             = "alpine"
+					}
+				}`, WithRootUser()),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"disk.0.acl":  "true",
+						"disk.0.size": "4",
+					}),
+					func(*terraform.State) error {
+						ctInfo, err := te.NodeClient().Container(accTestContainerID).GetContainer(t.Context())
+						require.NoError(te.t, err, "failed to get container")
+						require.NotNil(te.t, ctInfo.RootFS, "rootfs should not be nil")
+
+						require.NotNil(te.t, ctInfo.RootFS.ACL, "rootfs.acl should be set on the API after create")
+						require.True(te.t, bool(*ctInfo.RootFS.ACL), "rootfs.acl should be true on the API after create")
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func testAccDownloadContainerTemplate(t *testing.T, te *Environment, imageFileName string) {
 	t.Helper()
 	err := te.NodeStorageClient().DownloadFileByURL(context.Background(), &storage.DownloadURLPostRequestBody{

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -2019,13 +2019,35 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m any) d
 		}
 	}
 
+	diskACL := types.CustomBool(diskBlock[mkDiskACL].(bool))
+	diskQuota := types.CustomBool(diskBlock[mkDiskQuota].(bool))
+	diskReplicate := types.CustomBool(diskBlock[mkDiskReplicate].(bool))
 	diskSize := diskBlock[mkDiskSize].(int)
-	if diskDatastoreID != "" && (diskSize != dvDiskSize || len(mountPoints) > 0 || len(diskMountOptions) > 0) {
+
+	if diskDatastoreID != "" && (diskSize != dvDiskSize ||
+		len(mountPoints) > 0 ||
+		len(diskMountOptions) > 0 ||
+		bool(diskACL) ||
+		bool(diskQuota) ||
+		bool(diskReplicate)) {
 		// This is a special case where the rootfs size is set to a non-default value at creation time.
 		// see https://pve.proxmox.com/pve-docs/chapter-pct.html#_storage_backed_mount_points
 		rootFS = &containers.CustomRootFS{
 			Volume:       fmt.Sprintf("%s:%d", diskDatastoreID, diskSize),
 			MountOptions: &diskMountOptions,
+		}
+
+		// Only emit non-default values, matching the mount-point block convention above.
+		if diskACL {
+			rootFS.ACL = &diskACL
+		}
+
+		if diskQuota {
+			rootFS.Quota = &diskQuota
+		}
+
+		if diskReplicate {
+			rootFS.Replicate = &diskReplicate
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

The `proxmox_virtual_environment_container` resource silently dropped the `disk.acl`,
`disk.quota`, and `disk.replicate` fields on the initial create — they were only re-applied by a
second `terraform apply` via the update path. The create path constructed `CustomRootFS` with
only `Volume` and `MountOptions` and never read those three fields, and its gating condition
also ignored them, so a config like `disk { acl = true }` with the default `size = 4` produced
no `rootfs=` parameter at all.

This PR reads `acl`, `quota`, and `replicate` from the disk schema block in `containerCreateCustom`
and emits them on the create body using the same `if non-default { set }` convention already used
for the mount-point block. The gating condition that decides whether to construct `rootFS` is
extended to fire when any of the three is non-default, so single-attribute configurations with the
default size are covered too.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits). _N/A — no schema or doc-visible behavior change._
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md). _N/A — fix to existing SDK resource._
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes). _N/A — covered by acceptance tests + mitmproxy._

### Proof of Work

Two acceptance tests added — one targets the field-drop bug and one targets the gating-condition
bug. Both fail on `main` with `Attribute "disk.0.acl" value: expected 'false' to match 'true'`
and pass after the fix. `TestAccResourceContainerDiskResize` was run as a regression check on the
adjacent code.

```text
$ ./testacc --no-proxy 'TestAccResourceContainerDisk.*' -- -v

Running tests matching pattern: TestAccResourceContainerDisk.*
=== RUN   TestAccResourceContainerDiskResize
=== RUN   TestAccResourceContainerDiskOptionsAtCreate
=== RUN   TestAccResourceContainerDiskACLOnlyAtCreate
--- PASS: TestAccResourceContainerDiskOptionsAtCreate (23.39s)
--- PASS: TestAccResourceContainerDiskACLOnlyAtCreate (23.57s)
--- PASS: TestAccResourceContainerDiskResize (26.43s)
PASS
```

#### Wire-level verification (mitmproxy)

`TestAccResourceContainerDiskOptionsAtCreate` — privileged container with `acl=true`, `quota=true`,
`replicate=true`, `size=8`. POST `/api2/json/nodes/<node>/lxc` request body (URL-decoded):

```text
…&rootfs=acl=1,quota=1,replicate=1,volume=local-lvm:8&…
```

Subsequent GET on the new container's config shows PVE persisted all three fields:

```json
"rootfs": "local-lvm:vm-150981-disk-0,acl=1,quota=1,replicate=1,size=8G"
```

`TestAccResourceContainerDiskACLOnlyAtCreate` — unprivileged container with only `acl=true` and
default `size=4` (no mount points / mount options). POST request body (URL-decoded):

```text
…&rootfs=acl=1,volume=local-lvm:4&…
```

Without the gating-condition fix, no `rootfs=` parameter would have been sent at all, and PVE
would have used the storage default for `acl`. GET response after create:

```json
"rootfs": "local-lvm:vm-181873-disk-0,acl=1,size=4G"
```

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2742

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.7). All changes have been reviewed and verified by a human.*
