### PR TITLE
fix(lxc): avoid nil-bool panic when disk block is omitted

### DIFF
--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -3005,16 +3005,7 @@ func TestAccResourceContainerStartedToggle(t *testing.T) {
 	})
 }
 
-// TestAccResourceContainerNoDiskBlock verifies that omitting the `disk { ... }` block from
-// the HCL config does not crash the provider. PR #2824 added unguarded `.(bool)` reads on
-// `acl`, `quota`, `replicate` from the disk block, but the `mkDisk` DefaultFunc returns a
-// partial map missing those keys, so create panicked with
-// `interface conversion: interface {} is nil, not bool`. Regression test for issue #2893.
-//
-// `ExpectNonEmptyPlan: true` covers a pre-existing latent UX issue with the `mkDisk` schema
-// (Optional list + non-empty DefaultFunc): after apply, state holds the synthesized default
-// block, but Terraform's diff against a still-empty user config wants to remove it. That's
-// a separate UX issue, out of scope for this narrow panic fix.
+// Regression test for #2893: omitting the `disk { ... }` block must not panic create.
 //
 //nolint:paralleltest
 func TestAccResourceContainerNoDiskBlock(t *testing.T) {
@@ -3064,6 +3055,88 @@ func TestAccResourceContainerNoDiskBlock(t *testing.T) {
 						"disk.0.replicate": "false",
 					}),
 				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// Regression test for #2893: removing an explicit `disk { ... }` block must not panic
+// containerUpdate. Step 1's `datastore_id = "local"` matches the DefaultFunc so removal
+// does not trigger ForceNew and takes the update path.
+//
+//nolint:paralleltest
+func TestAccResourceContainerRemoveDiskBlock(t *testing.T) {
+	te := InitEnvironment(t)
+	imageFileName := fmt.Sprintf("%d-alpine-3.22-default_20250617_amd64.tar.xz", time.Now().UnixMicro())
+	testAccDownloadContainerTemplate(t, te, imageFileName)
+
+	accTestContainerID := 100000 + rand.Intn(99999)
+
+	te.AddTemplateVars(map[string]interface{}{
+		"ImageFileName":   imageFileName,
+		"TestContainerID": accTestContainerID,
+	})
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_container" "test_container" {
+					node_name    = "{{.NodeName}}"
+					vm_id        = {{.TestContainerID}}
+					started      = false
+					unprivileged = true
+					disk {
+						datastore_id  = "local"
+						size          = 4
+						mount_options = ["discard"]
+					}
+					initialization {
+						hostname = "test-remove-disk"
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_interface {
+						name = "vmbr0"
+					}
+					operating_system {
+						template_file_id = "local:vztmpl/{{.ImageFileName}}"
+						type             = "alpine"
+					}
+				}`, WithRootUser()),
+				Check: ResourceAttributes(accTestContainerName, map[string]string{
+					"disk.0.mount_options.#": "1",
+					"disk.0.mount_options.0": "discard",
+				}),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_container" "test_container" {
+					node_name    = "{{.NodeName}}"
+					vm_id        = {{.TestContainerID}}
+					started      = false
+					unprivileged = true
+					initialization {
+						hostname = "test-remove-disk"
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_interface {
+						name = "vmbr0"
+					}
+					operating_system {
+						template_file_id = "local:vztmpl/{{.ImageFileName}}"
+						type             = "alpine"
+					}
+				}`, WithRootUser()),
 				ExpectNonEmptyPlan: true,
 			},
 		},

--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -3005,6 +3005,71 @@ func TestAccResourceContainerStartedToggle(t *testing.T) {
 	})
 }
 
+// TestAccResourceContainerNoDiskBlock verifies that omitting the `disk { ... }` block from
+// the HCL config does not crash the provider. PR #2824 added unguarded `.(bool)` reads on
+// `acl`, `quota`, `replicate` from the disk block, but the `mkDisk` DefaultFunc returns a
+// partial map missing those keys, so create panicked with
+// `interface conversion: interface {} is nil, not bool`. Regression test for issue #2893.
+//
+// `ExpectNonEmptyPlan: true` covers a pre-existing latent UX issue with the `mkDisk` schema
+// (Optional list + non-empty DefaultFunc): after apply, state holds the synthesized default
+// block, but Terraform's diff against a still-empty user config wants to remove it. That's
+// a separate UX issue, out of scope for this narrow panic fix.
+//
+//nolint:paralleltest
+func TestAccResourceContainerNoDiskBlock(t *testing.T) {
+	te := InitEnvironment(t)
+	imageFileName := fmt.Sprintf("%d-alpine-3.22-default_20250617_amd64.tar.xz", time.Now().UnixMicro())
+	testAccDownloadContainerTemplate(t, te, imageFileName)
+
+	accTestContainerID := 100000 + rand.Intn(99999)
+
+	te.AddTemplateVars(map[string]interface{}{
+		"ImageFileName":   imageFileName,
+		"TestContainerID": accTestContainerID,
+	})
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_container" "test_container" {
+					node_name    = "{{.NodeName}}"
+					vm_id        = {{.TestContainerID}}
+					started      = false
+					unprivileged = true
+					initialization {
+						hostname = "test-no-disk-block"
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_interface {
+						name = "vmbr0"
+					}
+					operating_system {
+						template_file_id = "local:vztmpl/{{.ImageFileName}}"
+						type             = "alpine"
+					}
+				}`, WithRootUser()),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"disk.#":           "1",
+						"disk.0.size":      "4",
+						"disk.0.acl":       "false",
+						"disk.0.quota":     "false",
+						"disk.0.replicate": "false",
+					}),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccDownloadContainerTemplate(t *testing.T, te *Environment, imageFileName string) {
 	t.Helper()
 	err := te.NodeStorageClient().DownloadFileByURL(context.Background(), &storage.DownloadURLPostRequestBody{

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -390,7 +390,7 @@ func Container() *schema.Resource {
 						map[string]any{
 							mkDiskACL:          dvDiskACL,
 							mkDiskDatastoreID:  dvDiskDatastoreID,
-							mkDiskMountOptions: nil,
+							mkDiskMountOptions: []any{},
 							mkDiskQuota:        dvDiskQuota,
 							mkDiskReplicate:    dvDiskReplicate,
 							mkDiskSize:         dvDiskSize,

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -388,9 +388,12 @@ func Container() *schema.Resource {
 				DefaultFunc: func() (any, error) {
 					return []any{
 						map[string]any{
+							mkDiskACL:          dvDiskACL,
 							mkDiskDatastoreID:  dvDiskDatastoreID,
-							mkDiskSize:         dvDiskSize,
 							mkDiskMountOptions: nil,
+							mkDiskQuota:        dvDiskQuota,
+							mkDiskReplicate:    dvDiskReplicate,
+							mkDiskSize:         dvDiskSize,
 						},
 					}, nil
 				},


### PR DESCRIPTION
### What does this PR do?

Fixes a provider panic when creating a `proxmox_virtual_environment_container` without an
explicit `disk { ... }` block in the HCL config:

```text
panic: interface conversion: interface {} is nil, not bool
  at proxmoxtf/resource/container/container.go:2031 in containerCreateCustom
```

[PR #2824](https://github.com/bpg/terraform-provider-proxmox/pull/2824) added unguarded
`.(bool)` reads on `acl`, `quota`, `replicate` from the disk block, but the `mkDisk`
`DefaultFunc` returned a partial map containing only `datastore_id`, `size`, and
`mount_options`. When the user omits the block, `structure.GetSchemaBlock` returns the
DefaultFunc map verbatim (the SDK does not merge inner-attribute Defaults into a
DefaultFunc result), so the three keys were `nil` and the assertion panicked.

The fix adds `acl`, `quota`, and `replicate` to the `mkDisk` DefaultFunc with their
schema defaults (all `false`), bringing the block in line with the working sibling
`mkFeatures` DefaultFunc which already lists every inner key. The same change also
closes a latent same-shape panic in `containerUpdate` (`container.go:3636-3639`) that
would trigger if a user removed a previously-explicit `disk` block from config.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

New acceptance test `TestAccResourceContainerNoDiskBlock` reproduces the issue config
(no `disk` block) and verifies the synthesized default values are present in state:

```text
$ ./testacc --no-proxy TestAccResourceContainerNoDiskBlock -- -v

=== RUN   TestAccResourceContainerNoDiskBlock
=== PAUSE TestAccResourceContainerNoDiskBlock
=== CONT  TestAccResourceContainerNoDiskBlock
--- PASS: TestAccResourceContainerNoDiskBlock (4.68s)
PASS
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/test       5.314s
```

Pre-fix, the same test crashed the provider with the exact issue stack:

```text
panic: interface conversion: interface {} is nil, not bool

goroutine 451 [running]:
github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/container.containerCreateCustom(...)
        /Users/pasha/code/terraform-provider-proxmox/proxmoxtf/resource/container/container.go:2031 +0x355c
github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/container.containerCreate(...)
        /Users/pasha/code/terraform-provider-proxmox/proxmoxtf/resource/container/container.go:1254 +0x94
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(...)
...
FAIL    github.com/bpg/terraform-provider-proxmox/fwprovider/test       3.021s
```

Same line, same message, same call chain as the issue body — faithful reproduction.

Regression check on the two closest neighbour tests (both touch the same `disk` block
write path on create):

| Test | Result | Time |
| --- | --- | --- |
| `TestAccResourceContainerDiskOptionsAtCreate` (#2824 sibling — full disk opts on create) | PASS | 16.28s |
| `TestAccResourceContainerDiskACLOnlyAtCreate` (sibling — single disk opt on create)      | PASS | 17.58s |

The test sets `ExpectNonEmptyPlan: true` (with a documenting comment) to accommodate a
pre-existing latent UX issue with the `mkDisk` schema (`Optional` list + non-empty
`DefaultFunc`): after apply, state holds the synthesized default block, but Terraform's
diff against a still-empty user config wants to remove it. The plan-loop was masked
before because the panic blocked any container from being created. That's a separate UX
issue, out of scope for this narrow panic fix; it can be addressed in a follow-up by
making `mkDisk` `Optional+Computed` or by moving default synthesis into
`containerCreateCustom`.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2893

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.7). All changes have been reviewed and verified by a human.*
