### PR TITLE
Fix: use path-style pool URL for PVE 8.x compatibility

### DIFF
--- a/proxmox/pools/pool.go
+++ b/proxmox/pools/pool.go
@@ -28,7 +28,7 @@ func (c *Client) CreatePool(ctx context.Context, d *PoolCreateRequestBody) error
 
 // DeletePool deletes a pool.
 func (c *Client) DeletePool(ctx context.Context, id string) error {
-	err := c.DoRequest(ctx, http.MethodDelete, fmt.Sprintf("pools?poolid=%s", url.PathEscape(id)), nil, nil)
+	err := c.DoRequest(ctx, http.MethodDelete, fmt.Sprintf("pools/%s", url.PathEscape(id)), nil, nil)
 	if err != nil {
 		return fmt.Errorf("error deleting pool: %w", err)
 	}
@@ -40,7 +40,7 @@ func (c *Client) DeletePool(ctx context.Context, id string) error {
 func (c *Client) GetPool(ctx context.Context, id string) (*PoolGetResponseData, error) {
 	resBody := &PoolGetResponseBody{}
 
-	err := c.DoRequest(ctx, http.MethodGet, fmt.Sprintf("pools?poolid=%s", url.PathEscape(id)), nil, resBody)
+	err := c.DoRequest(ctx, http.MethodGet, fmt.Sprintf("pools/%s", url.PathEscape(id)), nil, resBody)
 	if err != nil {
 		return nil, fmt.Errorf("error getting pool: %w", err)
 	}
@@ -49,20 +49,11 @@ func (c *Client) GetPool(ctx context.Context, id string) (*PoolGetResponseData, 
 		return nil, api.ErrNoDataObjectInResponse
 	}
 
-	// Should always be with one single element
-	if len(resBody.Data) == 0 {
-		return nil, api.ErrResourceDoesNotExist
-	}
-
-	if len(resBody.Data) > 1 {
-		return nil, fmt.Errorf("error getting pool: expected 1 pool, but got %d", len(resBody.Data))
-	}
-
-	sort.Slice(resBody.Data[0].Members, func(i, j int) bool {
-		return resBody.Data[0].Members[i].ID < resBody.Data[0].Members[j].ID
+	sort.Slice(resBody.Data.Members, func(i, j int) bool {
+		return resBody.Data.Members[i].ID < resBody.Data.Members[j].ID
 	})
 
-	return resBody.Data[0], nil
+	return resBody.Data, nil
 }
 
 // ListPools retrieves a list of pools.
@@ -87,7 +78,7 @@ func (c *Client) ListPools(ctx context.Context) ([]*PoolListResponseData, error)
 
 // UpdatePool updates a pool.
 func (c *Client) UpdatePool(ctx context.Context, id string, d *PoolUpdateRequestBody) error {
-	err := c.DoRequest(ctx, http.MethodPut, fmt.Sprintf("pools?poolid=%s", url.PathEscape(id)), d, nil)
+	err := c.DoRequest(ctx, http.MethodPut, fmt.Sprintf("pools/%s", url.PathEscape(id)), d, nil)
 	if err != nil {
 		return fmt.Errorf("error updating pool: %w", err)
 	}

--- a/proxmox/pools/pool_types.go
+++ b/proxmox/pools/pool_types.go
@@ -18,7 +18,7 @@ type PoolCreateRequestBody struct {
 
 // PoolGetResponseBody contains the body from a pool get response.
 type PoolGetResponseBody struct {
-	Data []*PoolGetResponseData `json:"data,omitempty"`
+	Data *PoolGetResponseData `json:"data,omitempty"`
 }
 
 // PoolGetResponseData contains the data from a pool get response.


### PR DESCRIPTION
# Fix: use path-style pool URL for PVE 8.x compatibility

## Summary

On Proxmox VE 8.x, bpg's pool API calls fail with HTTP 400 because they use
the legacy `pools?poolid=<id>` query-string form, which the modern API
rejects. The fix switches `GetPool`, `DeletePool`, and `UpdatePool` to the
path-style `pools/<id>` endpoint and updates the `GetPool` response shape
to match. Diff is ~16 lines net; no public function signatures change.

## Problem

On a fresh PVE 8.0.4 cluster, every VM `Read` against bpg fails with:

```
failed to determine pool for VM <vmid>: failed to get details for pool "<name>":
  error getting pool: received an HTTP 400 response - Reason: Parameter
  verification failed. (poolid: property is not defined in schema and the
  schema does not allow additional properties)
```

Root cause: `proxmox/pools/pool.go` formats pool-by-id URLs as
`pools?poolid=<id>`. PVE 8.x's API schema removed the `poolid` query
parameter; the supported form is the path-style `pools/<id>` endpoint
(visible in the PVE API viewer for 8.x as `GET /pools/{poolid}`).

The failure is not limited to direct pool-resource operations. The VM
resource's `ReadCtx` (`proxmoxtf/resource/vm/vm.go`) calls
`findPoolForVM` whenever a VM's qemu config has no `pool:` attr — true
for VMs whose pool membership is stored on the pool resource rather than
inline. `findPoolForVM` iterates all cluster pools via `poolsAPI.GetPool`,
so it hits the broken URL on the first iteration and fails the entire
VM read. On affected clusters, this means **every VM import fails** with
the HTTP 400 above, even for VMs that are not actually in any pool.

LXC `container.go` ReadCtx does not call findPool, so containers are not
affected.

## Scope

Three functions in `proxmox/pools/pool.go`:

- **`GetPool`** (HTTP GET) — URL change + response-shape change
- **`DeletePool`** (HTTP DELETE) — URL change only (no response body)
- **`UpdatePool`** (HTTP PUT) — URL change only (no response body)

Response-shape change applies only to `GetPool` / `PoolGetResponseBody`:
the path-style endpoint returns `data: {comment, members: [...]}` as a
single object, whereas the legacy query-string endpoint returned a
single-element array. So `PoolGetResponseBody.Data` changes from
`[]*PoolGetResponseData` to `*PoolGetResponseData`, and `GetPool`'s
internal unpacking drops the array-length checks (which are now dead
code under the new shape).

## Impact on callers

`GetPool`'s public signature is unchanged — it still returns
`(*PoolGetResponseData, error)`. All existing call sites use the
dereferenced struct's `.Comment` / `.Members` fields, which are
unaffected:

- `proxmoxtf/resource/vm/vm.go:findPoolForVM` (the VM-import path that
  motivated this fix)
- `proxmoxtf/resource/pool/pool.go` (Read for the pool resource)
- `proxmoxtf/datasource/pool.go` (the pool data source)
- `fwprovider/pools/pool_membership.go` (pool-membership Read)
- `fwprovider/pools/pool_membership_test.go:checkPoolContainsMember`
  (acceptance-test helper)

The 404-not-found path remains correctly mapped to
`api.ErrResourceDoesNotExist` by the central API layer
(`proxmox/api/client.go`), so the existing skip-deleted-pool branch in
`findPoolForVM` continues to work. The previous `len(resBody.Data) == 0`
arm in `GetPool` is removed because under the new shape a missing pool
surfaces as a 404 → `ErrResourceDoesNotExist` rather than a 200 with an
empty array.

## Testing

- `go build ./...` clean.
- `go test ./...` clean (full suite, ~30s).
- Validated against a live PVE 8.0.4 cluster: `tofu import` of a VM
  previously failed with the HTTP 400 above; with this patch the import
  completes cleanly. Tested with a VM that is not a member of any pool
  (the case that triggers the full pool-iteration sweep in
  `findPoolForVM`).

## Discovery context

Found during IaC adoption (Track 2: Proxmox import). bpg
works on most operations against this cluster — the cluster is 3 PVE
8.0.4 nodes with 46 VMs across LVM-thin / NFS / Ceph storages — but
VM imports were blocked entirely by this single bug. Happy to provide
additional reproduction details or PVE API-viewer screenshots if useful.

## Notes

- This is the first of a small queue of upstream PRs from our
  cluster-diagnostic work. The next one (LXC `template_file_id`
  recoverability after import) is independent and will come in a
  separate PR.
- I've kept this PR strictly to the URL + response-shape change.
  Backward compatibility with PVE 7.x can be added separately (dispatch
  on `Version()` if needed); none of our clusters run 7.x so I have no
  way to validate that path here.
