### PR TITLE
fix(access): only warn on inline acl when set in config

### DIFF
--- a/proxmoxtf/resource/group.go
+++ b/proxmoxtf/resource/group.go
@@ -43,9 +43,6 @@ func Group() *schema.Resource {
 					"The inline `acl` block is no longer auto-populated from the cluster on refresh " +
 					"or import; existing groups with `acl` blocks continue to work, but new code " +
 					"should use `proxmox_acl`.",
-				DefaultFunc: func() (interface{}, error) {
-					return []interface{}{}, nil
-				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						mkResourceVirtualEnvironmentGroupACLPath: {

--- a/proxmoxtf/resource/group_test.go
+++ b/proxmoxtf/resource/group_test.go
@@ -67,3 +67,29 @@ func TestGroupSchema(t *testing.T) {
 		mkResourceVirtualEnvironmentGroupACLRoleID:    schema.TypeString,
 	})
 }
+
+// TestGroupACLDeprecationWarning verifies the deprecated `acl` block warns only when it is
+// actually set in config, not on every group that omits it.
+func TestGroupACLDeprecationWarning(t *testing.T) {
+	t.Parallel()
+
+	s := Group().Schema
+
+	if hasACLDeprecationWarning(s, map[string]any{
+		mkResourceVirtualEnvironmentGroupID: "test-group",
+	}) {
+		t.Error("unexpected acl deprecation warning when no acl block is configured")
+	}
+
+	if !hasACLDeprecationWarning(s, map[string]any{
+		mkResourceVirtualEnvironmentGroupID: "test-group",
+		mkResourceVirtualEnvironmentGroupACL: []any{
+			map[string]any{
+				mkResourceVirtualEnvironmentGroupACLPath:   "/",
+				mkResourceVirtualEnvironmentGroupACLRoleID: "Administrator",
+			},
+		},
+	}) {
+		t.Error("expected acl deprecation warning when an acl block is configured")
+	}
+}

--- a/proxmoxtf/resource/user.go
+++ b/proxmoxtf/resource/user.go
@@ -58,9 +58,6 @@ func User() *schema.Resource {
 					"The inline `acl` block is no longer auto-populated from the cluster on refresh " +
 					"or import; existing users with `acl` blocks continue to work, but new code " +
 					"should use `proxmox_acl`.",
-				DefaultFunc: func() (interface{}, error) {
-					return []interface{}{}, nil
-				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						mkResourceVirtualEnvironmentUserACLPath: {

--- a/proxmoxtf/resource/user_test.go
+++ b/proxmoxtf/resource/user_test.go
@@ -9,10 +9,26 @@ package resource
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/test"
 )
+
+// hasACLDeprecationWarning reports whether validating the given config against the
+// resource schema produces an "Argument is deprecated" warning for the `acl` attribute.
+func hasACLDeprecationWarning(s map[string]*schema.Schema, config map[string]any) bool {
+	diags := schema.InternalMap(s).Validate(terraform.NewResourceConfigRaw(config))
+
+	for _, d := range diags {
+		if d.Severity == diag.Warning && d.Summary == "Argument is deprecated" {
+			return true
+		}
+	}
+
+	return false
+}
 
 // TestUserInstantiation tests whether the User instance can be instantiated.
 func TestUserInstantiation(t *testing.T) {
@@ -77,4 +93,30 @@ func TestUserSchema(t *testing.T) {
 		mkResourceVirtualEnvironmentUserACLPropagate: schema.TypeBool,
 		mkResourceVirtualEnvironmentUserACLRoleID:    schema.TypeString,
 	})
+}
+
+// TestUserACLDeprecationWarning verifies the deprecated `acl` block warns only when it is
+// actually set in config, not on every user that omits it.
+func TestUserACLDeprecationWarning(t *testing.T) {
+	t.Parallel()
+
+	s := User().Schema
+
+	if hasACLDeprecationWarning(s, map[string]any{
+		mkResourceVirtualEnvironmentUserUserID: "test@pve",
+	}) {
+		t.Error("unexpected acl deprecation warning when no acl block is configured")
+	}
+
+	if !hasACLDeprecationWarning(s, map[string]any{
+		mkResourceVirtualEnvironmentUserUserID: "test@pve",
+		mkResourceVirtualEnvironmentUserACL: []any{
+			map[string]any{
+				mkResourceVirtualEnvironmentUserACLPath:   "/",
+				mkResourceVirtualEnvironmentUserACLRoleID: "Administrator",
+			},
+		},
+	}) {
+		t.Error("expected acl deprecation warning when an acl block is configured")
+	}
 }


### PR DESCRIPTION
### What does this PR do?

After deprecating the inline `acl` block on `proxmox_virtual_environment_user` and
`proxmox_virtual_environment_group` (in favor of the dedicated `proxmox_acl` resource), the
"Argument is deprecated" warning fired on **every** user and group instance — even those with
no `acl` block in config or state. The cause: the deprecated `acl` `TypeSet` declared a
`DefaultFunc` returning a non-nil empty slice. In terraform-plugin-sdk's `schemaMap.validate`,
a non-nil `DefaultFunc` result flips the internal "is set" flag to `true` for an absent
attribute, so validation reaches `validateType`, which emits the deprecation warning
unconditionally. This PR removes the `DefaultFunc` from both `acl` blocks; the `TypeSet` zero
value is already an empty set, so reads stay safe and no plan diff is introduced, while the
deprecation warning now fires only when an `acl` block is actually present in config.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

This is a config-validation behavior, which the acceptance-test framework (`helper/resource`)
cannot assert — it has no API to check warning diagnostics. The fix is therefore proven with
config-validation tests that exercise the exact SDK path that produced the bug
(`schema.InternalMap(...).Validate(...)`). Each test asserts no deprecation warning when `acl`
is omitted, and that the warning **does** still fire when an `acl` block is present.

**Before the fix (`DefaultFunc` still present) — tests fail, reproducing the bug:**

```text
=== RUN   TestGroupACLDeprecationWarning
=== RUN   TestUserACLDeprecationWarning
    user_test.go:108: unexpected acl deprecation warning when no acl block is configured
    group_test.go:81: unexpected acl deprecation warning when no acl block is configured
--- FAIL: TestUserACLDeprecationWarning (0.00s)
--- FAIL: TestGroupACLDeprecationWarning (0.00s)
FAIL
```

**After the fix (`DefaultFunc` removed) — tests pass:**

```text
$ go test ./proxmoxtf/resource/ -run 'TestUserACLDeprecationWarning|TestGroupACLDeprecationWarning' -v
=== RUN   TestGroupACLDeprecationWarning
=== RUN   TestUserACLDeprecationWarning
--- PASS: TestGroupACLDeprecationWarning (0.00s)
--- PASS: TestUserACLDeprecationWarning (0.00s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource
```

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2913

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.8). All changes have been reviewed and verified by a human.*
