### PR TITLE
feat(ha): add failback attribute to haresource

### DIFF
--- a/docs/data-sources/haresource.md
+++ b/docs/data-sources/haresource.md
@@ -38,6 +38,7 @@ output "proxmox_haresources_full" {
 ### Read-Only
 
 - `comment` (String) The comment associated with this resource.
+- `failback` (Boolean) Automatic failback to the preferred node when it becomes available again (PVE 9+).
 - `group` (String) The identifier of the High Availability group this resource is a member of.
 - `id` (String) The unique identifier of this resource.
 - `max_relocate` (Number) The maximal number of relocation attempts.

--- a/docs/data-sources/virtual_environment_haresource.md
+++ b/docs/data-sources/virtual_environment_haresource.md
@@ -40,6 +40,7 @@ output "proxmox_virtual_environment_haresources_full" {
 ### Read-Only
 
 - `comment` (String) The comment associated with this resource.
+- `failback` (Boolean) Automatic failback to the preferred node when it becomes available again (PVE 9+).
 - `group` (String) The identifier of the High Availability group this resource is a member of.
 - `id` (String) The unique identifier of this resource.
 - `max_relocate` (Number) The maximal number of relocation attempts.

--- a/docs/resources/haresource.md
+++ b/docs/resources/haresource.md
@@ -22,6 +22,7 @@ resource "proxmox_haresource" "example" {
   state       = "started"
   group       = "example"
   comment     = "Managed by Terraform"
+  failback    = true
 }
 ```
 
@@ -35,6 +36,7 @@ resource "proxmox_haresource" "example" {
 ### Optional
 
 - `comment` (String) The comment associated with this resource.
+- `failback` (Boolean) Automatic failback to the preferred node when it becomes available again (Proxmox VE 9+). Leave unset to use the cluster default.
 - `group` (String) The identifier of the High Availability group this resource is a member of.
 - `max_relocate` (Number) The maximal number of relocation attempts.
 - `max_restart` (Number) The maximal number of restart attempts.

--- a/docs/resources/virtual_environment_haresource.md
+++ b/docs/resources/virtual_environment_haresource.md
@@ -37,6 +37,7 @@ resource "proxmox_virtual_environment_haresource" "example" {
 ### Optional
 
 - `comment` (String) The comment associated with this resource.
+- `failback` (Boolean) Automatic failback to the preferred node when it becomes available again (Proxmox VE 9+). Leave unset to use the cluster default.
 - `group` (String) The identifier of the High Availability group this resource is a member of.
 - `max_relocate` (Number) The maximal number of relocation attempts.
 - `max_restart` (Number) The maximal number of restart attempts.

--- a/examples/resources/proxmox_haresource/resource.tf
+++ b/examples/resources/proxmox_haresource/resource.tf
@@ -6,4 +6,5 @@ resource "proxmox_haresource" "example" {
   state       = "started"
   group       = "example"
   comment     = "Managed by Terraform"
+  failback    = true
 }

--- a/fwprovider/cluster/ha/datasource_haresource.go
+++ b/fwprovider/cluster/ha/datasource_haresource.go
@@ -68,6 +68,10 @@ func (d *haResourceDatasource) Schema(_ context.Context, _ datasource.SchemaRequ
 				Description: "The comment associated with this resource.",
 				Computed:    true,
 			},
+			"failback": schema.BoolAttribute{
+				Description: "Automatic failback to the preferred node when it becomes available again (PVE 9+).",
+				Computed:    true,
+			},
 			"group": schema.StringAttribute{
 				Description: "The identifier of the High Availability group this resource is a member of.",
 				Computed:    true,

--- a/fwprovider/cluster/ha/model_haresource.go
+++ b/fwprovider/cluster/ha/model_haresource.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	"github.com/bpg/terraform-provider-proxmox/fwprovider/attribute"
 	haresources "github.com/bpg/terraform-provider-proxmox/proxmox/cluster/ha/resources"
 	proxmoxtypes "github.com/bpg/terraform-provider-proxmox/proxmox/types"
 )
@@ -27,6 +28,8 @@ type ResourceModel struct {
 	State types.String `tfsdk:"state"`
 	// The comment associated with this resource.
 	Comment types.String `tfsdk:"comment"`
+	// Whether the resource should automatically fail back to its preferred node when it becomes available again
+	Failback types.Bool `tfsdk:"failback"`
 	// The identifier of the High Availability group this resource is a member of.
 	Group types.String `tfsdk:"group"`
 	// The maximal number of relocation attempts.
@@ -41,7 +44,14 @@ func (d *ResourceModel) ImportFromAPI(data *haresources.HAResourceGetResponseDat
 	d.ResourceID = data.ID.ToValue()
 	d.Type = data.Type.ToValue()
 	d.State = data.State.ToValue()
+
 	d.Comment = types.StringPointerValue(data.Comment)
+	if data.Failback != nil {
+		d.Failback = types.BoolValue(bool(*data.Failback))
+	} else {
+		d.Failback = types.BoolNull()
+	}
+
 	d.Group = types.StringPointerValue(data.Group)
 	d.MaxRelocate = types.Int64PointerValue(data.MaxRelocate)
 	d.MaxRestart = types.Int64PointerValue(data.MaxRestart)
@@ -68,6 +78,7 @@ func (d *ResourceModel) toRequestBase() haresources.HAResourceDataBase {
 	return haresources.HAResourceDataBase{
 		State:       state,
 		Comment:     d.Comment.ValueStringPointer(),
+		Failback:    attribute.CustomBoolPtrFromValue(d.Failback),
 		Group:       d.Group.ValueStringPointer(),
 		MaxRelocate: d.MaxRelocate.ValueInt64Pointer(),
 		MaxRestart:  d.MaxRestart.ValueInt64Pointer(),
@@ -89,6 +100,10 @@ func (d *ResourceModel) ToUpdateRequest(state *ResourceModel) *haresources.HARes
 
 	if d.Comment.IsNull() && !state.Comment.IsNull() {
 		del = append(del, "comment")
+	}
+
+	if d.Failback.IsNull() && !state.Failback.IsNull() {
+		del = append(del, "failback")
 	}
 
 	if d.Group.IsNull() && !state.Group.IsNull() {

--- a/fwprovider/cluster/ha/resource_haresource.go
+++ b/fwprovider/cluster/ha/resource_haresource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -113,10 +112,6 @@ func (r *haResourceResource) Schema(
 				MarkdownDescription: "Automatic failback to the preferred node when it becomes available again (Proxmox VE 9+). " +
 					"Leave unset to use the cluster default.",
 				Optional: true,
-				Computed: true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"group": schema.StringAttribute{
 				Description: "The identifier of the High Availability group this resource is a member of.",

--- a/fwprovider/cluster/ha/resource_haresource.go
+++ b/fwprovider/cluster/ha/resource_haresource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -106,6 +107,15 @@ func (r *haResourceResource) Schema(
 					stringvalidator.UTF8LengthAtLeast(1),
 					stringvalidator.RegexMatches(regexp.MustCompile(`^\S|^$`), "must not start with whitespace"),
 					stringvalidator.RegexMatches(regexp.MustCompile(`\S$|^$`), "must not end with whitespace"),
+				},
+			},
+			"failback": schema.BoolAttribute{
+				MarkdownDescription: "Automatic failback to the preferred node when it becomes available again (Proxmox VE 9+). " +
+					"Leave unset to use the cluster default.",
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"group": schema.StringAttribute{

--- a/proxmox/cluster/ha/resources/resources_types.go
+++ b/proxmox/cluster/ha/resources/resources_types.go
@@ -29,6 +29,8 @@ type HAResourceGetResponseBody struct {
 type HAResourceDataBase struct {
 	// Resource comment, if defined
 	Comment *string `json:"comment,omitempty" url:"comment,omitempty"`
+	// Automatic failback to the preferred node when it becomes available again
+	Failback *types.CustomBool `json:"failback,omitempty" url:"failback,omitempty,int"`
 	// HA group identifier, if the resource is part of one.
 	Group *string `json:"group,omitempty" url:"group,omitempty"`
 	// Maximal number of service relocation attempts.


### PR DESCRIPTION
### What does this PR do?
Adds the `failback` attribute to `proxmox_haresource` (and the deprecated alias
  `proxmox_virtual_environment_haresource`) plus the matching data source.

  PVE 9.x exposes a per-resource `failback` boolean on `/cluster/ha/resources` that controls whether HA migrates a
  resource back to its preferred node once that node is healthy again. The provider previously had no way to set it,
  forcing users to run `ha-manager set vm:X --failback 1` over SSH after every Terraform apply.

### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
  Tested against an internal PVE 9.x 3-node cluster using `dev_overrides` with the locally-built provider. Two QEMU
  resources (vmid 990, 991) registered under HA with `failback = true`, then updated to `failback = false`, then
  destroyed.

  **Create with `failback = true`** — Terraform plan excerpt:

  ```
    # proxmox_virtual_environment_haresource.vm["990"] will be created
    + resource "proxmox_virtual_environment_haresource" "vm" {
        + comment     = "ha-test1"
        + failback    = true
        + id          = (known after apply)
        + resource_id = "vm:990"
        + state       = "started"
        + type        = "vm"
      }
  ```

  After apply, verified on cluster:
<img width="1244" height="506" alt="image" src="https://github.com/user-attachments/assets/72c2ef47-dfbe-4868-8634-4b51b6b1fed2" />
<img width="900" height="332" alt="image" src="https://github.com/user-attachments/assets/525b7a4f-7c62-4521-8b33-509688a7d8f9" />


  **Update from `true` → `false`** — plan excerpt:

  ```
    # proxmox_virtual_environment_haresource.vm["990"] will be updated in-place
    ~ resource "proxmox_virtual_environment_haresource" "vm" {
        ~ failback    = true -> false
          id          = "vm:990"
      }
  ```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2774

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
