### PR TITLE
fix(lxc): allow disabling feature flags on update

### DIFF
--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -677,7 +677,7 @@ func TestAccResourceContainerCloneFullFlag(t *testing.T) {
 					hostname = "test-linked-clone"
 				}
 			}`, WithRootUser()),
-				ExpectError: regexp.MustCompile(`Linked clone feature .* is not available`),
+				ExpectError: regexp.MustCompile(`(?s)Linked\s+clone feature .* is not available`),
 			},
 		},
 	})
@@ -2746,6 +2746,96 @@ func TestAccResourceContainerFeaturesRefresh(t *testing.T) {
 				Config:             containerConfig,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceContainerFeaturesToggleOff verifies that toggling a `features.*` bool
+// from `true` to `false` reaches PVE when features is the only changed attribute.
+// Without the fix for #2856, the URL body for such an update is empty and PVE returns
+// `HTTP 500 - no options specified`.
+func TestAccResourceContainerFeaturesToggleOff(t *testing.T) {
+	te := InitEnvironment(t)
+	imageFileName := fmt.Sprintf("%d-alpine-3.22-default_20250617_amd64.tar.xz", time.Now().UnixMicro())
+	testAccDownloadContainerTemplate(t, te, imageFileName)
+
+	accTestContainerID := 100000 + rand.Intn(99999)
+
+	te.AddTemplateVars(map[string]interface{}{
+		"ImageFileName":   imageFileName,
+		"TestContainerID": accTestContainerID,
+	})
+
+	containerConfig := func(nesting bool) string {
+		return te.RenderConfig(fmt.Sprintf(`
+			resource "proxmox_virtual_environment_container" "test_container" {
+				node_name    = "{{.NodeName}}"
+				vm_id        = {{.TestContainerID}}
+				unprivileged = true
+				disk {
+					datastore_id = "local-lvm"
+					size         = 4
+				}
+				features {
+					nesting = %t
+				}
+				initialization {
+					hostname = "test-features-toggle"
+					ip_config {
+						ipv4 {
+							address = "dhcp"
+						}
+					}
+				}
+				network_interface {
+					name = "vmbr0"
+				}
+				operating_system {
+					template_file_id = "local:vztmpl/{{.ImageFileName}}"
+					type             = "alpine"
+				}
+			}`, nesting), WithRootUser())
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: containerConfig(true),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"features.0.nesting": "true",
+					}),
+					func(*terraform.State) error {
+						ct := te.NodeClient().Container(accTestContainerID)
+						ctInfo, err := ct.GetContainer(t.Context())
+						require.NoError(te.t, err, "failed to get container")
+						require.NotNil(te.t, ctInfo.Features, "features should not be nil")
+						require.NotNil(te.t, ctInfo.Features.Nesting, "features.nesting should not be nil")
+						require.True(te.t, bool(*ctInfo.Features.Nesting), "features.nesting should be true in Proxmox")
+
+						return nil
+					},
+				),
+			},
+			{
+				Config: containerConfig(false),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"features.0.nesting": "false",
+					}),
+					func(*terraform.State) error {
+						ct := te.NodeClient().Container(accTestContainerID)
+						ctInfo, err := ct.GetContainer(t.Context())
+						require.NoError(te.t, err, "failed to get container")
+						if ctInfo.Features != nil && ctInfo.Features.Nesting != nil {
+							require.False(te.t, bool(*ctInfo.Features.Nesting), "features.nesting should be false in Proxmox")
+						}
+
+						return nil
+					},
+				),
 			},
 		},
 	})

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -2517,6 +2517,20 @@ func containerGetStartupBehavior(d *schema.ResourceData) *containers.CustomStart
 }
 
 func containerGetFeatures(resource *schema.Resource, d *schema.ResourceData) (*containers.CustomFeatures, error) {
+	return containerGetFeaturesInternal(resource, d, false)
+}
+
+// Always populates all bool flags so a true→false toggle reaches PVE instead of
+// being dropped by EncodeValues' nil-pointer skip.
+func containerGetFeaturesForUpdate(resource *schema.Resource, d *schema.ResourceData) (*containers.CustomFeatures, error) {
+	return containerGetFeaturesInternal(resource, d, true)
+}
+
+func containerGetFeaturesInternal(
+	resource *schema.Resource,
+	d *schema.ResourceData,
+	emitFalseBools bool,
+) (*containers.CustomFeatures, error) {
 	featuresBlock, err := structure.GetSchemaBlock(
 		resource,
 		d,
@@ -2548,19 +2562,19 @@ func containerGetFeatures(resource *schema.Resource, d *schema.ResourceData) (*c
 		MountTypes: &mountTypesConverted,
 	}
 
-	if nesting {
+	if bool(nesting) || emitFalseBools {
 		features.Nesting = &nesting
 	}
 
-	if keyctl {
+	if bool(keyctl) || emitFalseBools {
 		features.KeyControl = &keyctl
 	}
 
-	if fuse {
+	if bool(fuse) || emitFalseBools {
 		features.FUSE = &fuse
 	}
 
-	if mknod {
+	if bool(mknod) || emitFalseBools {
 		features.MakeDeviceNode = &mknod
 	}
 
@@ -3678,7 +3692,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 	}
 
 	if d.HasChange(mkFeatures) {
-		features, err := containerGetFeatures(container, d)
+		features, err := containerGetFeaturesForUpdate(container, d)
 		if err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
### What does this PR do?

Fixes #2856. `containerGetFeatures` only set the `Nesting` / `KeyControl` / `FUSE` /
`MakeDeviceNode` pointers when the bool was `true`, and `CustomFeatures.EncodeValues`
skipped nil pointers and an empty `MountTypes`. As a result, toggling a feature from
`true` to `false` was silently dropped from the PUT body, and a features-only change
where every flag became `false` left the body completely empty — PVE responded with
`HTTP 500 - no options specified`. Combined with the read-side refresh added in #2852,
this turned silent drift into a permanent apply-loop.

The fix splits the helper: `containerGetFeatures` (used by Create/Clone) is unchanged
and continues to emit only positive flags, so the wire body for fresh resources doesn't
duplicate PVE's documented defaults (per [ADR-004](docs/adr/004-schema-design-conventions.md#provider-defaults-vs-pve-defaults)).
A new `containerGetFeaturesForUpdate` (used by `containerUpdate`) always emits all four
bool flags, including zeros, so a `true → false` toggle reaches PVE and the PUT body is
never empty when features is the only changed attribute.

The drive-by edit to `TestAccResourceContainerCloneFullFlag` makes its `ExpectError`
regex tolerate the newline Terraform inserts inside `"Linked\n        clone feature ... is not available"`.
That test was already failing on `main` for an unrelated formatting reason; the fix
keeps the suite green so this PR's CI run is clean.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [x] For new resources: I followed the [reference examples](docs/adr/reference-examples.md). — n/a, no new resources.
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes). 

### Proof of Work

**Acceptance test (failing-then-passing):**

Reverting `proxmoxtf/resource/container/container.go` to `main` and running the new test:

```
=== RUN   TestAccResourceContainerFeaturesToggleOff
=== CONT  TestAccResourceContainerFeaturesToggleOff
    resource_container_test.go:2805: Step 2/2 error: Error running apply: exit status 1

        Error: All attempts fail:
        #1: received an HTTP 500 response - Reason: no options specified

          with proxmox_virtual_environment_container.test_container, ...
--- FAIL: TestAccResourceContainerFeaturesToggleOff (15.88s)
```

After applying the fix:

```
$ ./testacc TestAccResourceContainerFeaturesToggleOff
--- PASS: TestAccResourceContainerFeaturesToggleOff (16.62s)
PASS
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/test       17.204s
```

**Targeted acceptance suite (related tests + drive-by fix):**

```
$ ./testacc 'TestAccResourceContainerFeaturesToggleOff|TestAccResourceContainerFeaturesRefresh|TestAccResourceContainerCloneStartOnBoot|TestAccResourceContainerCloneFullFlag|TestAccResourceContainerStartOnBootRefresh' -- -v

--- PASS: TestAccResourceContainerFeaturesRefresh (28.67s)
--- PASS: TestAccResourceContainerCloneStartOnBoot (31.37s)
--- PASS: TestAccResourceContainerStartOnBootRefresh (15.63s)
--- PASS: TestAccResourceContainerFeaturesToggleOff (46.63s)
--- PASS: TestAccResourceContainerCloneFullFlag (55.29s)
PASS
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/test       60.200s
```

Full container suite (`./testacc 'TestAccResourceContainer.*'`): **23/23 PASS** after both fixes.

**Mitmproxy — wire-level verification:**

`POST /api2/json/nodes/pve/lxc` (Step 1, Create with `features { nesting = true }`), URL-decoded body excerpt:

```
features=nesting=1
```

Create path emits **only** the positive flag — Create/Clone do not duplicate PVE's
documented defaults on the wire (ADR-004 compliant).

`PUT /api2/json/nodes/pve/lxc/{vmid}/config` (Step 2, features-only `true → false`), URL-decoded body:

```
features=fuse=0,keyctl=0,nesting=0,mknod=0
```

→ PVE returns `200 OK`. Pre-fix, the same scenario produced an empty PUT body and
`HTTP 500 - no options specified`.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2856

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.7). All changes have been reviewed and verified by a human.*
