### PR TITLE
chore(lxc): restructure container docs for LLM retrieval

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -7,9 +7,20 @@ subcategory: Virtual Environment
 
 # Resource: proxmox_virtual_environment_container
 
-Manages a container.
+Manages an LXC container on a Proxmox VE node.
+
+A container's root filesystem (the `disk` block) and any additional volumes
+(`mount_point` blocks) can be placed on any Proxmox VE storage backend —
+directory, LVM, LVM-thin, ZFS, Ceph RBD, NFS, CIFS, or any other storage
+configured on the cluster. Bind mounts of arbitrary host directories are
+also supported. See the [Storage](#storage) section below for details.
 
 ## Example Usage
+
+### Basic container
+
+A minimal Ubuntu container with a 4&nbsp;GB rootfs on `local-lvm`,
+DHCP networking, and an SSH key:
 
 ```hcl
 resource "proxmox_virtual_environment_container" "ubuntu_container" {
@@ -49,40 +60,13 @@ resource "proxmox_virtual_environment_container" "ubuntu_container" {
     datastore_id = "local-lvm"
     size         = 4
   }
-  
+
   operating_system {
     template_file_id = proxmox_virtual_environment_download_file.ubuntu_2504_lxc_img.id
     # Or you can use a volume ID, as obtained from a "pvesm list <storage>"
     # template_file_id = "local:vztmpl/jammy-server-cloudimg-amd64.tar.gz"
-    type             = "ubuntu"
+    type = "ubuntu"
   }
-
-  mount_point {
-    # bind mount, *requires* root@pam authentication
-    volume = "/mnt/bindmounts/shared"
-    path   = "/mnt/shared"
-  }
-
-  mount_point {
-    # volume mount, a new volume will be created by PVE
-    volume = "local-lvm"
-    size   = "10G"
-    path   = "/mnt/volume"
-  }
-
-  mount_point {
-    # volume mount, an existing volume will be mounted
-    volume = "local-lvm:subvol-108-disk-101"
-    size   = "10G"
-    path   = "/mnt/data"
-  }
-
-  # To reference a mount point volume from another resource, use path_in_datastore:
-  # mount_point {
-  #   volume = other_container.mount_point[0].path_in_datastore
-  #   size   = "10G"
-  #   path   = "/mnt/shared"
-  # }
 
   startup {
     order      = "3"
@@ -124,6 +108,72 @@ output "ubuntu_container_public_key" {
 }
 ```
 
+### Custom storage configuration
+
+This example places the rootfs on a custom storage pool, attaches an
+additional volume, mounts an existing volume by ID, and bind-mounts a host
+directory. Any Proxmox storage backend (directory, LVM-thin, ZFS, Ceph RBD,
+NFS, CIFS) can be referenced by its storage ID:
+
+```hcl
+resource "proxmox_virtual_environment_container" "custom_storage" {
+  node_name = "first-node"
+  vm_id     = 1235
+
+  # Rootfs on a non-default storage pool, sized 32 GB.
+  disk {
+    datastore_id = "tank-zfs" # works with any storage backend (LVM-thin, ZFS, directory, Ceph, etc.)
+    size         = 32
+  }
+
+  # Allocate a new 10 GB volume on local-lvm and mount it inside the container.
+  mount_point {
+    volume = "local-lvm"
+    size   = "10G"
+    path   = "/mnt/volume"
+  }
+
+  # Mount an existing PVE volume by its storage ID.
+  mount_point {
+    volume = "local-lvm:subvol-108-disk-101"
+    size   = "10G"
+    path   = "/mnt/data"
+  }
+
+  # Bind-mount a host directory into the container (requires root@pam auth).
+  mount_point {
+    volume = "/mnt/bindmounts/shared"
+    path   = "/mnt/shared"
+  }
+
+  # ... initialization, network_interface, operating_system, etc.
+}
+```
+
+## Storage
+
+Containers attach storage through two block types:
+
+- **`disk`** — the root filesystem (rootfs). Exactly one rootfs per
+  container; the `datastore_id` argument selects the Proxmox storage pool
+  it lives on.
+- **`mount_point`** — zero or more additional volumes or bind mounts,
+  each mounted at a separate `path` inside the container.
+
+Both block types are backend-agnostic: `datastore_id` (on `disk`) and
+`volume` (on `mount_point`) accept any Proxmox storage ID, regardless of
+backend type. Run `pvesm status` on the host or use the
+[`proxmox_virtual_environment_datastores`](../data-sources/virtual_environment_datastores.md)
+data source to list configured storages.
+
+The `mount_point.volume` attribute accepts three forms:
+
+| Form                       | Meaning                                                  | Example                            |
+| -------------------------- | -------------------------------------------------------- | ---------------------------------- |
+| Storage ID                 | Allocate a new volume on that storage (requires `size`)  | `local-lvm`, `tank-zfs`            |
+| Storage ID + volume name   | Mount an existing volume by its full PVE volume ID       | `local-lvm:subvol-108-disk-101`    |
+| Absolute host path         | Bind-mount a host directory (requires `root@pam` auth)   | `/mnt/bindmounts/shared`           |
+
 ## Argument Reference
 
 - `clone` - (Optional) The cloning configuration.
@@ -153,9 +203,12 @@ output "ubuntu_container_public_key" {
     - `limit` - (Optional) Limit of CPU usage. Value `0` indicates no limit (defaults to `0`).
     - `units` - (Optional) The CPU units (defaults to `1024`).
 - `description` - (Optional) The description.
-- `disk` - (Optional) The disk configuration.
-    - `datastore_id` - (Optional) The identifier for the datastore to create the
-        disk in (defaults to `local`).
+- `disk` - (Optional) The root filesystem (rootfs) storage configuration.
+    Selects the Proxmox storage pool the container's root volume is created
+    on. Backend-agnostic — works with directory, LVM, LVM-thin, ZFS, Ceph
+    RBD, NFS, and any other configured Proxmox storage.
+    - `datastore_id` - (Optional) The Proxmox storage ID where the rootfs
+        volume is created (defaults to `local`).
     - `size` - (Optional) The size of the root filesystem in gigabytes (defaults
         to `4`). When set to 0 a directory or zfs/btrfs subvolume will be created.
         Requires `datastore_id` to be set.
@@ -193,7 +246,9 @@ output "ubuntu_container_public_key" {
     - `dedicated` - (Optional) The dedicated memory in megabytes (defaults
         to `512`).
     - `swap` - (Optional) The swap size in megabytes (defaults to `0`).
-- `mount_point`
+- `mount_point` - (Optional) An additional volume mount or host bind mount
+    (multiple blocks supported). Use this for data volumes, shared
+    directories, or attaching pre-existing PVE volumes.
     - `acl` (Optional) Explicitly enable or disable ACL support.
     - `backup` (Optional) Whether to include the mount point in backups (only
         used for volume mount points, defaults to `false`).
@@ -208,8 +263,11 @@ output "ubuntu_container_public_key" {
         nodes.
     - `size` (Optional) Volume size (only for volume mount points).
         Can be specified with a unit suffix (e.g. `10G`).
-    - `volume` (Required) Volume, device or directory to mount into the
-        container.
+    - `volume` (Required) Volume reference. Accepts a Proxmox storage ID
+        (e.g. `local-lvm`) to allocate a new volume, a full PVE volume ID
+        (e.g. `local-lvm:subvol-108-disk-101`) to mount an existing volume,
+        or an absolute host path (e.g. `/mnt/bindmounts/shared`) to
+        bind-mount a host directory.
     - `path_in_datastore` (Computed) The in-datastore path to the mount point volume.
         Use this attribute for cross-resource references instead of `volume`.
 - `idmap` - (Optional) UID/GID mapping for unprivileged containers (multiple

--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -1208,6 +1208,83 @@ func TestAccResourceContainerMountPoint(t *testing.T) {
 	})
 }
 
+// TestAccResourceContainerMountPointBindMount verifies that mount_point.volume accepts an
+// absolute host path to bind-mount a host directory into the container. Bind mounts take a
+// different code path than volume mounts: the API stores the host path verbatim in the
+// "volume" token and requires root@pam authentication.
+func TestAccResourceContainerMountPointBindMount(t *testing.T) {
+	te := InitEnvironment(t)
+	accTestContainerID := 100000 + rand.Intn(99999)
+	imageFileName := fmt.Sprintf("%d-alpine-3.22-default_20250617_amd64.tar.xz", time.Now().UnixMicro())
+
+	testAccDownloadContainerTemplate(t, te, imageFileName)
+
+	te.AddTemplateVars(map[string]interface{}{
+		"ImageFileName":   imageFileName,
+		"TestContainerID": accTestContainerID,
+	})
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_container" "test_container" {
+					node_name = "{{.NodeName}}"
+					vm_id     = {{ .TestContainerID }}
+					started   = false
+					disk {
+						datastore_id = "local-lvm"
+						size         = 4
+					}
+					mount_point {
+						# bind mount: absolute host path is mounted into the container
+						volume = "/var/log"
+						path   = "/mnt/host_logs"
+					}
+					initialization {
+						hostname = "test-bind-mount"
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_interface {
+						name = "vmbr0"
+					}
+					operating_system {
+						template_file_id = "local:vztmpl/{{.ImageFileName}}"
+						type             = "alpine"
+					}
+				}`, WithRootUser()),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_container.test_container", map[string]string{
+						"mount_point.#":        "1",
+						"mount_point.0.volume": "/var/log",
+						"mount_point.0.path":   "/mnt/host_logs",
+					}),
+					func(*terraform.State) error {
+						ct := te.NodeClient().Container(accTestContainerID)
+
+						ctInfo, err := ct.GetContainer(t.Context())
+						require.NoError(te.t, err, "failed to get container")
+
+						mp0, ok := ctInfo.MountPoints["mp0"]
+						require.True(te.t, ok, `"mp0" mount point not found`)
+						require.NotNil(te.t, mp0, `"mp0" mount point is <nil>`)
+						// for bind mounts the API stores the host path in Volume (no "storage:" prefix)
+						require.Equal(te.t, "/var/log", mp0.Volume, "bind-mount volume should be the host path")
+						require.Equal(te.t, "/mnt/host_logs", mp0.MountPoint)
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceContainerIpv4Ipv6(t *testing.T) {
 	te := InitEnvironment(t)
 	accTestContainerID := 100000 + rand.Intn(99999)


### PR DESCRIPTION
### What does this PR do?
<!--- Clearly state the problem and how this PR solves it. -->

### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [ ] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [ ] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #0000 | Relates #0000

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
