### PR TITLE
fix(network): catch omitted `vlan_aware` in `vids` validator

### DIFF
--- a/fwprovider/nodes/network/resource_linux_bridge.go
+++ b/fwprovider/nodes/network/resource_linux_bridge.go
@@ -326,7 +326,10 @@ func (r *linuxBridgeResource) ValidateConfig(
 	// `vids` (bridge-vids) only applies to VLAN-aware bridges. Setting it
 	// without `vlan_aware = true` has no effect on PVE — surface the
 	// dependency at plan time so the misconfiguration is loud, not silent.
-	if attribute.IsDefined(data.VIDs) && attribute.IsDefined(data.VLANAware) && !data.VLANAware.ValueBool() {
+	// Skip only when `vlan_aware` is unknown (e.g. a cross-resource reference);
+	// null means the user omitted it from config and PVE defaults to false, which
+	// is still a misconfiguration when `vids` is set.
+	if attribute.IsDefined(data.VIDs) && !data.VLANAware.IsUnknown() && !data.VLANAware.ValueBool() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("vids"),
 			"Invalid attribute combination",

--- a/fwprovider/nodes/network/resource_linux_bridge_test.go
+++ b/fwprovider/nodes/network/resource_linux_bridge_test.go
@@ -321,6 +321,21 @@ func TestAccResourceLinuxBridgeVIDsValidation(t *testing.T) {
 				ExpectError: regexp.MustCompile(`(?s)at least 1`),
 				PlanOnly:    true,
 			},
+			// vids set + vlan_aware omitted → ValidateConfig still errors. PVE
+			// defaults vlan_aware to false, so the misconfiguration is real;
+			// only an unresolved (unknown) vlan_aware should be skipped.
+			{
+				Config: te.RenderConfig(fmt.Sprintf(`
+				resource "proxmox_network_linux_bridge" "test" {
+					address   = "%s"
+					name      = "%s"
+					node_name = "{{.NodeName}}"
+					vids      = "1 2 3"
+				}
+				`, ipV4cidr, iface)),
+				ExpectError: regexp.MustCompile(`(?s)requires.*vlan_aware`),
+				PlanOnly:    true,
+			},
 			// vids set + vlan_aware explicitly false → ValidateConfig errors.
 			// Covers the migration scenario: a user toggling vlan_aware off
 			// without first removing vids.


### PR DESCRIPTION
### What does this PR do?

@granda my recommendation on your PR #2841 actually broke one edge case scenario, so fixing it here. 

Tightens `proxmox_network_linux_bridge.ValidateConfig` so that setting `vids` without `vlan_aware` is caught at plan time again.

#2841 replaced the validator's null/unknown guards with `attribute.IsDefined(...)`, which correctly stops firing for unknown values (e.g. `vlan_aware = some_resource.bool_attr`) but as a side effect also stopped firing when `vlan_aware` was omitted from config. Since PVE defaults a missing `bridge-vlan-aware` to false, that was a real misconfiguration silently allowed through.

The fix skips only the unknown case and still catches the null (omitted) case:

```go
if attribute.IsDefined(data.VIDs) && !data.VLANAware.IsUnknown() && !data.VLANAware.ValueBool() {
```

| `vlan_aware` value | Error fires? |
|---|---|
| known `true` | no |
| known `false` (explicit) | yes |
| unknown (cross-resource ref) | no — preserves the #2841 fix |
| null (omitted from config) | yes — restored |

A new step in `TestAccResourceLinuxBridgeVIDsValidation` covers the omitted case.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits). — _N/A; no schema change._
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md). — _N/A._
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes). — _N/A._

### Proof of Work

**Test coverage:** the new `TestAccResourceLinuxBridgeVIDsValidation` step (`vids = "1 2 3"` with `vlan_aware` omitted) directly reproduces the regression. Verified via `git stash` of the validator fix that the new step fails on the unfixed code with `expected an error with pattern, no match on: The non-refresh plan was not empty.`, and passes once the fix is restored.

```text
$ ./testacc "TestAccResourceLinuxBridge.*" -- -v
=== RUN   TestAccResourceLinuxBridge
--- PASS: TestAccResourceLinuxBridge (9.81s)
=== RUN   TestAccResourceLinuxBridgeVIDs
--- PASS: TestAccResourceLinuxBridgeVIDs (13.07s)
=== RUN   TestAccResourceLinuxBridgeVIDsToggleVLANAware
--- PASS: TestAccResourceLinuxBridgeVIDsToggleVLANAware (6.81s)
=== RUN   TestAccResourceLinuxBridgeVIDsValidation
--- PASS: TestAccResourceLinuxBridgeVIDsValidation (0.37s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/network
```

`make lint` clean. No schema change → no `make docs` needed. Tested against PVE 8.4.19.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #2840

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.7). All changes have been reviewed and verified by a human.*
