### PR TITLE
fix(vm): refresh hook_script_file_id in read

### DIFF
--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -5688,6 +5688,18 @@ func vmReadPrimitiveValues(
 		diags = append(diags, diag.FromErr(err)...)
 	}
 
+	currentHookScript := d.Get(mkHookScriptFileID).(string)
+
+	if len(clone) == 0 || currentHookScript != dvHookScript {
+		if vmConfig.HookScript != nil {
+			err = d.Set(mkHookScriptFileID, *vmConfig.HookScript)
+		} else {
+			err = d.Set(mkHookScriptFileID, "")
+		}
+
+		diags = append(diags, diag.FromErr(err)...)
+	}
+
 	currentTags := d.Get(mkTags).([]any)
 
 	err = d.Set(mkOnBoot, vmConfig.StartOnBoot)


### PR DESCRIPTION
### What does this PR do?

The `hook_script_file_id` attribute on `proxmox_virtual_environment_vm` was never refreshed in
state: `vmReadPrimitiveValues` sets ~30 primitives via `d.Set` but never `hook_script_file_id`,
so an out-of-band change (e.g. `qm set <vmid> -hookscript local:snippets/new.pl`) stayed
invisible to `terraform refresh`/`plan` forever, and `vmUpdate`'s `d.HasChanges` check compared
against stale state. This adds the missing clone-guarded `d.Set` block, mirroring the existing
`description` read in the same function and the identical fix applied to the LXC container
resource in #2852. Closes the VM half of the refresh gap fixed for containers in #2850/#2852.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits). — N/A: read-logic only, schema and docs unchanged.
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)). — See Proof of Work: a hookscript acceptance test is infeasible in the current test infra; #2852 shipped the identical LXC fix with none.
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md). — N/A: not a new resource.
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes). — N/A: resource read-path fix.

### Proof of Work

This is a byte-for-byte port of the merged LXC fix at
`proxmoxtf/resource/container/container.go:3391-3398` (#2852, `e316aba0`), and mirrors the
existing `description` read in the same `vmReadPrimitiveValues` function. The clone-skip guard
prevents a cloned VM that inherited the parent template's hookscript (but whose user did not set
`hook_script_file_id`) from showing spurious drift. `git log -S "d.Set(mkHookScriptFileID"`
returns nothing — the read was never present, so this is a long-standing gap, not a regression.

**Before / after** (reproduction from the issue):

```hcl
resource "proxmox_virtual_environment_vm" "example" {
  vm_id               = 999
  node_name           = "pve"
  hook_script_file_id = "local:snippets/old.pl"
}
```

1. Apply, then on the host: `qm set 999 -hookscript local:snippets/new.pl`
2. `terraform refresh` && `terraform plan`

- **Before:** plan still shows `hook_script_file_id = "local:snippets/old.pl"` — no drift detected.
- **After:** refresh pulls `local:snippets/new.pl` from the config GET, and plan reports the diff.

**Why no acceptance test:** an out-of-band drift test for `hookscript` (the pattern #2852 used
for `features`/`start_on_boot`) is infeasible in the current test infrastructure. PVE requires
the snippet file to be **executable**, and the test SSH user cannot `chmod +x` a root-owned
snippet (NOPASSWD sudo allowlist is `tee`/`qm`/`pvesm`/`pct` only). PVE also gates hookscript
writes to `root@pam` basic auth (API tokens are rejected). For these reasons #2852 itself shipped
the identical LXC hookscript fix with no hookscript test, and no hookscript test exists anywhere
in the repository. The change is a faithful, line-for-line copy of that merged, reviewed fix.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2853

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.8). All changes have been reviewed and verified by a human.*
