### PR TITLE
fix(vm): remove node-local devices before migration

### DIFF
--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -2061,6 +2061,67 @@ func TestAccResourceVMUpdateWhileStopped(t *testing.T) {
 	})
 }
 
+func TestAccResourceVMMigrateRemoveHostPCI(t *testing.T) {
+	te := InitEnvironment(t)
+
+	hostPCIID := utils.GetAnyStringEnv("PROXMOX_VE_ACC_VM_MIGRATE_HOSTPCI_ID")
+	if te.Node2Name == "" || hostPCIID == "" {
+		t.Skip("PROXMOX_VE_ACC_NODE_2_NAME and PROXMOX_VE_ACC_VM_MIGRATE_HOSTPCI_ID must be set")
+	}
+
+	te.AddTemplateVars(map[string]any{
+		"HostPCIID": hostPCIID,
+	})
+
+	resourceName := "proxmox_virtual_environment_vm.test_migrate_hostpci"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_migrate_hostpci" {
+					node_name       = "{{.NodeName}}"
+					started         = true
+					stop_on_destroy = true
+					migrate         = true
+					name            = "test-migrate-hostpci"
+
+					hostpci {
+						device = "hostpci0"
+						id     = "{{.HostPCIID}}"
+					}
+				}`, WithRootUser()),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "node_name", te.NodeName),
+					resource.TestCheckResourceAttr(resourceName, "hostpci.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "hostpci.0.device", "hostpci0"),
+					resource.TestCheckResourceAttr(resourceName, "hostpci.0.id", hostPCIID),
+				),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_migrate_hostpci" {
+					node_name       = "{{.Node2Name}}"
+					started         = true
+					stop_on_destroy = true
+					migrate         = true
+					name            = "test-migrate-hostpci"
+				}`, WithRootUser()),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "node_name", te.Node2Name),
+					resource.TestCheckResourceAttr(resourceName, "hostpci.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func stopVM(te *Environment, vmID string) error {
 	id, err := strconv.Atoi(vmID)
 	if err != nil {

--- a/proxmox/nodes/vms/custom_numa_device.go
+++ b/proxmox/nodes/vms/custom_numa_device.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox/helpers/ptr"
@@ -23,8 +24,8 @@ type CustomNUMADevice struct {
 	Policy        *string   `json:"policy,omitempty"    url:"policy,omitempty"`
 }
 
-// CustomNUMADevices handles QEMU NUMA device parameters.
-type CustomNUMADevices []CustomNUMADevice
+// CustomNUMADevices handles QEMU NUMA device parameters by slot.
+type CustomNUMADevices map[int]CustomNUMADevice
 
 // EncodeValues converts a CustomNUMADevice struct to a URL value.
 func (r *CustomNUMADevice) EncodeValues(key string, v *url.Values) error {
@@ -49,11 +50,19 @@ func (r *CustomNUMADevice) EncodeValues(key string, v *url.Values) error {
 	return nil
 }
 
-// EncodeValues converts a CustomNUMADevices array to multiple URL values.
+// EncodeValues converts a CustomNUMADevices map to multiple URL values.
 func (r CustomNUMADevices) EncodeValues(key string, v *url.Values) error {
-	for i, d := range r {
-		if err := d.EncodeValues(fmt.Sprintf("%s%d", key, i), v); err != nil {
-			return fmt.Errorf("failed to encode NUMA device %d: %w", i, err)
+	slots := make([]int, 0, len(r))
+	for slot := range r {
+		slots = append(slots, slot)
+	}
+
+	sort.Ints(slots)
+
+	for _, slot := range slots {
+		device := r[slot]
+		if err := device.EncodeValues(fmt.Sprintf("%s%d", key, slot), v); err != nil {
+			return fmt.Errorf("failed to encode NUMA device %d: %w", slot, err)
 		}
 	}
 

--- a/proxmox/nodes/vms/custom_numa_device_test.go
+++ b/proxmox/nodes/vms/custom_numa_device_test.go
@@ -7,7 +7,10 @@
 package vms
 
 import (
+	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCustomNUMADevice_UnmarshalJSON(t *testing.T) {
@@ -49,4 +52,22 @@ func TestCustomNUMADevice_UnmarshalJSON(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCustomNUMADevices_EncodeValuesSparseSlots(t *testing.T) {
+	t.Parallel()
+
+	values := url.Values{}
+	devices := CustomNUMADevices{
+		5: {
+			CPUIDs: []string{"0", "1"},
+			Memory: new(1024),
+		},
+	}
+
+	err := devices.EncodeValues("numa", &values)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"cpus=0;1,memory=1024"}, values["numa5"])
+	require.NotContains(t, values, "numa0")
 }

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5867,6 +5867,225 @@ func vmUpdatePool(
 	return nil
 }
 
+type vmPreMigrationDeletePlan struct {
+	list []string
+	set  map[string]struct{}
+}
+
+func vmUpdateNodeLocalDevicesBeforeMigration(
+	ctx context.Context,
+	client proxmox.Client,
+	vmAPI *vms.Client,
+	d *schema.ResourceData,
+	vmID int,
+	power *vmPowerTracker,
+) (vmPreMigrationDeletePlan, diag.Diagnostics) {
+	deletePlan := vmPreMigrationNodeLocalDeviceDeletes(d)
+	if len(deletePlan.list) == 0 {
+		return deletePlan, nil
+	}
+
+	migrationState, err := vmGetMigrationState(ctx, client, vmAPI, vmID)
+	if err != nil {
+		return deletePlan, diag.FromErr(err)
+	}
+
+	if migrationState.isRunning && migrationState.isHAManaged {
+		return deletePlan, diag.Errorf(
+			"cannot remove or replace node-local devices before migrating running HA-managed VM %d. "+
+				"Split this into separate applies, or stop/disable HA management for the VM before applying this change",
+			vmID,
+		)
+	}
+
+	// Node-local devices must be removed from the effective VM configuration before migration. For a
+	// running VM, that means taking it offline first; otherwise Proxmox keeps the old device attached
+	// as a pending change and migration can still fail on the source-only hardware dependency.
+	template := d.Get(mkTemplate).(bool)
+
+	powerOffForMigration := vmPowerOffForPendingChanges(ctx, vmAPI, d, template, true, power)
+	if powerOffForMigration.blockedByPolicy {
+		return deletePlan, rebootAfterUpdateDisabledError("remove or replace node-local devices before migration")
+	}
+
+	if powerOffForMigration.diags.HasError() {
+		return deletePlan, powerOffForMigration.diags
+	}
+
+	updateBody := &vms.UpdateRequestBody{
+		Delete: deletePlan.list,
+	}
+
+	if err := vmAPI.UpdateVM(ctx, updateBody); err != nil {
+		return deletePlan, diag.FromErr(err)
+	}
+
+	return deletePlan, nil
+}
+
+type vmMigrationState struct {
+	isRunning    bool
+	isHAManaged  bool
+	haResourceID types.HAResourceID
+}
+
+func vmGetMigrationState(ctx context.Context, client proxmox.Client, vmAPI *vms.Client, vmID int) (vmMigrationState, error) {
+	vmStatus, err := vmAPI.GetVMStatus(ctx)
+	if err != nil {
+		return vmMigrationState{}, fmt.Errorf("failed to get VM %d status: %w", vmID, err)
+	}
+
+	haResourceID := types.HAResourceID{
+		Type: types.HAResourceTypeVM,
+		Name: strconv.Itoa(vmID),
+	}
+
+	isHAManaged, err := client.Cluster().HA().Resources().Exists(ctx, haResourceID)
+	if err != nil {
+		return vmMigrationState{}, fmt.Errorf("failed to check HA status for VM %d: %w", vmID, err)
+	}
+
+	return vmMigrationState{
+		isRunning:    vmStatus.Status == "running",
+		isHAManaged:  isHAManaged,
+		haResourceID: haResourceID,
+	}, nil
+}
+
+func vmPreMigrationNodeLocalDeviceDeletes(d *schema.ResourceData) vmPreMigrationDeletePlan {
+	deletePlan := vmPreMigrationDeletePlan{
+		set: map[string]struct{}{},
+	}
+
+	if d.HasChange(mkHostPCI) {
+		appendPreMigrationDeletes(&deletePlan, vmChangedOrRemovedSlots(d, mkHostPCI, mkHostPCIDevice, "hostpci"))
+	}
+
+	if d.HasChange(mkHostUSB) {
+		appendPreMigrationDeletes(&deletePlan, vmChangedOrRemovedSlots(d, mkHostUSB, "", "usb"))
+	}
+
+	if d.HasChange(mkNUMA) {
+		appendPreMigrationDeletes(&deletePlan, vmChangedOrRemovedSlots(d, mkNUMA, mkNUMADevice, "numa"))
+	}
+
+	return deletePlan
+}
+
+func appendPreMigrationDeletes(deletePlan *vmPreMigrationDeletePlan, devices []string) {
+	for _, device := range devices {
+		if _, exists := deletePlan.set[device]; exists {
+			continue
+		}
+
+		deletePlan.list = append(deletePlan.list, device)
+		deletePlan.set[device] = struct{}{}
+	}
+}
+
+func vmChangedOrRemovedSlots(d *schema.ResourceData, attr, slotKey, fallbackPrefix string) []string {
+	oldValue, newValue := d.GetChange(attr)
+
+	return vmChangedOrRemovedSlotsFromValues(oldValue, newValue, slotKey, fallbackPrefix)
+}
+
+func vmChangedOrRemovedSlotsFromValues(oldValue, newValue any, slotKey, fallbackPrefix string) []string {
+	oldDevices, oldSlots := vmDeviceBlocksBySlot(oldValue, slotKey, fallbackPrefix)
+	newDevices, _ := vmDeviceBlocksBySlot(newValue, slotKey, fallbackPrefix)
+
+	devices := make([]string, 0, len(oldDevices))
+	for _, device := range oldSlots {
+		oldBlock := oldDevices[device]
+
+		newBlock, ok := newDevices[device]
+		if !ok || !cmp.Equal(oldBlock, newBlock) {
+			devices = append(devices, device)
+		}
+	}
+
+	return devices
+}
+
+func vmDeviceBlocksBySlot(value any, slotKey, fallbackPrefix string) (map[string]map[string]any, []string) {
+	list, ok := value.([]any)
+	if !ok {
+		return nil, nil
+	}
+
+	devices := make(map[string]map[string]any, len(list))
+	slots := make([]string, 0, len(list))
+
+	for i, entry := range list {
+		block, ok := entry.(map[string]any)
+		if !ok || block == nil {
+			continue
+		}
+
+		device := fmt.Sprintf("%s%d", fallbackPrefix, i)
+
+		if slotKey != "" {
+			if configuredDevice, ok := block[slotKey].(string); ok && configuredDevice != "" {
+				device = configuredDevice
+			}
+		}
+
+		devices[device] = block
+		slots = append(slots, device)
+	}
+
+	return devices, slots
+}
+
+func vmDeviceSlotSet(slots []string) map[string]struct{} {
+	slotSet := make(map[string]struct{}, len(slots))
+	for _, slot := range slots {
+		slotSet[slot] = struct{}{}
+	}
+
+	return slotSet
+}
+
+func vmPCIDeviceSlotSet(devices vms.CustomPCIDevices) map[string]struct{} {
+	slotSet := make(map[string]struct{}, len(devices))
+	for slot := range devices {
+		slotSet[slot] = struct{}{}
+	}
+
+	return slotSet
+}
+
+func vmSequentialDeviceSlotSet(prefix string, count int) map[string]struct{} {
+	slotSet := make(map[string]struct{}, count)
+	for i := range count {
+		slotSet[fmt.Sprintf("%s%d", prefix, i)] = struct{}{}
+	}
+
+	return slotSet
+}
+
+func vmAppendMissingDeviceDeletes(
+	del []string,
+	prefix string,
+	maxDevices int,
+	configuredDevices map[string]struct{},
+	preMigrationDeletePlan vmPreMigrationDeletePlan,
+) []string {
+	for i := range maxDevices {
+		device := fmt.Sprintf("%s%d", prefix, i)
+		if _, exists := configuredDevices[device]; exists {
+			continue
+		}
+
+		if _, alreadyDeleted := preMigrationDeletePlan.set[device]; alreadyDeleted {
+			continue
+		}
+
+		del = append(del, device)
+	}
+
+	return del
+}
+
 func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	// reset the default timeout for the update operation
 	ctx = context.WithoutCancel(ctx)
@@ -5880,6 +6099,8 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 
 	nodeName := d.Get(mkNodeName).(string)
 	rebootRequired := false
+	nodeNameChanged := d.HasChange(mkNodeName)
+	oldNodeName := nodeName
 
 	vmID, e := strconv.Atoi(d.Id())
 	if e != nil {
@@ -5893,22 +6114,34 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 		return diag.FromErr(e)
 	}
 
-	// If the node name has changed we need to migrate the VM to the new node before we do anything else.
-	if d.HasChange(mkNodeName) {
+	if nodeNameChanged {
+		oldNodeNameValue, _ := d.GetChange(mkNodeName)
+		oldNodeName = oldNodeNameValue.(string)
+	}
+
+	vmAPI := client.Node(oldNodeName).VM(vmID)
+
+	preMigrationDeletePlan := vmPreMigrationDeletePlan{set: map[string]struct{}{}}
+
+	if nodeNameChanged {
+		var preMigrationDiags diag.Diagnostics
+
+		preMigrationDeletePlan, preMigrationDiags = vmUpdateNodeLocalDevicesBeforeMigration(ctx, client, vmAPI, d, vmID, power)
+		if preMigrationDiags.HasError() {
+			return preMigrationDiags
+		}
+
 		migrateTimeoutSec := d.Get(mkTimeoutMigrate).(int)
 
 		migrateCtx, cancel := context.WithTimeout(ctx, time.Duration(migrateTimeoutSec)*time.Second)
 		defer cancel()
 
-		oldNodeNameValue, _ := d.GetChange(mkNodeName)
-		oldNodeName := oldNodeNameValue.(string)
-
 		if migrateDiags := migrateVM(migrateCtx, client, vmID, oldNodeName, nodeName); migrateDiags.HasError() {
 			return migrateDiags
 		}
-	}
 
-	vmAPI := client.Node(nodeName).VM(vmID)
+		vmAPI = client.Node(nodeName).VM(vmID)
+	}
 
 	updateBody := &vms.UpdateRequestBody{}
 
@@ -6419,33 +6652,55 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 
 	// Prepare the new hostpci devices configuration.
 	if d.HasChange(mkHostPCI) {
-		updateBody.PCIDevices = vmGetHostPCIDeviceObjects(d)
-
-		for i := len(updateBody.PCIDevices); i < maxResourceVirtualEnvironmentVMHostPCIDevices; i++ {
-			del = append(del, fmt.Sprintf("hostpci%d", i))
+		pciDevices := vmGetHostPCIDeviceObjects(d)
+		if len(pciDevices) > 0 {
+			updateBody.PCIDevices = pciDevices
 		}
+
+		del = vmAppendMissingDeviceDeletes(
+			del,
+			"hostpci",
+			maxResourceVirtualEnvironmentVMHostPCIDevices,
+			vmPCIDeviceSlotSet(pciDevices),
+			preMigrationDeletePlan,
+		)
 
 		rebootRequired = true
 	}
 
 	// Prepare the new numa devices configuration.
 	if d.HasChange(mkNUMA) {
-		updateBody.NUMADevices = vmGetNumaDeviceObjects(d)
-
-		for i := len(updateBody.NUMADevices); i < maxResourceVirtualEnvironmentVMNUMADevices; i++ {
-			del = append(del, fmt.Sprintf("numa%d", i))
+		numaDevices := vmGetNumaDeviceObjects(d)
+		if len(numaDevices) > 0 {
+			updateBody.NUMADevices = numaDevices
 		}
+
+		_, configuredNUMADevices := vmDeviceBlocksBySlot(d.Get(mkNUMA), mkNUMADevice, "numa")
+		del = vmAppendMissingDeviceDeletes(
+			del,
+			"numa",
+			maxResourceVirtualEnvironmentVMNUMADevices,
+			vmDeviceSlotSet(configuredNUMADevices),
+			preMigrationDeletePlan,
+		)
 
 		rebootRequired = true
 	}
 
 	// Prepare the new usb devices configuration.
 	if d.HasChange(mkHostUSB) {
-		updateBody.USBDevices = vmGetHostUSBDeviceObjects(d)
-
-		for i := len(updateBody.USBDevices); i < maxResourceVirtualEnvironmentVMHostUSBDevices; i++ {
-			del = append(del, fmt.Sprintf("usb%d", i))
+		usbDevices := vmGetHostUSBDeviceObjects(d)
+		if len(usbDevices) > 0 {
+			updateBody.USBDevices = usbDevices
 		}
+
+		del = vmAppendMissingDeviceDeletes(
+			del,
+			"usb",
+			maxResourceVirtualEnvironmentVMHostUSBDevices,
+			vmSequentialDeviceSlotSet("usb", len(usbDevices)),
+			preMigrationDeletePlan,
+		)
 
 		rebootRequired = true
 	}
@@ -6671,9 +6926,12 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 	// Merge non-disk deletions with any disk deletions already queued.
 	updateBody.Delete = append(updateBody.Delete, del...)
 
-	e = vmAPI.UpdateVM(ctx, updateBody)
-	if e != nil {
-		return diag.FromErr(e)
+	// Pre-migration cleanup can handle the only changed fields.
+	if !updateBody.IsEmpty() {
+		e = vmAPI.UpdateVM(ctx, updateBody)
+		if e != nil {
+			return diag.FromErr(e)
+		}
 	}
 
 	// Handle template conversion if the template flag changed to true
@@ -7371,34 +7629,20 @@ func findPoolForVM(ctx context.Context, poolsAPI *pools.Client, vmID int) (strin
 func migrateVM(ctx context.Context, client proxmox.Client, vmID int, sourceNode, targetNode string) diag.Diagnostics {
 	vmAPI := client.Node(sourceNode).VM(vmID)
 
-	// check if VM is running
-	vmStatus, err := vmAPI.GetVMStatus(ctx)
+	migrationState, err := vmGetMigrationState(ctx, client, vmAPI, vmID)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to get VM %d status: %w", vmID, err))
-	}
-
-	isRunning := vmStatus.Status == "running"
-
-	// check if VM is HA-managed
-	haResourceID := types.HAResourceID{
-		Type: types.HAResourceTypeVM,
-		Name: strconv.Itoa(vmID),
-	}
-
-	isHAManaged, err := client.Cluster().HA().Resources().Exists(ctx, haResourceID)
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("failed to check HA status for VM %d: %w", vmID, err))
+		return diag.FromErr(err)
 	}
 
 	// for running HA-managed VMs, use HA migration
-	if isRunning && isHAManaged {
-		return diag.FromErr(migrateHAVM(ctx, client, vmID, haResourceID, targetNode))
+	if migrationState.isRunning && migrationState.isHAManaged {
+		return diag.FromErr(migrateHAVM(ctx, client, vmID, migrationState.haResourceID, targetNode))
 	}
 
 	// for stopped HA-managed VMs, temporarily remove from HA to allow standard migration
 	// (Proxmox intercepts standard migrate for HA VMs and only sets a preference)
-	if !isRunning && isHAManaged {
-		return migrateStoppedHAVM(ctx, client, vmID, haResourceID, sourceNode, targetNode)
+	if !migrationState.isRunning && migrationState.isHAManaged {
+		return migrateStoppedHAVM(ctx, client, vmID, migrationState.haResourceID, sourceNode, targetNode)
 	}
 
 	// for non-HA VMs (running or stopped), use standard migration

--- a/proxmoxtf/resource/vm/vm_test.go
+++ b/proxmoxtf/resource/vm/vm_test.go
@@ -27,6 +27,135 @@ func TestVMInstantiation(t *testing.T) {
 	}
 }
 
+func TestVMChangedOrRemovedSlotsFromValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		oldValue       []any
+		newValue       []any
+		slotKey        string
+		fallbackPrefix string
+		expected       []string
+	}{
+		{
+			name: "hostpci removal",
+			oldValue: []any{
+				map[string]any{mkHostPCIDevice: "hostpci0", mkHostPCIDeviceID: "0000:81:00.0"},
+			},
+			newValue:       []any{},
+			slotKey:        mkHostPCIDevice,
+			fallbackPrefix: "hostpci",
+			expected:       []string{"hostpci0"},
+		},
+		{
+			name: "hostpci same slot replacement",
+			oldValue: []any{
+				map[string]any{mkHostPCIDevice: "hostpci0", mkHostPCIDeviceID: "0000:81:00.0"},
+			},
+			newValue: []any{
+				map[string]any{mkHostPCIDevice: "hostpci0", mkHostPCIDeviceID: "0000:82:00.0"},
+			},
+			slotKey:        mkHostPCIDevice,
+			fallbackPrefix: "hostpci",
+			expected:       []string{"hostpci0"},
+		},
+		{
+			name: "hostpci addition only",
+			oldValue: []any{
+				map[string]any{mkHostPCIDevice: "hostpci0", mkHostPCIDeviceID: "0000:81:00.0"},
+			},
+			newValue: []any{
+				map[string]any{mkHostPCIDevice: "hostpci0", mkHostPCIDeviceID: "0000:81:00.0"},
+				map[string]any{mkHostPCIDevice: "hostpci1", mkHostPCIDeviceID: "0000:82:00.0"},
+			},
+			slotKey:        mkHostPCIDevice,
+			fallbackPrefix: "hostpci",
+			expected:       []string{},
+		},
+		{
+			name: "usb positional replacement",
+			oldValue: []any{
+				map[string]any{mkHostUSBDevice: "1234:0001"},
+				map[string]any{mkHostUSBDevice: "1234:0002"},
+			},
+			newValue: []any{
+				map[string]any{mkHostUSBDevice: "1234:0001"},
+				map[string]any{mkHostUSBDevice: "1234:0003"},
+			},
+			slotKey:        "",
+			fallbackPrefix: "usb",
+			expected:       []string{"usb1"},
+		},
+		{
+			name: "numa removal keeps configured slot",
+			oldValue: []any{
+				map[string]any{mkNUMADevice: "numa2", mkNUMACPUIDs: "0;1", mkNUMAMemory: 1024},
+			},
+			newValue:       []any{},
+			slotKey:        mkNUMADevice,
+			fallbackPrefix: "numa",
+			expected:       []string{"numa2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := vmChangedOrRemovedSlotsFromValues(tt.oldValue, tt.newValue, tt.slotKey, tt.fallbackPrefix)
+
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestVMAppendMissingDeviceDeletesKeepsConfiguredNonSequentialSlots(t *testing.T) {
+	t.Parallel()
+
+	configuredDevices := map[string]struct{}{
+		"hostpci5": {},
+	}
+	preMigrationDeletePlan := vmPreMigrationDeletePlan{
+		set: map[string]struct{}{
+			"hostpci3": {},
+		},
+	}
+
+	actual := vmAppendMissingDeviceDeletes(nil, "hostpci", 8, configuredDevices, preMigrationDeletePlan)
+
+	require.Equal(t, []string{"hostpci0", "hostpci1", "hostpci2", "hostpci4", "hostpci6", "hostpci7"}, actual)
+}
+
+func TestVMGetNumaDeviceObjectsKeepsConfiguredNonSequentialSlot(t *testing.T) {
+	t.Parallel()
+
+	resourceData := schema.TestResourceDataRaw(t, VM().Schema, map[string]any{
+		mkNUMA: []any{
+			map[string]any{
+				mkNUMADevice:        "numa5",
+				mkNUMACPUIDs:        "0;1",
+				mkNUMAHostNodeNames: "0",
+				mkNUMAMemory:        1024,
+				mkNUMAPolicy:        "preferred",
+			},
+		},
+	})
+
+	actual := vmGetNumaDeviceObjects(resourceData)
+
+	require.Len(t, actual, 1)
+	require.Contains(t, actual, 5)
+	require.NotContains(t, actual, 0)
+	require.Equal(t, []string{"0", "1"}, actual[5].CPUIDs)
+	require.NotNil(t, actual[5].Memory)
+	require.Equal(t, 1024, *actual[5].Memory)
+	require.NotNil(t, actual[5].HostNodeNames)
+	require.Equal(t, []string{"0"}, *actual[5].HostNodeNames)
+	require.NotNil(t, actual[5].Policy)
+	require.Equal(t, "preferred", *actual[5].Policy)
+}
+
 // TestVMSchema tests the VM schema.
 func TestVMSchema(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
### What does this PR do?
Fixes VM migration when node_name changes together with removal or replacement of node-local VM devices.

Previously, the VM update flow migrated the VM before applying configuration changes. This caused migrations to fail when the diff removed or replaced source-node-local devices such as raw hostpci, hostusb, or numa devices, because those devices were still present on the source VM at migration time.

This PR applies removals/replacements for node-local device slots on the source node before migration, then continues with the normal target-node update after migration.

### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [x] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work
<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

My test proxmox system unfortunately doesn't have a pci device, so I couldn't test the acceptence test, I can't tell if it works as expected.
I tested it manually in our production system by creating a VM with a hostpci device, then commenting the section and migrating it away in the same operation. This worked as expected.
<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2803

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
