### PR TITLE
fix(network): allow unknown `ports` on linux bridge validate

### DIFF
--- a/fwprovider/nodes/network/resource_linux_bridge.go
+++ b/fwprovider/nodes/network/resource_linux_bridge.go
@@ -84,7 +84,7 @@ func (m *linuxBridgeResourceModel) exportToNetworkInterfaceCreateUpdateBody(
 
 	var sanitizedPorts []string
 
-	if !m.Ports.IsNull() && !m.Ports.IsUnknown() {
+	if attribute.IsDefined(m.Ports) {
 		var portsList []string
 
 		d := m.Ports.ElementsAs(ctx, &portsList, false)

--- a/fwprovider/nodes/network/resource_linux_bridge.go
+++ b/fwprovider/nodes/network/resource_linux_bridge.go
@@ -58,12 +58,15 @@ type linuxBridgeResourceModel struct {
 	Comment   types.String            `tfsdk:"comment"`
 	Timeout   types.Int64             `tfsdk:"timeout_reload"`
 	// Linux bridge attributes
-	Ports     []types.String `tfsdk:"ports"`
-	VLANAware types.Bool     `tfsdk:"vlan_aware"`
-	VIDs      types.String   `tfsdk:"vids"`
+	Ports     types.List   `tfsdk:"ports"`
+	VLANAware types.Bool   `tfsdk:"vlan_aware"`
+	VIDs      types.String `tfsdk:"vids"`
 }
 
-func (m *linuxBridgeResourceModel) exportToNetworkInterfaceCreateUpdateBody() *nodes.NetworkInterfaceCreateUpdateRequestBody {
+func (m *linuxBridgeResourceModel) exportToNetworkInterfaceCreateUpdateBody(
+	ctx context.Context,
+	diags *diag.Diagnostics,
+) *nodes.NetworkInterfaceCreateUpdateRequestBody {
 	body := &nodes.NetworkInterfaceCreateUpdateRequestBody{
 		Iface:     m.Name.ValueString(),
 		Type:      "bridge",
@@ -81,10 +84,21 @@ func (m *linuxBridgeResourceModel) exportToNetworkInterfaceCreateUpdateBody() *n
 
 	var sanitizedPorts []string
 
-	for _, port := range m.Ports {
-		port := strings.TrimSpace(port.ValueString())
-		if len(port) > 0 {
-			sanitizedPorts = append(sanitizedPorts, port)
+	if !m.Ports.IsNull() && !m.Ports.IsUnknown() {
+		var portsList []string
+
+		d := m.Ports.ElementsAs(ctx, &portsList, false)
+		diags.Append(d...)
+
+		if d.HasError() {
+			return body
+		}
+
+		for _, port := range portsList {
+			port = strings.TrimSpace(port)
+			if len(port) > 0 {
+				sanitizedPorts = append(sanitizedPorts, port)
+			}
 		}
 	}
 
@@ -145,10 +159,10 @@ func (m *linuxBridgeResourceModel) importFromNetworkInterfaceList(
 			return fmt.Errorf("failed to parse bridge ports: %s", *iface.BridgePorts)
 		}
 
-		diags = ports.ElementsAs(ctx, &m.Ports, false)
-		if diags.HasError() {
-			return fmt.Errorf("failed to build bridge ports list: %s", *iface.BridgePorts)
-		}
+		m.Ports = ports
+	} else if m.Ports.ElementType(ctx) == nil {
+		// state.Set rejects a zero-value List (no element type) on fresh ImportState.
+		m.Ports = types.ListNull(types.StringType)
 	}
 
 	if iface.BridgeVIDs != nil {
@@ -340,7 +354,6 @@ func (r *linuxBridgeResource) ValidateConfig(
 	}
 }
 
-//nolint:dupl
 func (r *linuxBridgeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan linuxBridgeResourceModel
 
@@ -351,7 +364,10 @@ func (r *linuxBridgeResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	body := plan.exportToNetworkInterfaceCreateUpdateBody()
+	body := plan.exportToNetworkInterfaceCreateUpdateBody(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	err := r.client.Node(plan.NodeName.ValueString()).CreateNetworkInterface(ctx, body)
 	if err != nil {
@@ -468,7 +484,10 @@ func (r *linuxBridgeResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	body := plan.exportToNetworkInterfaceCreateUpdateBody()
+	body := plan.exportToNetworkInterfaceCreateUpdateBody(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	var toDelete []string
 

--- a/fwprovider/nodes/network/resource_linux_bridge_test.go
+++ b/fwprovider/nodes/network/resource_linux_bridge_test.go
@@ -298,6 +298,35 @@ func TestAccResourceLinuxBridgeVIDsToggleVLANAware(t *testing.T) {
 	})
 }
 
+// Regression test for #2851: `ports` referencing an unknown value must not
+// break `tofu validate` / `terraform plan`.
+func TestAccResourceLinuxBridgeUnknownPorts(t *testing.T) {
+	te := test.InitEnvironment(t)
+
+	iface := fmt.Sprintf("vmbr%d", gofakeit.Number(10, 9999))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(fmt.Sprintf(`
+				resource "terraform_data" "ports_source" {
+					input = ["enp1s0"]
+				}
+
+				resource "proxmox_network_linux_bridge" "test" {
+					name      = "%s"
+					node_name = "{{.NodeName}}"
+					ports     = terraform_data.ports_source.output
+				}
+				`, iface)),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccResourceLinuxBridgeVIDsValidation(t *testing.T) {
 	te := test.InitEnvironment(t)
 

--- a/fwprovider/nodes/network/resource_linux_vlan.go
+++ b/fwprovider/nodes/network/resource_linux_vlan.go
@@ -242,7 +242,6 @@ func (r *linuxVLANResource) Configure(
 	r.client = cfg.Client
 }
 
-//nolint:dupl
 func (r *linuxVLANResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan linuxVLANResourceModel
 


### PR DESCRIPTION
### What does this PR do?

PR #2841 added a `ValidateConfig` to `proxmox_network_linux_bridge` to enforce the `vids` ↔ `vlan_aware` cross-attribute rule. That `ValidateConfig` decodes the full config into the resource model, but the model declared `Ports []types.String` — a Go slice that cannot carry the framework's `unknown` value. Result: any non-literal `ports` expression (variable, `for_each` value, conditional, or computed-attribute reference) broke `tofu validate` / `terraform validate` on v0.105.0, even when the resource was gated behind `count = 0`.

This PR migrates `Ports` to `types.List`, which carries `unknown` natively. The schema, HCL surface, state file format, and PVE wire format are all unchanged — only the Go-side reflection target changed.

### Usage Example

The following config validates cleanly again on v0.105.0+:

```hcl
variable "ports" {
  type    = list(string)
  default = null
}

resource "proxmox_network_linux_bridge" "br0" {
  node_name = "pve"
  name      = "vmbr99"
  ports     = var.ports != null ? sort(var.ports) : []
}
```

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits). _(N/A — schema unchanged; `make docs` produced no diff.)_
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md). _(N/A — not a new resource.)_
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes). _(N/A — fix is internal to the Framework reflection layer; no provider-config or example changes.)_

### Proof of Work

A new acceptance test, `TestAccResourceLinuxBridgeUnknownPorts`, reproduces the bug by referencing `terraform_data.foo.output` (unknown at plan time) for `ports`. On `main`, the test fails with the exact framework error from the issue:

```
Error: Value Conversion Error
  with proxmox_network_linux_bridge.test,
  on terraform_plugin_test.tf line 32:
  32:   ports = terraform_data.ports_source.output

Received unknown value, however the target type cannot handle unknown values.
Path: ports
Target Type: []basetypes.StringValue
Suggested Type: basetypes.ListValue
```

After the fix, the full bridge suite passes (5/5 tests, ~23s):

```
$ ./testacc 'TestAccResourceLinuxBridge.*'
=== RUN   TestAccResourceLinuxBridge
--- PASS: TestAccResourceLinuxBridge (7.41s)
=== RUN   TestAccResourceLinuxBridgeVIDs
--- PASS: TestAccResourceLinuxBridgeVIDs (9.50s)
=== RUN   TestAccResourceLinuxBridgeVIDsToggleVLANAware
--- PASS: TestAccResourceLinuxBridgeVIDsToggleVLANAware (5.08s)
=== RUN   TestAccResourceLinuxBridgeUnknownPorts
--- PASS: TestAccResourceLinuxBridgeUnknownPorts (0.45s)
=== RUN   TestAccResourceLinuxBridgeVIDsValidation
--- PASS: TestAccResourceLinuxBridgeVIDsValidation (0.36s)
ok    github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/network    23.285s
```

`make build`, `make lint` (0 issues), `make test`, and `go vet -tags=acceptance` all clean. `make docs` produced no diff (schema unchanged).

#### Notes

- The fix preserves the existing `ports = []` semantics — `importFromNetworkInterfaceList` does not overwrite `m.Ports` with `ListNull` when PVE returns no `BridgePorts`, mirroring the `Comments` preservation pattern in the same file. A zero-value defense (`else if m.Ports.ElementType(ctx) == nil`) handles fresh `ImportState`, where `types.List{}` lacks an element type and `state.Set` would otherwise reject it.
- The `-1` line in `resource_linux_vlan.go` is the linter auto-removing a `//nolint:dupl` directive that became obsolete because `linuxBridgeResource.Create` is now structurally distinct from `linuxVLANResource.Create` (extra diagnostics-error guard). No behavior change.
- `linuxBondResource.Slaves` has the same `[]types.String` shape but no `ValidateConfig`, so the same regression does not currently fire there. Out of scope for this PR.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2851

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.7). All changes have been reviewed and verified by a human.*
