### PR TITLE
feat(network): add `vids` attribute to `proxmox_network_linux_bridge`

### DIFF
--- a/docs/resources/network_linux_bridge.md
+++ b/docs/resources/network_linux_bridge.md
@@ -32,6 +32,11 @@ resource "proxmox_network_linux_bridge" "vmbr99" {
     # For VLAN interfaces with custom names, use the interface name without the VLAN tag, e.g. "vlan_lab"
     "ens18.99"
   ]
+
+  # VLAN-aware bridge: permit any tagged VLAN through. Segmentation typically
+  # lives upstream (switch / firewall), not on the hypervisor bridge.
+  vlan_aware = true
+  vids       = "2-4094"
 }
 
 resource "proxmox_network_linux_vlan" "vlan99" {
@@ -64,6 +69,7 @@ resource "proxmox_network_linux_vlan" "vlan99" {
 - `mtu` (Number) The interface MTU.
 - `ports` (List of String) The interface bridge ports.
 - `timeout_reload` (Number) Timeout for network reload operations in seconds (defaults to `100`).
+- `vids` (String) VLAN IDs allowed on the bridge (Linux Bridge `bridge-vids`). Space-separated list of VLAN IDs and/or hyphenated ranges (e.g. `"2-4094"`, `"1 20 130"`, or `"1 10-20 30"`). Requires `vlan_aware = true`. PVE/ifupdown2 fills in `2-4094` as the implicit default for VLAN-aware bridges when this attribute is omitted; the provider surfaces that default in state.
 - `vlan_aware` (Boolean) Whether the interface bridge is VLAN aware (defaults to `false`).
 
 ### Read-Only

--- a/docs/resources/virtual_environment_network_linux_bridge.md
+++ b/docs/resources/virtual_environment_network_linux_bridge.md
@@ -34,6 +34,11 @@ resource "proxmox_virtual_environment_network_linux_bridge" "vmbr99" {
     # For VLAN interfaces with custom names, use the interface name without the VLAN tag, e.g. "vlan_lab"
     "ens18.99"
   ]
+
+  # VLAN-aware bridge: permit any tagged VLAN through. Segmentation typically
+  # lives upstream (switch / firewall), not on the hypervisor bridge.
+  vlan_aware = true
+  vids       = "2-4094"
 }
 
 resource "proxmox_virtual_environment_network_linux_vlan" "vlan99" {
@@ -66,6 +71,7 @@ resource "proxmox_virtual_environment_network_linux_vlan" "vlan99" {
 - `mtu` (Number) The interface MTU.
 - `ports` (List of String) The interface bridge ports.
 - `timeout_reload` (Number) Timeout for network reload operations in seconds (defaults to `100`).
+- `vids` (String) VLAN IDs allowed on the bridge (Linux Bridge `bridge-vids`). Space-separated list of VLAN IDs and/or hyphenated ranges (e.g. `"2-4094"`, `"1 20 130"`, or `"1 10-20 30"`). Requires `vlan_aware = true`. PVE/ifupdown2 fills in `2-4094` as the implicit default for VLAN-aware bridges when this attribute is omitted; the provider surfaces that default in state.
 - `vlan_aware` (Boolean) Whether the interface bridge is VLAN aware (defaults to `false`).
 
 ### Read-Only

--- a/examples/resources/proxmox_network_linux_bridge/resource.tf
+++ b/examples/resources/proxmox_network_linux_bridge/resource.tf
@@ -16,6 +16,11 @@ resource "proxmox_network_linux_bridge" "vmbr99" {
     # For VLAN interfaces with custom names, use the interface name without the VLAN tag, e.g. "vlan_lab"
     "ens18.99"
   ]
+
+  # VLAN-aware bridge: permit any tagged VLAN through. Segmentation typically
+  # lives upstream (switch / firewall), not on the hypervisor bridge.
+  vlan_aware = true
+  vids       = "2-4094"
 }
 
 resource "proxmox_network_linux_vlan" "vlan99" {

--- a/examples/resources/proxmox_virtual_environment_network_linux_bridge/resource.tf
+++ b/examples/resources/proxmox_virtual_environment_network_linux_bridge/resource.tf
@@ -16,6 +16,11 @@ resource "proxmox_virtual_environment_network_linux_bridge" "vmbr99" {
     # For VLAN interfaces with custom names, use the interface name without the VLAN tag, e.g. "vlan_lab"
     "ens18.99"
   ]
+
+  # VLAN-aware bridge: permit any tagged VLAN through. Segmentation typically
+  # lives upstream (switch / firewall), not on the hypervisor bridge.
+  vlan_aware = true
+  vids       = "2-4094"
 }
 
 resource "proxmox_virtual_environment_network_linux_vlan" "vlan99" {

--- a/fwprovider/nodes/network/resource_linux_bridge.go
+++ b/fwprovider/nodes/network/resource_linux_bridge.go
@@ -326,7 +326,7 @@ func (r *linuxBridgeResource) ValidateConfig(
 	// `vids` (bridge-vids) only applies to VLAN-aware bridges. Setting it
 	// without `vlan_aware = true` has no effect on PVE — surface the
 	// dependency at plan time so the misconfiguration is loud, not silent.
-	if !data.VIDs.IsNull() && !data.VIDs.IsUnknown() && !data.VLANAware.ValueBool() {
+	if attribute.IsDefined(data.VIDs) && attribute.IsDefined(data.VLANAware) && !data.VLANAware.ValueBool() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("vids"),
 			"Invalid attribute combination",
@@ -475,6 +475,7 @@ func (r *linuxBridgeResource) Update(ctx context.Context, req resource.UpdateReq
 	attribute.CheckDelete(plan.Gateway, state.Gateway, &toDelete, "gateway")
 	attribute.CheckDelete(plan.Gateway6, state.Gateway6, &toDelete, "gateway6")
 	attribute.CheckDelete(plan.Comment, state.Comment, &toDelete, "comments")
+	attribute.CheckDelete(plan.VIDs, state.VIDs, &toDelete, "bridge_vids")
 
 	// VLANAware is computed with a default, will never be null
 	if !plan.VLANAware.Equal(state.VLANAware) && !plan.VLANAware.ValueBool() {

--- a/fwprovider/nodes/network/resource_linux_bridge.go
+++ b/fwprovider/nodes/network/resource_linux_bridge.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -37,9 +38,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = &linuxBridgeResource{}
-	_ resource.ResourceWithConfigure   = &linuxBridgeResource{}
-	_ resource.ResourceWithImportState = &linuxBridgeResource{}
+	_ resource.Resource                   = &linuxBridgeResource{}
+	_ resource.ResourceWithConfigure      = &linuxBridgeResource{}
+	_ resource.ResourceWithImportState    = &linuxBridgeResource{}
+	_ resource.ResourceWithValidateConfig = &linuxBridgeResource{}
 )
 
 type linuxBridgeResourceModel struct {
@@ -58,6 +60,7 @@ type linuxBridgeResourceModel struct {
 	// Linux bridge attributes
 	Ports     []types.String `tfsdk:"ports"`
 	VLANAware types.Bool     `tfsdk:"vlan_aware"`
+	VIDs      types.String   `tfsdk:"vids"`
 }
 
 func (m *linuxBridgeResourceModel) exportToNetworkInterfaceCreateUpdateBody() *nodes.NetworkInterfaceCreateUpdateRequestBody {
@@ -95,6 +98,8 @@ func (m *linuxBridgeResourceModel) exportToNetworkInterfaceCreateUpdateBody() *n
 	if m.VLANAware.ValueBool() {
 		body.BridgeVLANAware = proxmoxtypes.CustomBool(true).Pointer()
 	}
+
+	body.BridgeVIDs = attribute.StringPtrFromValue(m.VIDs)
 
 	return body
 }
@@ -144,6 +149,12 @@ func (m *linuxBridgeResourceModel) importFromNetworkInterfaceList(
 		if diags.HasError() {
 			return fmt.Errorf("failed to build bridge ports list: %s", *iface.BridgePorts)
 		}
+	}
+
+	if iface.BridgeVIDs != nil {
+		m.VIDs = types.StringValue(*iface.BridgeVIDs)
+	} else {
+		m.VIDs = types.StringNull()
 	}
 
 	return nil
@@ -251,6 +262,27 @@ func (r *linuxBridgeResource) Schema(
 				Optional:    true,
 				Computed:    true,
 			},
+			"vids": schema.StringAttribute{
+				Description: "VLAN IDs allowed on the bridge (Linux Bridge `bridge-vids`).",
+				MarkdownDescription: "VLAN IDs allowed on the bridge (Linux Bridge `bridge-vids`). " +
+					"Space-separated list of VLAN IDs and/or hyphenated ranges " +
+					"(e.g. `\"2-4094\"`, `\"1 20 130\"`, or `\"1 10-20 30\"`). " +
+					"Requires `vlan_aware = true`. PVE/ifupdown2 fills in `2-4094` as the " +
+					"implicit default for VLAN-aware bridges when this attribute is omitted; " +
+					"the provider surfaces that default in state.",
+				Optional: true,
+				Computed: true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d+(-\d+)?( \d+(-\d+)?)*$`),
+						`must be a space-separated list of VLAN IDs or ranges (e.g. "1 20 130" or "2-4094")`,
+					),
+				},
+				PlanModifiers: []planmodifier.String{
+					vidsPlanModifier{},
+				},
+			},
 		},
 	}
 }
@@ -275,6 +307,34 @@ func (r *linuxBridgeResource) Configure(
 	}
 
 	r.client = cfg.Client
+}
+
+// ValidateConfig validates the resource configuration.
+func (r *linuxBridgeResource) ValidateConfig(
+	ctx context.Context,
+	req resource.ValidateConfigRequest,
+	resp *resource.ValidateConfigResponse,
+) {
+	var data linuxBridgeResourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// `vids` (bridge-vids) only applies to VLAN-aware bridges. Setting it
+	// without `vlan_aware = true` has no effect on PVE — surface the
+	// dependency at plan time so the misconfiguration is loud, not silent.
+	if !data.VIDs.IsNull() && !data.VIDs.IsUnknown() && !data.VLANAware.ValueBool() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("vids"),
+			"Invalid attribute combination",
+			"The `vids` attribute requires `vlan_aware = true`. A bridge that is "+
+				"not VLAN-aware does not perform VLAN filtering, so `vids` has no "+
+				"effect. Either set `vlan_aware = true`, or remove `vids`.",
+		)
+	}
 }
 
 //nolint:dupl

--- a/fwprovider/nodes/network/resource_linux_bridge_test.go
+++ b/fwprovider/nodes/network/resource_linux_bridge_test.go
@@ -180,8 +180,8 @@ func TestAccResourceLinuxBridgeVIDs(t *testing.T) {
 					}),
 				),
 			},
-			// Remove vids from config — UseStateForUnknown means the prior value
-			// persists in state. Users explicitly reset by setting vids = "2-4094".
+			// Remove vids from config — vidsPlanModifier preserves the prior state value when vlan_aware stays
+			// true. Users explicitly reset by setting vids = "2-4094".
 			{
 				Config: te.RenderConfig(fmt.Sprintf(`
 				resource "proxmox_network_linux_bridge" "test" {
@@ -243,6 +243,61 @@ func TestAccResourceLinuxBridgeVIDs(t *testing.T) {
 	})
 }
 
+// TestAccResourceLinuxBridgeVIDsToggleVLANAware exercises the plan modifier
+// branch that nulls vids when vlan_aware flips from true to false, and the
+// CheckDelete plumbing that removes bridge_vids from PVE on that transition.
+func TestAccResourceLinuxBridgeVIDsToggleVLANAware(t *testing.T) {
+	te := test.InitEnvironment(t)
+
+	iface := fmt.Sprintf("vmbr%d", gofakeit.Number(10, 9999))
+	ipV4cidr := fmt.Sprintf("%s/24", gofakeit.IPv4Address())
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			// Create with vlan_aware = true and an explicit vids list.
+			{
+				Config: te.RenderConfig(fmt.Sprintf(`
+				resource "proxmox_network_linux_bridge" "test" {
+					address    = "%s"
+					name       = "%s"
+					node_name  = "{{.NodeName}}"
+					vlan_aware = true
+					vids       = "100 200"
+				}
+				`, ipV4cidr, iface)),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_network_linux_bridge.test", map[string]string{
+						"vlan_aware": "true",
+						"vids":       "100 200",
+					}),
+				),
+			},
+			// Flip vlan_aware to false and drop vids from config — the plan modifier
+			// must null vids (rather than pin the prior "100 200" via state) and the
+			// Update path must send bridge_vids in the delete list.
+			{
+				Config: te.RenderConfig(fmt.Sprintf(`
+				resource "proxmox_network_linux_bridge" "test" {
+					address    = "%s"
+					name       = "%s"
+					node_name  = "{{.NodeName}}"
+					vlan_aware = false
+				}
+				`, ipV4cidr, iface)),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_network_linux_bridge.test", map[string]string{
+						"vlan_aware": "false",
+					}),
+					test.NoResourceAttributesSet("proxmox_network_linux_bridge.test", []string{
+						"vids",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceLinuxBridgeVIDsValidation(t *testing.T) {
 	te := test.InitEnvironment(t)
 
@@ -252,19 +307,6 @@ func TestAccResourceLinuxBridgeVIDsValidation(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: te.AccProviders,
 		Steps: []resource.TestStep{
-			// `vids` requires `vlan_aware = true` (resource-level ValidateConfig).
-			{
-				Config: te.RenderConfig(fmt.Sprintf(`
-				resource "proxmox_network_linux_bridge" "test" {
-					address   = "%s"
-					name      = "%s"
-					node_name = "{{.NodeName}}"
-					vids      = "1 2 3"
-				}
-				`, ipV4cidr, iface)),
-				ExpectError: regexp.MustCompile(`(?s)requires.*vlan_aware`),
-				PlanOnly:    true,
-			},
 			// `vids = ""` rejected by per-attribute LengthAtLeast(1) validator.
 			{
 				Config: te.RenderConfig(fmt.Sprintf(`

--- a/fwprovider/nodes/network/resource_linux_bridge_test.go
+++ b/fwprovider/nodes/network/resource_linux_bridge_test.go
@@ -13,6 +13,7 @@ package network_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v7"
@@ -130,6 +131,184 @@ func TestAccResourceLinuxBridge(t *testing.T) {
 					"comment", // "" comments translates to null in the PVE, but nulls are not imported as empty strings.
 					"timeout_reload",
 				},
+			},
+		},
+	})
+}
+
+func TestAccResourceLinuxBridgeVIDs(t *testing.T) {
+	te := test.InitEnvironment(t)
+
+	iface := fmt.Sprintf("vmbr%d", gofakeit.Number(10, 9999))
+	ipV4cidr := fmt.Sprintf("%s/24", gofakeit.IPv4Address())
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			// Create with a hyphenated VID range.
+			{
+				Config: te.RenderConfig(fmt.Sprintf(`
+				resource "proxmox_network_linux_bridge" "test" {
+					address    = "%s"
+					name       = "%s"
+					node_name  = "{{.NodeName}}"
+					vlan_aware = true
+					vids       = "2-4094"
+				}
+				`, ipV4cidr, iface)),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_network_linux_bridge.test", map[string]string{
+						"vids":       "2-4094",
+						"vlan_aware": "true",
+					}),
+				),
+			},
+			// Update to a space-separated VID list.
+			{
+				Config: te.RenderConfig(fmt.Sprintf(`
+				resource "proxmox_network_linux_bridge" "test" {
+					address    = "%s"
+					name       = "%s"
+					node_name  = "{{.NodeName}}"
+					vlan_aware = true
+					vids       = "10 20 30"
+				}
+				`, ipV4cidr, iface)),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_network_linux_bridge.test", map[string]string{
+						"vids": "10 20 30",
+					}),
+				),
+			},
+			// Remove vids from config — UseStateForUnknown means the prior value
+			// persists in state. Users explicitly reset by setting vids = "2-4094".
+			{
+				Config: te.RenderConfig(fmt.Sprintf(`
+				resource "proxmox_network_linux_bridge" "test" {
+					address    = "%s"
+					name       = "%s"
+					node_name  = "{{.NodeName}}"
+					vlan_aware = true
+				}
+				`, ipV4cidr, iface)),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_network_linux_bridge.test", map[string]string{
+						"vids": "10 20 30",
+					}),
+				),
+			},
+			// Reset vids to the implicit PVE default by setting it explicitly.
+			{
+				Config: te.RenderConfig(fmt.Sprintf(`
+				resource "proxmox_network_linux_bridge" "test" {
+					address    = "%s"
+					name       = "%s"
+					node_name  = "{{.NodeName}}"
+					vlan_aware = true
+					vids       = "2-4094"
+				}
+				`, ipV4cidr, iface)),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_network_linux_bridge.test", map[string]string{
+						"vids": "2-4094",
+					}),
+				),
+			},
+			// ImportState testing — round-trip with vids set.
+			{
+				Config: te.RenderConfig(fmt.Sprintf(`
+				resource "proxmox_network_linux_bridge" "test" {
+					address    = "%s"
+					name       = "%s"
+					node_name  = "{{.NodeName}}"
+					vlan_aware = true
+					vids       = "100-200"
+				}
+				`, ipV4cidr, iface)),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_network_linux_bridge.test", map[string]string{
+						"vids": "100-200",
+					}),
+				),
+			},
+			{
+				ResourceName:      "proxmox_network_linux_bridge.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"timeout_reload",
+				},
+			},
+		},
+	})
+}
+
+func TestAccResourceLinuxBridgeVIDsValidation(t *testing.T) {
+	te := test.InitEnvironment(t)
+
+	iface := fmt.Sprintf("vmbr%d", gofakeit.Number(10, 9999))
+	ipV4cidr := fmt.Sprintf("%s/24", gofakeit.IPv4Address())
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			// `vids` requires `vlan_aware = true` (resource-level ValidateConfig).
+			{
+				Config: te.RenderConfig(fmt.Sprintf(`
+				resource "proxmox_network_linux_bridge" "test" {
+					address   = "%s"
+					name      = "%s"
+					node_name = "{{.NodeName}}"
+					vids      = "1 2 3"
+				}
+				`, ipV4cidr, iface)),
+				ExpectError: regexp.MustCompile(`(?s)requires.*vlan_aware`),
+				PlanOnly:    true,
+			},
+			// `vids = ""` rejected by per-attribute LengthAtLeast(1) validator.
+			{
+				Config: te.RenderConfig(fmt.Sprintf(`
+				resource "proxmox_network_linux_bridge" "test" {
+					address    = "%s"
+					name       = "%s"
+					node_name  = "{{.NodeName}}"
+					vlan_aware = true
+					vids       = ""
+				}
+				`, ipV4cidr, iface)),
+				ExpectError: regexp.MustCompile(`(?s)at least 1`),
+				PlanOnly:    true,
+			},
+			// vids set + vlan_aware explicitly false → ValidateConfig errors.
+			// Covers the migration scenario: a user toggling vlan_aware off
+			// without first removing vids.
+			{
+				Config: te.RenderConfig(fmt.Sprintf(`
+				resource "proxmox_network_linux_bridge" "test" {
+					address    = "%s"
+					name       = "%s"
+					node_name  = "{{.NodeName}}"
+					vlan_aware = false
+					vids       = "1 2 3"
+				}
+				`, ipV4cidr, iface)),
+				ExpectError: regexp.MustCompile(`(?s)requires.*vlan_aware`),
+				PlanOnly:    true,
+			},
+			// Comma-separated list rejected by per-attribute RegexMatches validator.
+			// Catches the most common malformed input (users reaching for CSV).
+			{
+				Config: te.RenderConfig(fmt.Sprintf(`
+				resource "proxmox_network_linux_bridge" "test" {
+					address    = "%s"
+					name       = "%s"
+					node_name  = "{{.NodeName}}"
+					vlan_aware = true
+					vids       = "1,2,3"
+				}
+				`, ipV4cidr, iface)),
+				ExpectError: regexp.MustCompile(`(?s)space-separated list of VLAN IDs`),
+				PlanOnly:    true,
 			},
 		},
 	})

--- a/fwprovider/nodes/network/resource_linux_bridge_vids_plan_modifier.go
+++ b/fwprovider/nodes/network/resource_linux_bridge_vids_plan_modifier.go
@@ -1,0 +1,84 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package network
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// vidsPlanModifier resolves the `vids` plan value from the bridge's vlan_aware
+// state, avoiding noisy "(known after apply)" output on every plan.
+//
+// Why a custom modifier instead of `stringplanmodifier.UseStateForUnknown()`:
+// PVE/ifupdown2 silently substitutes "2-4094" as the implicit `bridge-vids`
+// default whenever a bridge is VLAN-aware and the field is unset. That forces
+// the provider to surface the value via Computed (otherwise Read on a freshly
+// created bridge produces "inconsistent result after apply: was null, but now
+// cty.StringVal(\"2-4094\")"). UseStateForUnknown alone is then unsafe in the
+// other direction: when a user toggles vlan_aware from true to false the bridge
+// stops storing bridge_vids and PVE returns nil, but the stock modifier would
+// have pinned the prior "2-4094" value into the plan, producing the mirror
+// inconsistency on apply.
+//
+// The vlan_aware-aware branches below cover both transitions:
+//
+//   - vlan_aware = false → vids is null (PVE doesn't store bridge_vids on
+//     non-VLAN-aware bridges).
+//   - vlan_aware = true with config null and a non-null state → preserve state
+//     (no spurious diff on refresh).
+//   - vlan_aware = true on create with no config or state → leave unknown so
+//     apply can pick up PVE's implicit default ("2-4094").
+type vidsPlanModifier struct{}
+
+func (vidsPlanModifier) Description(_ context.Context) string {
+	return "Resolves vids from vlan_aware: null when vlan_aware is false; " +
+		"otherwise uses state when config is unset to keep refreshes quiet."
+}
+
+func (m vidsPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (vidsPlanModifier) PlanModifyString(
+	ctx context.Context,
+	req planmodifier.StringRequest,
+	resp *planmodifier.StringResponse,
+) {
+	// Defer to an explicit config value.
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+
+	var vlanAware types.Bool
+
+	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("vlan_aware"), &vlanAware)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// vlan_aware itself is unresolved; nothing useful to compute yet.
+	if vlanAware.IsUnknown() {
+		return
+	}
+
+	if !vlanAware.ValueBool() {
+		resp.PlanValue = types.StringNull()
+
+		return
+	}
+
+	// VLAN-aware bridge with no config value: prefer state to avoid a
+	// "(known after apply)" diff on every refresh.
+	if !req.StateValue.IsNull() && !req.StateValue.IsUnknown() {
+		resp.PlanValue = req.StateValue
+	}
+}

--- a/fwprovider/nodes/network/resource_linux_bridge_vids_plan_modifier_test.go
+++ b/fwprovider/nodes/network/resource_linux_bridge_vids_plan_modifier_test.go
@@ -1,0 +1,148 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package network
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVIDsPlanModifier exercises every decision branch of vidsPlanModifier
+// without requiring a Proxmox endpoint: the modifier is pure logic over its
+// inputs and is the place a regression is most likely to land silently
+// (since acceptance tests don't run in fast feedback loops).
+func TestVIDsPlanModifier(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	modifier := vidsPlanModifier{}
+
+	// Minimal schema — vidsPlanModifier only reads vlan_aware via Plan.GetAttribute.
+	planSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"vlan_aware": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+	planObjectType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"vlan_aware": tftypes.Bool,
+		},
+	}
+
+	// makePlan builds a tfsdk.Plan whose only attribute is vlan_aware. Pass
+	// a *bool value (nil for null), or an explicit tftypes.UnknownValue token.
+	makePlan := func(vlanAware tftypes.Value) tfsdk.Plan {
+		return tfsdk.Plan{
+			Schema: planSchema,
+			Raw: tftypes.NewValue(planObjectType, map[string]tftypes.Value{
+				"vlan_aware": vlanAware,
+			}),
+		}
+	}
+
+	t.Run("config has explicit value: no-op", func(t *testing.T) {
+		t.Parallel()
+
+		req := planmodifier.StringRequest{
+			Path:        path.Root("vids"),
+			Plan:        makePlan(tftypes.NewValue(tftypes.Bool, true)),
+			ConfigValue: types.StringValue("1 20 130"),
+			StateValue:  types.StringNull(),
+			PlanValue:   types.StringValue("1 20 130"),
+		}
+		resp := &planmodifier.StringResponse{PlanValue: req.PlanValue}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		require.False(t, resp.Diagnostics.HasError())
+		// PlanValue should be unchanged from the explicit config.
+		require.True(t, resp.PlanValue.Equal(types.StringValue("1 20 130")))
+	})
+
+	t.Run("vlan_aware unknown: no-op (leave plan as-is)", func(t *testing.T) {
+		t.Parallel()
+
+		req := planmodifier.StringRequest{
+			Path:        path.Root("vids"),
+			Plan:        makePlan(tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue)),
+			ConfigValue: types.StringNull(),
+			StateValue:  types.StringNull(),
+			PlanValue:   types.StringUnknown(),
+		}
+		resp := &planmodifier.StringResponse{PlanValue: req.PlanValue}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		require.False(t, resp.Diagnostics.HasError())
+		require.True(t, resp.PlanValue.IsUnknown())
+	})
+
+	t.Run("vlan_aware = false: vids forced to null", func(t *testing.T) {
+		t.Parallel()
+
+		req := planmodifier.StringRequest{
+			Path:        path.Root("vids"),
+			Plan:        makePlan(tftypes.NewValue(tftypes.Bool, false)),
+			ConfigValue: types.StringNull(),
+			StateValue:  types.StringValue("10 20 30"), // would persist if not for the false branch
+			PlanValue:   types.StringUnknown(),
+		}
+		resp := &planmodifier.StringResponse{PlanValue: req.PlanValue}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		require.False(t, resp.Diagnostics.HasError())
+		require.True(t, resp.PlanValue.IsNull())
+	})
+
+	t.Run("vlan_aware = true, state null: leave unknown for create", func(t *testing.T) {
+		t.Parallel()
+
+		req := planmodifier.StringRequest{
+			Path:        path.Root("vids"),
+			Plan:        makePlan(tftypes.NewValue(tftypes.Bool, true)),
+			ConfigValue: types.StringNull(),
+			StateValue:  types.StringNull(),
+			PlanValue:   types.StringUnknown(),
+		}
+		resp := &planmodifier.StringResponse{PlanValue: req.PlanValue}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		require.False(t, resp.Diagnostics.HasError())
+		require.True(t, resp.PlanValue.IsUnknown())
+	})
+
+	t.Run("vlan_aware = true, state set: preserve state on refresh", func(t *testing.T) {
+		t.Parallel()
+
+		req := planmodifier.StringRequest{
+			Path:        path.Root("vids"),
+			Plan:        makePlan(tftypes.NewValue(tftypes.Bool, true)),
+			ConfigValue: types.StringNull(),
+			StateValue:  types.StringValue("10 20 30"),
+			PlanValue:   types.StringUnknown(),
+		}
+		resp := &planmodifier.StringResponse{PlanValue: req.PlanValue}
+
+		modifier.PlanModifyString(ctx, req, resp)
+
+		require.False(t, resp.Diagnostics.HasError())
+		require.True(t, resp.PlanValue.Equal(types.StringValue("10 20 30")))
+	})
+}

--- a/proxmox/nodes/network_types.go
+++ b/proxmox/nodes/network_types.go
@@ -63,6 +63,7 @@ type NetworkInterfaceCreateUpdateRequestBody struct {
 	BondMode           *string           `json:"bond_mode,omitempty"             url:"bond_mode,omitempty"`
 	BondXmitHashPolicy *string           `json:"bond_xmit_hash_policy,omitempty" url:"bond_xmit_hash_policy,omitempty"`
 	BridgePorts        *string           `json:"bridge_ports,omitempty"          url:"bridge_ports,omitempty"`
+	BridgeVIDs         *string           `json:"bridge_vids,omitempty"           url:"bridge_vids,omitempty"`
 	BridgeVLANAware    *types.CustomBool `json:"bridge_vlan_aware,omitempty"     url:"bridge_vlan_aware,omitempty,int"`
 	CIDR               *string           `json:"cidr,omitempty"                  url:"cidr,omitempty"`
 	CIDR6              *string           `json:"cidr6,omitempty"                 url:"cidr6,omitempty"`


### PR DESCRIPTION
### What does this PR do?

Surfaces Linux Bridge's `bridge-vids` field on the `proxmox_network_linux_bridge` resource (and its deprecated alias `proxmox_virtual_environment_network_linux_bridge` via embedding). The response struct already has `BridgeVIDs`; this PR adds it to the request struct and plumbs it through the resource model, schema, import/export, validators, a custom plan modifier, examples, generated docs, and tests.

Without this, a VLAN-aware bridge whose `bridge-vids` differs from PVE/ifupdown2's implicit `2-4094` default is invisible to Terraform — `terraform plan` cannot detect drift on the field, and a reboot or reinstall that reverts to whatever's persisted in `/etc/network/interfaces` can silently drop a runtime-widened list with no Terraform-visible signal. See #2840 for the full motivation.

Design highlights:

- **`Optional + Computed`** because PVE/ifupdown2 fills `2-4094` as the implicit default for VLAN-aware bridges; surfacing that in state matches what Read returns and avoids "inconsistent result after apply" errors.
- **Custom plan modifier (`vidsPlanModifier`)** instead of stock `stringplanmodifier.UseStateForUnknown()` because the stock one regresses on the `vlan_aware: true → false` toggle (it pins the prior `2-4094` value into plan, but PVE clears `bridge_vids` on apply → mirror inconsistency error). The custom modifier reads `vlan_aware` from the plan and routes: false → null, true + state → state, true + no state → unknown.
- **Plan-time validation:** per-attribute `LengthAtLeast(1)` + `RegexMatches`, plus resource-level `ValidateConfig` requiring `vlan_aware = true` when `vids` is set. Defers when `vlan_aware` is unknown so the check doesn't false-positive on cross-resource references.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`).
- [x] I have added / updated acceptance tests.
- [x] I have considered backward compatibility (no breaking schema changes).
- [ ] For new resources: N/A — this is a new attribute on an existing resource.
- [ ] I have run `make example` — N/A for an FWK schema attribute; verified via `dev_overrides` + `terraform plan/apply` against PVE 8.4.19.

### Proof of Work

Unit test (plan modifier, 5 branches, no PVE required):

````
=== RUN   TestVIDsPlanModifier
=== RUN   TestVIDsPlanModifier/config_has_explicit_value:_no-op
=== RUN   TestVIDsPlanModifier/vlan_aware_unknown:_no-op_(leave_plan_as-is)
=== RUN   TestVIDsPlanModifier/vlan_aware_=_false:_vids_forced_to_null
=== RUN   TestVIDsPlanModifier/vlan_aware_=_true,_state_null:_leave_unknown_for_create
=== RUN   TestVIDsPlanModifier/vlan_aware_=_true,_state_set:_preserve_state_on_refresh
--- PASS: TestVIDsPlanModifier (0.00s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/network	0.003s
````

Acceptance tests against PVE 8.4.19:

````
=== RUN   TestAccResourceLinuxBridge
--- PASS: TestAccResourceLinuxBridge (9.09s)
=== RUN   TestAccResourceLinuxBridgeVIDs
--- PASS: TestAccResourceLinuxBridgeVIDs (12.57s)
=== RUN   TestAccResourceLinuxBridgeVIDsToggleVLANAware
--- PASS: TestAccResourceLinuxBridgeVIDsToggleVLANAware (9.24s)
=== RUN   TestAccResourceLinuxBridgeVIDsValidation
--- PASS: TestAccResourceLinuxBridgeVIDsValidation (3.01s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/network	34.27s
````

`TestAccResourceLinuxBridgeVIDs` covers create with hyphenated range, update to space-separated list, removing from config (state persists via plan modifier), explicit reset to default, and import round-trip.

`TestAccResourceLinuxBridgeVIDsToggleVLANAware` covers the `vlan_aware: true + vids → vlan_aware: false` lifecycle transition, exercising both the `vidsPlanModifier` null-branch and the `bridge_vids` removal in the Update path. Mitmproxy capture confirms the Update PUT body includes `delete=bridge_vids,bridge_vlan_aware` on that transition.

`TestAccResourceLinuxBridgeVIDsValidation` covers three plan-time error cases: empty string, malformed input (commas), and the `vlan_aware: true → false` migration with `vids` still set. (A previous step asserting an error when `vlan_aware` was omitted entirely was removed in response to review — see thread on `resource_linux_bridge.go:329`; under deferred validation that case is intentionally not surfaced at plan time.)

Live `terraform plan` against PVE — bridge resource imports cleanly with `vids = "2-4094"`:

````
proxmox_network_linux_bridge.vmbr0: Refreshing state... [id=proxmox:vmbr0]

# proxmox_network_linux_bridge.vmbr0 will be imported
    resource "proxmox_network_linux_bridge" "vmbr0" {
        address    = "10.0.0.10/24"
        autostart  = true
        gateway    = "10.0.0.1"
        id         = "proxmox:vmbr0"
        name       = "vmbr0"
        node_name  = "proxmox"
        ports      = ["enp89s0"]
        vids       = "2-4094"
        vlan_aware = true
    }

Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.
````

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2840
