### PR TITLE
fix(vm): prevent VM restart on import from keyboard/agent defaults

### DIFF
--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 	"github.com/bpg/terraform-provider-proxmox/utils"
 )
 
@@ -785,6 +787,68 @@ func TestAccResourceVMImport(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestAccResourceVMImportEffectiveDefaults verifies that importing an externally-created VM
+// reads back the provider's effective defaults for fields whose schema default is non-empty
+// (keyboard_layout, agent.type), instead of "". A "" read-back diffs against the defaulted
+// config and, on apply, reboots / stop-starts the VM (issue #2902, continuation of #932).
+func TestAccResourceVMImportEffectiveDefaults(t *testing.T) {
+	te := InitEnvironment(t)
+
+	vmID := 100000 + rand.Intn(99999)
+
+	// Create a bare VM directly via the API (not via the provider) so PVE has agent enabled
+	// without an explicit type and no keyboard set — the state an externally-created VM has.
+	ctx := context.Background()
+	createResult := te.NodeClient().VM(0).CreateVM(ctx, &vms.CreateRequestBody{
+		VMID:  vmID,
+		Agent: &vms.CustomAgent{Enabled: types.CustomBool(true).Pointer()},
+	})
+	require.NoError(t, createResult.Err(), "failed to create bare VM %d", vmID)
+
+	t.Cleanup(func() {
+		_ = te.NodeClient().VM(vmID).DeleteVM(context.Background(), true, true).Err()
+	})
+
+	te.AddTemplateVars(map[string]any{"TestVMID": vmID})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_vm" "vm_defaults" {
+						node_name = "{{.NodeName}}"
+						vm_id     = {{.TestVMID}}
+
+						agent {
+							enabled = true
+						}
+					}`),
+				ResourceName:  "proxmox_virtual_environment_vm.vm_defaults",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s/%d", te.NodeName, vmID),
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 imported state, got %d", len(states))
+					}
+
+					attrs := states[0].Attributes
+
+					if got := attrs["keyboard_layout"]; got != "en-us" {
+						return fmt.Errorf("keyboard_layout = %q, want %q (effective default)", got, "en-us")
+					}
+
+					if got := attrs["agent.0.type"]; got != "virtio" {
+						return fmt.Errorf("agent.0.type = %q, want %q (effective default)", got, "virtio")
+					}
+
+					return nil
+				},
+			},
+		},
+	})
 }
 
 func TestAccResourceVMInitialization(t *testing.T) {

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -4417,7 +4417,8 @@ func vmReadCustom(
 			if vmConfig.Agent.Type != nil {
 				agent[mkAgentType] = *vmConfig.Agent.Type
 			} else {
-				agent[mkAgentType] = ""
+				// PVE omits an unset agent type; report the schema default so imported VMs don't diff and stop-start.
+				agent[mkAgentType] = dvAgentType
 			}
 
 			// preserve wait_for_ip from current state if present
@@ -5736,8 +5737,8 @@ func vmReadPrimitiveValues(
 		if vmConfig.KeyboardLayout != nil {
 			err = d.Set(mkKeyboardLayout, *vmConfig.KeyboardLayout)
 		} else {
-			// Default value of "keyboard" is "" according to the API documentation.
-			err = d.Set(mkKeyboardLayout, "")
+			// PVE omits an unset keyboard; report the schema default so imported VMs don't diff and reboot.
+			err = d.Set(mkKeyboardLayout, dvKeyboardLayout)
 		}
 
 		diags = append(diags, diag.FromErr(err)...)


### PR DESCRIPTION
### What does this PR do?

After importing an externally-created VM, `terraform plan` showed a perpetual `update in-place`
diff for two provider defaults — `keyboard_layout = "en-us"` and `agent { type = "virtio" }` —
and applying it silently rebooted (keyboard) or stop/started (agent) the VM with no warning in
the plan (issue #2902, continuation of #932).

Root cause: the SDK VM resource declares non-empty schema defaults for these fields, but the
Read/import path stored `""` when PVE reported the field unset, so the empty state perpetually
diffed against the defaulted config. This only affected imported VMs — provider-created VMs send
both fields on create, so Read gets them back. The fix makes Read report the effective schema
default (`en-us` / `virtio`) instead of `""` when PVE returns nil, so imported state matches the
config and no spurious diff/restart occurs. The sibling `machine` attribute uses the same code
shape but is unaffected because its default is empty.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!-- No docs change: the `en-us` / `virtio` defaults are already documented; this fix only makes
import honor them. No schema change, so backward compatibility holds (state for already-imported
VMs converges to the documented default and the spurious diff disappears). -->

### Proof of Work

Added `TestAccResourceVMImportEffectiveDefaults`, which creates a bare VM directly via the API
(agent enabled, no `type`; no `keyboard`) — i.e. an externally-created VM — imports it, and
asserts the imported state reads the effective defaults. This is a strong-coverage test: it
fails without the fix and passes with it.

**Before the fix (RED):**

```text
=== RUN   TestAccResourceVMImportEffectiveDefaults
    testing_new_import_state.go:295: keyboard_layout = "", want "en-us" (effective default)
--- FAIL: TestAccResourceVMImportEffectiveDefaults (2.04s)
FAIL
```

**After the fix (GREEN) + regression of the existing import / agent tests:**

```text
=== RUN   TestAccResourceVMImport
--- PASS: TestAccResourceVMImport (4.25s)
=== RUN   TestAccResourceVMImportEffectiveDefaults
--- PASS: TestAccResourceVMImportEffectiveDefaults (1.74s)
=== RUN   TestAccResourceVMVirtioSCSISingleWithAgent
--- PASS: TestAccResourceVMVirtioSCSISingleWithAgent (49.16s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	55.669s
```

Behavioral summary — import an externally-created VM, then `terraform plan`:

- **Before:** `+ keyboard_layout = "en-us"` and `~ agent { + type = "virtio" }`; `apply`
  reboots / stop-starts the VM.
- **After:** imported state already holds `en-us` / `virtio`; no diff, no restart.

`make build`, `make lint` (0 issues), and `make test` all pass. No new or changed outbound API
calls — the change is Read-side only and removes the spurious `UpdateVM`, so mitmproxy
verification is not applicable.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2902

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.7). All changes have been reviewed and verified by a human.*
