### PR TITLE
fix(lxc): gate `host_managed` on PVE 9.1+, not 9.0+

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -236,7 +236,7 @@ output "ubuntu_container_public_key" {
     - `firewall` - (Optional) Whether this interface's firewall rules should be
         used (defaults to `false`).
     - `host_managed` - (Optional) Whether the host runs DHCP on this interface's
-        behalf (defaults to `false`). Requires Proxmox VE 9.0+. Required for
+        behalf (defaults to `false`). Requires Proxmox VE 9.1+. Required for
         application containers that do not include a DHCP client.
     - `mac_address` - (Optional) The MAC address.
     - `mtu` - (Optional) Maximum transfer unit of the interface. Cannot be

--- a/proxmox/version/capabilities.go
+++ b/proxmox/version/capabilities.go
@@ -26,7 +26,7 @@ func (v *ProxmoxVersion) SupportModernAptSources() bool {
 }
 
 // SupportContainerHostManaged checks if the Proxmox version supports the `host-managed` flag on LXC network interfaces.
-// PVE 9.0+ accepts the flag; older releases reject the unknown sub-key.
+// PVE 9.1+ accepts the flag; older releases reject the unknown sub-key.
 func (v *ProxmoxVersion) SupportContainerHostManaged() bool {
-	return v.GreaterThanOrEqual(version.Must(version.NewVersion("9.0.0")))
+	return v.GreaterThanOrEqual(version.Must(version.NewVersion("9.1.0")))
 }

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -930,7 +930,7 @@ func Container() *schema.Resource {
 						},
 						mkNetworkInterfaceHostManaged: {
 							Type:        schema.TypeBool,
-							Description: "Whether the host runs DHCP on this interface's behalf. Requires Proxmox VE 9.0+.",
+							Description: "Whether the host runs DHCP on this interface's behalf. Requires Proxmox VE 9.1+.",
 							Optional:    true,
 							Default:     dvNetworkInterfaceHostManaged,
 						},
@@ -2311,7 +2311,7 @@ func containerCreateStart(ctx context.Context, d *schema.ResourceData, m any) di
 	return append(diags, containerRead(ctx, d, m)...)
 }
 
-// supportContainerHostManaged probes the cluster version to gate the host-managed flag (PVE 9.0+).
+// supportContainerHostManaged probes the cluster version to gate the host-managed flag (PVE 9.1+).
 // On older releases callers must elide host-managed=0 because the API rejects the unknown sub-key.
 func supportContainerHostManaged(ctx context.Context, client proxmox.Client) bool {
 	ver := version.MinimumProxmoxVersion


### PR DESCRIPTION
### What does this PR do?

Follow-up to #2812: corrects the version gate for the LXC `host_managed` network interface flag. The flag was introduced in `pve-container` 6.0.15, which shipped with Proxmox VE **9.1** alongside OCI container support — not 9.0 as originally claimed.

The relevant pve-container commit ([c5fefa1](https://github.com/proxmox/pve-container/commit/c5fefa136396fd28fd187229e9d8f373517df4fc), Nov 16 2025) lands in 6.0.15. PVE 9.0 ships with an older `pve-container` and rejects the unknown sub-key, so a provider running against 9.0 would fail when sending `host-managed=1`.

Changes:

- `SupportContainerHostManaged()` now checks `>= 9.1.0`.
- Schema description and SDK doc updated to "Requires Proxmox VE 9.1+".
- Inline comment on `supportContainerHostManaged()` updated.

### Backwards Compatibility

No schema or behavior change for users on PVE 9.1+. Users on PVE 9.0 who set `host_managed = true` will now see the flag elided (the API would have rejected it anyway), matching the existing fallback for older releases.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (SDK docs edited directly).
- [ ] I have added / updated acceptance tests — N/A, this is a version-gate constant + comment/doc fix; existing `TestAccResourceContainerHostManaged` still applies.
- [x] I have considered backward compatibility (no breaking schema changes).
- [x] I have run `make build` and `make test`.

### Proof of Work

Addresses review feedback from @rgov on #2812: https://github.com/bpg/terraform-provider-proxmox/pull/2812#issuecomment-4320327057

```
$ make lint
0 issues.

$ make build
go build -o "./build/terraform-provider-proxmox_v0.104.0"

$ make test
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/container	1.660s
[... all packages ok ...]
```

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #2812


<!---
BEGIN_COMMIT_OVERRIDE
fix(lxc): gate `host_managed` on PVE 9.1+, not 9.0+ (#2828)
END_COMMIT_OVERRIDE
--->