### PR TITLE
fix(lxc): skip empty config PUT for lifecycle-only updates

### DIFF
--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -2914,6 +2914,97 @@ func TestAccResourceContainerStartOnBootRefresh(t *testing.T) {
 	})
 }
 
+// TestAccResourceContainerStartedToggle verifies that toggling `started` from `true` to
+// `false` (and back) succeeds when no other attribute changes. Without the fix for #2883,
+// such an apply sent an empty PUT /config to PVE and failed with
+// `HTTP 500 - no options specified`, because the `containerUpdate` gate fired on
+// `HasChangesExcept(mkIDMap)` without excluding `mkStarted` — which is applied through
+// Start/Shutdown calls, not through the config PUT.
+func TestAccResourceContainerStartedToggle(t *testing.T) {
+	te := InitEnvironment(t)
+	imageFileName := fmt.Sprintf("%d-alpine-3.22-default_20250617_amd64.tar.xz", time.Now().UnixMicro())
+	testAccDownloadContainerTemplate(t, te, imageFileName)
+
+	accTestContainerID := 100000 + rand.Intn(99999)
+
+	te.AddTemplateVars(map[string]interface{}{
+		"ImageFileName":   imageFileName,
+		"TestContainerID": accTestContainerID,
+	})
+
+	containerConfig := func(started bool) string {
+		return te.RenderConfig(fmt.Sprintf(`
+			resource "proxmox_virtual_environment_container" "test_container" {
+				node_name    = "{{.NodeName}}"
+				vm_id        = {{.TestContainerID}}
+				unprivileged = true
+				started      = %t
+				disk {
+					datastore_id = "local-lvm"
+					size         = 4
+				}
+				initialization {
+					hostname = "test-started-toggle"
+					ip_config {
+						ipv4 {
+							address = "dhcp"
+						}
+					}
+				}
+				network_interface {
+					name = "vmbr0"
+				}
+				operating_system {
+					template_file_id = "local:vztmpl/{{.ImageFileName}}"
+					type             = "alpine"
+				}
+			}`, started), WithRootUser())
+	}
+
+	expectStatus := func(want string) func(*terraform.State) error {
+		return func(*terraform.State) error {
+			st, err := te.NodeClient().Container(accTestContainerID).GetContainerStatus(t.Context())
+			require.NoError(te.t, err, "failed to get container status")
+			require.Equal(te.t, want, st.Status, "container status mismatch in Proxmox")
+
+			return nil
+		}
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: containerConfig(true),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"started": "true",
+					}),
+					expectStatus("running"),
+				),
+			},
+			{
+				Config: containerConfig(false),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"started": "false",
+					}),
+					expectStatus("stopped"),
+				),
+			},
+			{
+				Config: containerConfig(true),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"started": "true",
+					}),
+					expectStatus("running"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDownloadContainerTemplate(t *testing.T, te *Environment, imageFileName string) {
 	t.Helper()
 	err := te.NodeStorageClient().DownloadFileByURL(context.Background(), &storage.DownloadURLPostRequestBody{

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -3526,6 +3526,12 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		Delete: []string{},
 	}
 
+	// Tracks whether any field of updateBody (other than Delete) was populated.
+	// Required so attributes that don't map to PUT /config — `started` (Start/Shutdown),
+	// `idmap` (SSH), timeouts and `wait_for_ip` (provider-local) — don't trigger an
+	// empty-body PUT that PVE rejects with HTTP 500 "no options specified" (#2883).
+	bodyDirty := false
+
 	rebootRequired := false
 	container := Container()
 
@@ -3536,11 +3542,13 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 	if d.HasChange(mkDescription) {
 		description := d.Get(mkDescription).(string)
 		updateBody.Description = &description
+		bodyDirty = true
 	}
 
 	if d.HasChange(mkTemplate) {
 		template := types.CustomBool(d.Get(mkTemplate).(bool))
 		updateBody.Template = &template
+		bodyDirty = true
 	}
 
 	// Prepare the new console configuration.
@@ -3567,6 +3575,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		updateBody.TTY = &consoleTTYCount
 
 		rebootRequired = true
+		bodyDirty = true
 	}
 
 	// Prepare the new CPU configuration.
@@ -3599,6 +3608,8 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		if cpuUnits > 0 {
 			updateBody.CPUUnits = &cpuUnits
 		}
+
+		bodyDirty = true
 	}
 
 	if d.HasChange(mkDisk) {
@@ -3678,6 +3689,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		}
 
 		updateBody.RootFS = rootFS
+		bodyDirty = true
 	}
 
 	if d.HasChange(mkEnvironmentVariables) {
@@ -3689,6 +3701,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		}
 
 		rebootRequired = true
+		bodyDirty = true
 	}
 
 	if d.HasChange(mkFeatures) {
@@ -3698,6 +3711,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		}
 
 		updateBody.Features = features
+		bodyDirty = true
 	}
 
 	if d.HasChange(mkHookScriptFileID) {
@@ -3707,6 +3721,8 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		} else {
 			updateBody.Delete = append(updateBody.Delete, "hookscript")
 		}
+
+		bodyDirty = true
 	}
 
 	// Prepare the new initialization configuration.
@@ -3806,11 +3822,13 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		}
 
 		rebootRequired = true
+		bodyDirty = true
 	}
 
 	if d.HasChange(mkInitialization + ".0." + mkInitializationHostname) {
 		updateBody.Hostname = &initializationHostname
 		rebootRequired = true
+		bodyDirty = true
 	}
 
 	if d.HasChange(mkInitialization + ".0." + mkInitializationEntrypoint) {
@@ -3821,6 +3839,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		}
 
 		rebootRequired = true
+		bodyDirty = true
 	}
 
 	// Prepare the new memory configuration.
@@ -3843,6 +3862,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		updateBody.Swap = &memorySwap
 
 		rebootRequired = true
+		bodyDirty = true
 	}
 
 	// Prepare the new device passthrough configuration.
@@ -3877,6 +3897,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		updateBody.PassthroughDevices = passthroughDevices
 
 		rebootRequired = true
+		bodyDirty = true
 	}
 
 	// Prepare the new idmap configuration (applied via SSH after the lock is released).
@@ -3904,6 +3925,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		updateBody.MountPoints = mountPointsMap
 
 		rebootRequired = true
+		bodyDirty = true
 	}
 
 	// Prepare the new network interface configuration.
@@ -4004,6 +4026,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		}
 
 		rebootRequired = true
+		bodyDirty = true
 	}
 
 	if d.HasChange(mkStartup) {
@@ -4011,6 +4034,8 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		if updateBody.StartupBehavior == nil {
 			updateBody.Delete = append(updateBody.Delete, "startup")
 		}
+
+		bodyDirty = true
 	}
 
 	// Prepare the new operating system configuration.
@@ -4031,25 +4056,31 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		updateBody.OSType = &operatingSystemType
 
 		rebootRequired = true
+		bodyDirty = true
 	}
 
 	if d.HasChange(mkProtection) {
 		protection := types.CustomBool(d.Get(mkProtection).(bool))
 		updateBody.Protection = &protection
+		bodyDirty = true
 	}
 
 	if d.HasChange(mkStartOnBoot) {
 		startOnBoot := types.CustomBool(d.Get(mkStartOnBoot).(bool))
 		updateBody.StartOnBoot = &startOnBoot
+		bodyDirty = true
 	}
 
 	if d.HasChange(mkTags) {
 		tagString := containerGetTagsString(d)
 		updateBody.Tags = &tagString
+		bodyDirty = true
 	}
 
-	// Update the configuration via API if there are non-idmap changes.
-	if len(updateBody.Delete) > 0 || d.HasChangesExcept(mkIDMap) {
+	// Only PUT /config when we actually have fields to send. Attributes whose changes
+	// don't populate updateBody (`started`, `idmap`, timeouts, `wait_for_ip`) must not
+	// trigger an empty-body request — PVE rejects those with HTTP 500 (#2883).
+	if bodyDirty || len(updateBody.Delete) > 0 {
 		e = containerAPI.UpdateContainer(ctx, &updateBody)
 		if e != nil {
 			return diag.FromErr(e)


### PR DESCRIPTION
### What does this PR do?

Fixes #2883. When the only attribute changed on a `proxmox_virtual_environment_container`
resource was `started`, the apply failed with `HTTP 500 - no options specified`. The
`containerUpdate` gate at `proxmoxtf/resource/container/container.go` used
`d.HasChangesExcept(mkIDMap)`, but `mkStarted` is structurally a non-`PUT /config` attribute
(it's applied through `StartContainer` / `ShutdownContainer` after the config update). The
gate therefore fired with an empty `updateBody`, and PVE rejected the empty PUT.

The fix replaces the brittle exclusion-list gate with a `bodyDirty bool` set at every branch
that populates a field on `updateBody`. The PUT is now skipped whenever no body field was
populated — automatically covering `started`, the existing `idmap` carve-out, and the
provider-local `timeout_*` / `wait_for_ip` attributes, all of which can change without
producing any wire-level config to send. This also makes the gate immune to future schema
additions of non-`PUT /config` attributes.

Sibling precedent: PR #2857 (issue #2856) fixed the same `HTTP 500 - no options specified`
symptom for a features-only toggle, but with a domain-specific fix (force-emit feature
flags). That fix worked inside body assembly; this one had to live in the gate because
`started` doesn't belong in `updateBody` at all.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits). — n/a, no schema or docs changes.
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [x] For new resources: I followed the [reference examples](docs/adr/reference-examples.md). — n/a, no new resources.
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

**Test coverage: Strong** — the new acceptance test `TestAccResourceContainerStartedToggle`
replicates the exact reporter scenario (apply with `started = true`, then change only
`started = false`). The test was verified to fail without the fix with the exact error the
reporter saw, and pass with the fix. A third step flips back to `started = true` for
bidirectional coverage. Direct PVE status assertions confirm the container actually
transitions, not just that Terraform state was updated.

#### TDD Evidence — RED (without fix)

```
=== RUN   TestAccResourceContainerStartedToggle
=== PAUSE TestAccResourceContainerStartedToggle
=== CONT  TestAccResourceContainerStartedToggle
    resource_container_test.go:2974: Step 2/3 error: Error running apply: exit status 1

        Error: All attempts fail:
        #1: received an HTTP 500 response - Reason: no options specified

          with proxmox_virtual_environment_container.test_container,
          on terraform_plugin_test.tf line 25, in resource "proxmox_virtual_environment_container" "test_container":
          25:             resource "proxmox_virtual_environment_container" "test_container" {

--- FAIL: TestAccResourceContainerStartedToggle (18.72s)
FAIL
FAIL    github.com/bpg/terraform-provider-proxmox/fwprovider/test    19.227s
```

This is the same `HTTP 500 - Reason: no options specified` reported in #2883.

#### TDD Evidence — GREEN (with fix)

```
./testacc TestAccResourceContainerStartedToggle

=== RUN   TestAccResourceContainerStartedToggle
=== PAUSE TestAccResourceContainerStartedToggle
=== CONT  TestAccResourceContainerStartedToggle
--- PASS: TestAccResourceContainerStartedToggle (24.41s)
PASS
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/test    25.004s
```

#### Mitmproxy verification — empty PUT is gone

Captured wire traffic for the full 3-step toggle (create → stop → start → delete teardown):

| Method | Path | Count |
| ------ | ---- | ----- |
| `POST` | `/api2/json/nodes/pve/lxc` | 1 (create) |
| `GET`  | `/api2/json/nodes/pve/lxc/<id>/config` | 8 (read/refresh) |
| `GET`  | `/api2/json/nodes/pve/lxc/<id>/status/current` | 21 (polling) |
| `GET`  | `/api2/json/nodes/pve/lxc/<id>/interfaces` | 9 (refresh) |
| `POST` | `/api2/json/nodes/pve/lxc/<id>/status/start` | 1 (Step 3) |
| `POST` | `/api2/json/nodes/pve/lxc/<id>/status/shutdown` | 2 (Step 2 + delete) |
| `DELETE` | `/api2/json/nodes/pve/lxc/<id>` | 1 (teardown) |
| **`PUT`** | **`/api2/json/nodes/pve/lxc/<id>/config`** | **0** |

Without the fix this run would have produced two `PUT /config` calls — one per started
toggle — both with empty bodies and both rejected with HTTP 500. Lifecycle transitions are
now performed exclusively via the dedicated `status/start` / `status/shutdown` endpoints.

#### Regression — full container acceptance suite

```
./testacc "TestAccResourceContainer.*"
```


### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2883

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.7). All changes have been reviewed and verified by a human.*
