### PR TITLE
fix(lxc): apply idmap on first boot after container create

### DIFF
--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -2159,6 +2159,108 @@ func TestAccResourceContainerIDMap(t *testing.T) {
 	})
 }
 
+// TestAccResourceContainerIDMapFirstBoot verifies that a configured idmap is active on the
+// container's first boot after create, not only after an out-of-band reboot (issue #2895).
+// It inspects the running container's /proc/self/uid_map and /proc/self/gid_map via the node,
+// since the API config read-back passes regardless of whether the map is actually applied.
+func TestAccResourceContainerIDMapFirstBoot(t *testing.T) {
+	te := InitEnvironment(t)
+	imageFileName := fmt.Sprintf("%d-alpine-3.22-default_20250617_amd64.tar.xz", time.Now().UnixMicro())
+	testAccDownloadContainerTemplate(t, te, imageFileName)
+
+	accTestContainerID := 100000 + rand.Intn(99999)
+
+	te.AddTemplateVars(map[string]interface{}{
+		"ImageFileName":   imageFileName,
+		"TestContainerID": accTestContainerID,
+		"TimeoutDelete":   300,
+	})
+
+	// assertConfiguredMapActive reads the given map file inside the running container and requires
+	// the configured second range "1000 101000 64536" to be present. Under the default unprivileged
+	// mapping (a single "0 100000 65536" line) that row cannot appear, so this fails when the idmap
+	// is not active on first boot. The map stays within root's default subuid/subgid range
+	// (100000+65536) so the container can actually start on a stock host.
+	assertConfiguredMapActive := func(mapFile string) func(*terraform.State) error {
+		return func(*terraform.State) error {
+			out := te.ExecuteNodeCommands([]string{
+				fmt.Sprintf("/usr/sbin/pct exec %d -- cat %s", accTestContainerID, mapFile),
+			})
+
+			for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+				if f := strings.Fields(line); len(f) == 3 && f[0] == "1000" && f[1] == "101000" && f[2] == "64536" {
+					return nil
+				}
+			}
+
+			return fmt.Errorf("%s inside running container should contain the configured mapping (1000 101000 64536), got:\n%s", mapFile, out)
+		}
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_container" "test_container" {
+					node_name      = "{{.NodeName}}"
+					vm_id          = {{.TestContainerID}}
+					timeout_delete = {{ .TimeoutDelete }}
+					unprivileged   = true
+					started        = true
+					disk {
+						datastore_id = "local-lvm"
+						size         = 4
+					}
+					idmap {
+						type         = "uid"
+						container_id = 0
+						host_id      = 100000
+						size         = 1000
+					}
+					idmap {
+						type         = "uid"
+						container_id = 1000
+						host_id      = 101000
+						size         = 64536
+					}
+					idmap {
+						type         = "gid"
+						container_id = 0
+						host_id      = 100000
+						size         = 1000
+					}
+					idmap {
+						type         = "gid"
+						container_id = 1000
+						host_id      = 101000
+						size         = 64536
+					}
+					initialization {
+						hostname = "test-idmap-boot"
+						ip_config {
+							ipv4 {
+								address = "dhcp"
+							}
+						}
+					}
+					network_interface {
+						name = "vmbr0"
+					}
+					operating_system {
+						template_file_id = "local:vztmpl/{{.ImageFileName}}"
+						type             = "alpine"
+					}
+				}`, WithRootUser()),
+				Check: resource.ComposeTestCheckFunc(
+					assertConfiguredMapActive("/proc/self/uid_map"),
+					assertConfiguredMapActive("/proc/self/gid_map"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceContainerEntrypoint(t *testing.T) {
 	te := InitEnvironment(t)
 	accTestContainerID := 100000 + rand.Intn(99999)

--- a/fwprovider/test/test_environment.go
+++ b/fwprovider/test/test_environment.go
@@ -13,6 +13,7 @@ import (
 	"maps"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -34,6 +35,7 @@ import (
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/storage"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/pools"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/ssh"
 	sdkV2provider "github.com/bpg/terraform-provider-proxmox/proxmoxtf/provider"
 	"github.com/bpg/terraform-provider-proxmox/utils"
 )
@@ -281,6 +283,58 @@ func (e *Environment) NodeClient() *nodes.Client {
 // NodeStorageClient returns a new storage client for the test environment.
 func (e *Environment) NodeStorageClient() *storage.Client {
 	return &storage.Client{Client: e.NodeClient(), StorageName: e.DatastoreID}
+}
+
+// staticNodeResolver resolves any node name to a fixed SSH address/port.
+type staticNodeResolver struct {
+	node ssh.ProxmoxNode
+}
+
+func (r staticNodeResolver) Resolve(context.Context, string) (ssh.ProxmoxNode, error) {
+	return r.node, nil
+}
+
+// ExecuteNodeCommands runs shell commands on the test node over SSH as the root API user
+// (PROXMOX_VE_USERNAME / PROXMOX_VE_PASSWORD) and returns the combined output. Connecting as
+// root avoids the restricted sudoers allowlist of the provider's SSH user, so privileged
+// commands such as `pct exec` work without sudo.
+func (e *Environment) ExecuteNodeCommands(commands []string) string {
+	e.t.Helper()
+
+	address := utils.GetAnyStringEnv("PROXMOX_VE_ACC_NODE_SSH_ADDRESS")
+	if address == "" {
+		u, err := url.Parse(utils.GetAnyStringEnv("PROXMOX_VE_ENDPOINT"))
+		require.NoError(e.t, err)
+
+		address = u.Hostname()
+	}
+
+	port := int32(22)
+
+	if p := utils.GetAnyStringEnv("PROXMOX_VE_ACC_NODE_SSH_PORT"); p != "" {
+		v, err := strconv.ParseInt(p, 10, 32)
+		require.NoError(e.t, err)
+
+		port = int32(v)
+	}
+
+	// Strip the realm from "root@pam" to get the SSH login name.
+	username := strings.Split(utils.GetAnyStringEnv("PROXMOX_VE_USERNAME"), "@")[0]
+
+	client, err := ssh.NewClient(
+		username,
+		utils.GetAnyStringEnv("PROXMOX_VE_PASSWORD"),
+		false, "", false,
+		"",
+		"", "", "",
+		staticNodeResolver{node: ssh.ProxmoxNode{Address: address, Port: port}},
+	)
+	require.NoError(e.t, err)
+
+	out, err := client.ExecuteNodeCommands(context.Background(), e.NodeName, commands)
+	require.NoError(e.t, err)
+
+	return string(out)
 }
 
 // DownloadCloudImage downloads a cloud image with a unique filename for use in VM tests.

--- a/fwprovider/test/test_environment.go
+++ b/fwprovider/test/test_environment.go
@@ -331,7 +331,7 @@ func (e *Environment) ExecuteNodeCommands(commands []string) string {
 	)
 	require.NoError(e.t, err)
 
-	out, err := client.ExecuteNodeCommands(context.Background(), e.NodeName, commands)
+out, err := client.ExecuteNodeCommands(e.t.Context(), e.NodeName, commands)
 	require.NoError(e.t, err)
 
 	return string(out)

--- a/fwprovider/test/test_environment.go
+++ b/fwprovider/test/test_environment.go
@@ -331,7 +331,7 @@ func (e *Environment) ExecuteNodeCommands(commands []string) string {
 	)
 	require.NoError(e.t, err)
 
-out, err := client.ExecuteNodeCommands(e.t.Context(), e.NodeName, commands)
+	out, err := client.ExecuteNodeCommands(e.t.Context(), e.NodeName, commands)
 	require.NoError(e.t, err)
 
 	return string(out)

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -2320,6 +2320,24 @@ func containerCreateStart(ctx context.Context, d *schema.ResourceData, m any) di
 		return diags
 	}
 
+	// idmap is written to the config via SSH after create, but PVE's first start does not apply
+	// it; a reboot regenerates the runtime mapping. Mirrors the rebootRequired path in update.
+	if len(containerGetIDMaps(d.Get(mkIDMap).([]any))) > 0 {
+		rebootTimeoutSec := d.Get(mkTimeoutCreate).(int)
+
+		rebootDiags := sdkresource.TaskResultDiags(containerAPI.RebootContainer(
+			ctx,
+			&containers.RebootRequestBody{
+				Timeout: &rebootTimeoutSec,
+			},
+		), "Container reboot")
+		if rebootDiags.HasError() {
+			return append(diags, rebootDiags...)
+		}
+
+		diags = append(diags, rebootDiags...)
+	}
+
 	return append(diags, containerRead(ctx, d, m)...)
 }
 


### PR DESCRIPTION
### What does this PR do?

For unprivileged containers, a configured `idmap` was written to the container config (via SSH) on create but was not active on the container's first boot — the container started with the default unprivileged mapping (`0 100000 65536`), so bind-mounted host directories appeared as `nobody:nogroup`. `terraform apply` reported success, making the misconfiguration silent; only an out-of-band reboot (`pct reboot`) activated the configured map. The create path (shared `containerCreateStart`, used by both the create and clone flows) wrote the idmap then started the container but never rebooted, unlike the update path which already reboots a running container when the idmap changes (`rebootRequired`). This PR makes the create path issue one reboot after start when an idmap is configured, so the mapping is active on first boot.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

Root cause: since idmap support was added, both create paths (`containerCreateCustom`, `containerCreateClone`) write `lxc.idmap` to `/etc/pve/lxc/<vmid>.conf` via SSH, then call the shared `containerCreateStart`, which only starts the container and never reboots. PVE's first `pct start` does not apply the freshly-written `lxc.idmap`; only a reboot regenerates the runtime mapping. The update path already handled this; the create path did not (a gap since inception, not a regression).

Fix: in `containerCreateStart`, after a successful start, if an idmap is configured, issue one `RebootContainer`, mirroring the update path. The PVE-side reboot timeout uses the configurable `timeout_create` attribute (default 1800s). The shared helper covers both the custom and clone create paths.

The new acceptance test asserts the **running** container's effective mapping (not just the API config read-back, which passes regardless). It creates a started, unprivileged container with a 2-line idmap (within root's default subuid/subgid range `100000+65536`) and checks that `/proc/self/uid_map` and `/proc/self/gid_map` inside the running container contain the configured `1000 101000 64536` row — impossible under the default single-line `0 100000 65536` map.

Verified red→green:

- **Without the fix:** `uid_map` = `0 100000 65536` (default), assertion fails.
- **With the fix:** configured map present, assertion passes.

```
./testacc "TestAccResourceContainerIDMap.*" --no-proxy -- -v

=== RUN   TestAccResourceContainerIDMap
=== RUN   TestAccResourceContainerIDMapFirstBoot
--- PASS: TestAccResourceContainerIDMap (14.43s)
--- PASS: TestAccResourceContainerIDMapFirstBoot (23.06s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	24.694s
```

`TestAccResourceContainerIDMap` (the pre-existing test, `started = false`) still passes — no regression; the reboot branch only triggers for started, idmap-configured containers.

API verification: no new API parameters. The change adds an existing `RebootContainer` (POST `/lxc/<vmid>/status/reboot`) call, verified behaviorally by reading the actual applied mapping inside the running container.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2895

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.8). All changes have been reviewed and verified by a human.*
