### PR TITLE
feat(vm): add agent.wait_for_ip.enabled to disable IP lookup

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -138,10 +138,11 @@ output "ubuntu_vm_public_key" {
         - `isa` - ISA Serial Port.
         - `virtio` - VirtIO (paravirtualized).
     - `wait_for_ip` - (Optional) Configuration for waiting for specific IP address types when the VM starts.
+        - `enabled` - (Optional) Whether to wait for the agent to report an IP address (defaults to `true`). Set to `false` to disable the IP lookup entirely, so the provider does not wait for the agent during `refresh` and at the end of `apply`. Useful when the guest agent is slow to start, not yet installed, or not running, to avoid blocking those operations. When disabled, `ipv4_addresses`, `ipv6_addresses`, and `network_interface_names` are left empty.
         - `ipv4` - (Optional) Wait for at least one IPv4 address (non-loopback, non-link-local) (defaults to `false`).
         - `ipv6` - (Optional) Wait for at least one IPv6 address (non-loopback, non-link-local) (defaults to `false`).
 
-        When `wait_for_ip` is not specified or both `ipv4` and `ipv6` are `false`, the provider waits for any valid global unicast address (IPv4 or IPv6). In dual-stack networks where DHCPv6 responds faster, this may result in only IPv6 addresses being available. Set `ipv4 = true` to ensure IPv4 address availability.
+        When `wait_for_ip` is not specified or both `ipv4` and `ipv6` are `false` (and `enabled` is `true`), the provider waits for any valid global unicast address (IPv4 or IPv6). In dual-stack networks where DHCPv6 responds faster, this may result in only IPv6 addresses being available. Set `ipv4 = true` to ensure IPv4 address availability.
 - `amd_sev` - (Optional) Secure Encrypted Virtualization (SEV) features by AMD CPUs.
     - `type` - (Optional) Enable standard SEV with `std` or enable experimental SEV-ES with the `es` option or enable experimental SEV-SNP with the `snp` option (defaults to `std`).
     - `allow_smt` - (Optional) Sets policy bit to allow Simultaneous Multi Threading (SMT)

--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -1362,6 +1362,73 @@ func TestAccResourceVMNetwork(t *testing.T) {
 				}),
 			),
 		}}},
+		{"disable agent IP wait", []resource.TestStep{{
+			Config: te.RenderConfig(`
+			resource "proxmox_virtual_environment_file" "cloud_config" {
+				content_type = "snippets"
+				datastore_id = "local"
+				node_name = "{{.NodeName}}"
+				overwrite = true
+				source_raw {
+					data = <<-EOF
+					#cloud-config
+					runcmd:
+					  - apt update
+					  - apt install -y qemu-guest-agent
+					  - systemctl enable qemu-guest-agent
+					  - systemctl start qemu-guest-agent
+					EOF
+					file_name = "{{.TestName}}-disable-wait-cloud-config.yaml"
+				}
+			}
+
+			resource "proxmox_virtual_environment_vm" "test_vm_no_wait" {
+				node_name = "{{.NodeName}}"
+				started   = true
+				stop_on_destroy = true
+				agent {
+					enabled = true
+					wait_for_ip {
+						enabled = false
+					}
+				}
+				cpu {
+					cores = 2
+				}
+				memory {
+					dedicated = 2048
+				}
+				disk {
+					datastore_id = "local-lvm"
+					file_id      = "{{.ImageFileID}}"
+					interface    = "virtio0"
+					iothread     = true
+					discard      = "on"
+					size         = 20
+				}
+				initialization {
+					ip_config {
+						ipv4 {
+							address = "dhcp"
+						}
+					}
+					user_data_file_id = proxmox_virtual_environment_file.cloud_config.id
+				}
+				network_device {
+					bridge = "vmbr0"
+				}
+			}`),
+			Check: resource.ComposeTestCheckFunc(
+				// wait_for_ip.enabled = false: the provider skips the agent IP lookup, so the
+				// address attributes stay empty even though the guest agent is running.
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm_no_wait", map[string]string{
+					"agent.0.wait_for_ip.0.enabled": "false",
+					"ipv4_addresses.#":              "0",
+					"ipv6_addresses.#":              "0",
+					"network_interface_names.#":     "0",
+				}),
+			),
+		}}},
 		{"network device disconnected", []resource.TestStep{
 			{
 				Config: te.RenderConfig(`

--- a/proxmox/nodes/vms/vms.go
+++ b/proxmox/nodes/vms/vms.go
@@ -561,6 +561,11 @@ func (c *Client) WaitForNetworkInterfacesFromVMAgent(
 	timeout time.Duration,
 	waitForIPConfig *WaitForIPConfig, // configuration for which IP types to wait for (nil = wait for any global unicast)
 ) (*GetQEMUNetworkInterfacesResponseData, error) {
+	if waitForIPConfig != nil && waitForIPConfig.Skip {
+		// wait_for_ip.enabled = false: the caller disabled the agent IP lookup entirely.
+		return &GetQEMUNetworkInterfacesResponseData{}, nil
+	}
+
 	errNoIPsYet := errors.New("no ips yet")
 
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)

--- a/proxmox/nodes/vms/vms.go
+++ b/proxmox/nodes/vms/vms.go
@@ -563,7 +563,10 @@ func (c *Client) WaitForNetworkInterfacesFromVMAgent(
 ) (*GetQEMUNetworkInterfacesResponseData, error) {
 	if waitForIPConfig != nil && waitForIPConfig.Skip {
 		// wait_for_ip.enabled = false: the caller disabled the agent IP lookup entirely.
-		return &GetQEMUNetworkInterfacesResponseData{}, nil
+		// Return a non-nil empty Result to honor the success contract (err == nil => Result != nil).
+		return &GetQEMUNetworkInterfacesResponseData{
+			Result: &[]GetQEMUNetworkInterfacesResponseResult{},
+		}, nil
 	}
 
 	errNoIPsYet := errors.New("no ips yet")

--- a/proxmox/nodes/vms/vms_types.go
+++ b/proxmox/nodes/vms/vms_types.go
@@ -35,6 +35,7 @@ var (
 
 // WaitForIPConfig specifies which IP address types to wait for when waiting for network interfaces.
 type WaitForIPConfig struct {
+	Skip bool // Skip the agent IP wait entirely (wait_for_ip.enabled = false)
 	IPv4 bool // Wait for at least one IPv4 address (non-loopback, non-link-local)
 	IPv6 bool // Wait for at least one IPv6 address (non-loopback, non-link-local)
 }

--- a/proxmoxtf/resource/vm/agent_test.go
+++ b/proxmoxtf/resource/vm/agent_test.go
@@ -1,0 +1,84 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package resource
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
+)
+
+// TestVMAgentWaitForIPEnabledSchema verifies the agent.wait_for_ip block exposes an
+// `enabled` master switch that defaults to true (waiting stays the default behavior).
+func TestVMAgentWaitForIPEnabledSchema(t *testing.T) {
+	t.Parallel()
+
+	agentBlock, ok := VM().Schema[mkAgent].Elem.(*schema.Resource)
+	require.True(t, ok, "agent block must be a *schema.Resource")
+
+	waitForIP, ok := agentBlock.Schema[mkAgentWaitForIP].Elem.(*schema.Resource)
+	require.True(t, ok, "wait_for_ip block must be a *schema.Resource")
+
+	enabled, ok := waitForIP.Schema[mkAgentWaitForIPEnabled]
+	require.True(t, ok, "wait_for_ip must expose an `enabled` attribute")
+	require.Equal(t, schema.TypeBool, enabled.Type)
+	require.Equal(t, true, enabled.Default, "wait_for_ip.enabled must default to true")
+}
+
+// TestAgentWaitForIPConfigFromBlock verifies the wait_for_ip block is translated into the
+// right WaitForIPConfig, including the new disable path.
+func TestAgentWaitForIPConfigFromBlock(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		block map[string]any
+		want  *vms.WaitForIPConfig
+	}{
+		{
+			name:  "enabled false -> skip",
+			block: map[string]any{mkAgentWaitForIPEnabled: false},
+			want:  &vms.WaitForIPConfig{Skip: true},
+		},
+		{
+			name:  "enabled true, no family -> wait for any (nil)",
+			block: map[string]any{mkAgentWaitForIPEnabled: true},
+			want:  nil,
+		},
+		{
+			name:  "enabled true, ipv4 -> wait for ipv4",
+			block: map[string]any{mkAgentWaitForIPEnabled: true, mkAgentWaitForIPIPv4: true},
+			want:  &vms.WaitForIPConfig{IPv4: true},
+		},
+		{
+			name:  "enabled false wins over family",
+			block: map[string]any{mkAgentWaitForIPEnabled: false, mkAgentWaitForIPIPv4: true},
+			want:  &vms.WaitForIPConfig{Skip: true},
+		},
+		{
+			name:  "enabled absent defaults to wait (backward compat)",
+			block: map[string]any{mkAgentWaitForIPIPv4: true},
+			want:  &vms.WaitForIPConfig{IPv4: true},
+		},
+		{
+			name:  "empty block waits for any (nil)",
+			block: map[string]any{},
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, agentWaitForIPConfigFromBlock(tt.block))
+		})
+	}
+}

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -44,39 +44,40 @@ import (
 )
 
 const (
-	dvRebootAfterCreation = false
-	dvRebootAfterUpdate   = true
-	dvOnBoot              = true
-	dvACPI                = true
-	dvAgentEnabled        = false
-	dvAgentTimeout        = "15m"
-	dvAgentTrim           = false
-	dvAgentType           = "virtio"
-	dvAMDSEVType          = "std"
-	dvAMDSEVAllowSMT      = true
-	dvAMDSEVKernelHashes  = false
-	dvAMDSEVNoDebug       = false
-	dvAMDSEVNoKeySharing  = false
-	dvAudioDeviceDevice   = "intel-hda"
-	dvAudioDeviceDriver   = "spice"
-	dvAudioDeviceEnabled  = true
-	dvBIOS                = "seabios"
-	dvCDROMEnabled        = false
-	dvCDROMFileID         = ""
-	dvCDROMInterface      = "ide3"
-	dvCloneDatastoreID    = ""
-	dvCloneNodeName       = ""
-	dvCloneFull           = true
-	dvCloneRetries        = 1
-	dvCPUArchitecture     = ""
-	dvCPUCores            = 1
-	dvCPUHotplugged       = 0
-	dvCPULimit            = float64(0)
-	dvCPUNUMA             = false
-	dvCPUSockets          = 1
-	dvCPUType             = "qemu64"
-	dvCPUAffinity         = ""
-	dvDescription         = ""
+	dvRebootAfterCreation   = false
+	dvRebootAfterUpdate     = true
+	dvOnBoot                = true
+	dvACPI                  = true
+	dvAgentEnabled          = false
+	dvAgentTimeout          = "15m"
+	dvAgentTrim             = false
+	dvAgentType             = "virtio"
+	dvAgentWaitForIPEnabled = true
+	dvAMDSEVType            = "std"
+	dvAMDSEVAllowSMT        = true
+	dvAMDSEVKernelHashes    = false
+	dvAMDSEVNoDebug         = false
+	dvAMDSEVNoKeySharing    = false
+	dvAudioDeviceDevice     = "intel-hda"
+	dvAudioDeviceDriver     = "spice"
+	dvAudioDeviceEnabled    = true
+	dvBIOS                  = "seabios"
+	dvCDROMEnabled          = false
+	dvCDROMFileID           = ""
+	dvCDROMInterface        = "ide3"
+	dvCloneDatastoreID      = ""
+	dvCloneNodeName         = ""
+	dvCloneFull             = true
+	dvCloneRetries          = 1
+	dvCPUArchitecture       = ""
+	dvCPUCores              = 1
+	dvCPUHotplugged         = 0
+	dvCPULimit              = float64(0)
+	dvCPUNUMA               = false
+	dvCPUSockets            = 1
+	dvCPUType               = "qemu64"
+	dvCPUAffinity           = ""
+	dvDescription           = ""
 
 	// dvHotplug is the Proxmox VE default hotplug value.
 	// When hotplug is not explicitly configured, PVE uses "network,disk,usb".
@@ -158,52 +159,53 @@ const (
 	maxResourceVirtualEnvironmentVMNUMADevices  = 8
 	maxResourceVirtualEnvironmentVirtiofsShares = 8
 
-	mkRebootAfterCreation = "reboot"
-	mkRebootAfterUpdate   = "reboot_after_update"
-	mkOnBoot              = "on_boot"
-	mkBootOrder           = "boot_order"
-	mkACPI                = "acpi"
-	mkAgent               = "agent"
-	mkAgentEnabled        = "enabled"
-	mkAgentTimeout        = "timeout"
-	mkAgentTrim           = "trim"
-	mkAgentType           = "type"
-	mkAgentWaitForIP      = "wait_for_ip"
-	mkAgentWaitForIPIPv4  = "ipv4"
-	mkAgentWaitForIPIPv6  = "ipv6"
-	mkAMDSEV              = "amd_sev"
-	mkAMDSEVType          = "type"
-	mkAMDSEVAllowSMT      = "allow_smt"
-	mkAMDSEVKernelHashes  = "kernel_hashes"
-	mkAMDSEVNoDebug       = "no_debug"
-	mkAMDSEVNoKeySharing  = "no_key_sharing"
-	mkAudioDevice         = "audio_device"
-	mkAudioDeviceDevice   = "device"
-	mkAudioDeviceDriver   = "driver"
-	mkAudioDeviceEnabled  = "enabled"
-	mkBIOS                = "bios"
-	mkCDROM               = "cdrom"
-	mkCDROMEnabled        = "enabled"
-	mkCDROMFileID         = "file_id"
-	mkCDROMInterface      = "interface"
-	mkClone               = "clone"
-	mkCloneRetries        = "retries"
-	mkCloneDatastoreID    = "datastore_id"
-	mkCloneNodeName       = "node_name"
-	mkCloneVMID           = "vm_id"
-	mkCloneFull           = "full"
-	mkCPU                 = "cpu"
-	mkCPUArchitecture     = "architecture"
-	mkCPUCores            = "cores"
-	mkCPUFlags            = "flags"
-	mkCPUHotplugged       = "hotplugged"
-	mkCPULimit            = "limit"
-	mkCPUNUMA             = "numa"
-	mkCPUSockets          = "sockets"
-	mkCPUType             = "type"
-	mkCPUUnits            = "units"
-	mkCPUAffinity         = "affinity"
-	mkDescription         = "description"
+	mkRebootAfterCreation   = "reboot"
+	mkRebootAfterUpdate     = "reboot_after_update"
+	mkOnBoot                = "on_boot"
+	mkBootOrder             = "boot_order"
+	mkACPI                  = "acpi"
+	mkAgent                 = "agent"
+	mkAgentEnabled          = "enabled"
+	mkAgentTimeout          = "timeout"
+	mkAgentTrim             = "trim"
+	mkAgentType             = "type"
+	mkAgentWaitForIP        = "wait_for_ip"
+	mkAgentWaitForIPEnabled = "enabled"
+	mkAgentWaitForIPIPv4    = "ipv4"
+	mkAgentWaitForIPIPv6    = "ipv6"
+	mkAMDSEV                = "amd_sev"
+	mkAMDSEVType            = "type"
+	mkAMDSEVAllowSMT        = "allow_smt"
+	mkAMDSEVKernelHashes    = "kernel_hashes"
+	mkAMDSEVNoDebug         = "no_debug"
+	mkAMDSEVNoKeySharing    = "no_key_sharing"
+	mkAudioDevice           = "audio_device"
+	mkAudioDeviceDevice     = "device"
+	mkAudioDeviceDriver     = "driver"
+	mkAudioDeviceEnabled    = "enabled"
+	mkBIOS                  = "bios"
+	mkCDROM                 = "cdrom"
+	mkCDROMEnabled          = "enabled"
+	mkCDROMFileID           = "file_id"
+	mkCDROMInterface        = "interface"
+	mkClone                 = "clone"
+	mkCloneRetries          = "retries"
+	mkCloneDatastoreID      = "datastore_id"
+	mkCloneNodeName         = "node_name"
+	mkCloneVMID             = "vm_id"
+	mkCloneFull             = "full"
+	mkCPU                   = "cpu"
+	mkCPUArchitecture       = "architecture"
+	mkCPUCores              = "cores"
+	mkCPUFlags              = "flags"
+	mkCPUHotplugged         = "hotplugged"
+	mkCPULimit              = "limit"
+	mkCPUNUMA               = "numa"
+	mkCPUSockets            = "sockets"
+	mkCPUType               = "type"
+	mkCPUUnits              = "units"
+	mkCPUAffinity           = "affinity"
+	mkDescription           = "description"
 
 	mkNUMA              = "numa"
 	mkNUMADevice        = "device"
@@ -423,6 +425,12 @@ func VM() *schema.Resource {
 						MinItems:    0,
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{
+								mkAgentWaitForIPEnabled: {
+									Type:        schema.TypeBool,
+									Description: "Whether to wait for the agent to report an IP address; set to false to skip the lookup entirely",
+									Optional:    true,
+									Default:     dvAgentWaitForIPEnabled,
+								},
 								mkAgentWaitForIPIPv4: {
 									Type:        schema.TypeBool,
 									Description: "Wait for at least one IPv4 address (non-loopback, non-link-local)",
@@ -7587,12 +7595,22 @@ func getAgentWaitForIPConfig(d *schema.ResourceData) *vms.WaitForIPConfig {
 
 	waitForIPBlock := waitForIPList[0].(map[string]any)
 
-	config := &vms.WaitForIPConfig{
-		IPv4: getBoolFromBlock(waitForIPBlock, mkAgentWaitForIPIPv4, false),
-		IPv6: getBoolFromBlock(waitForIPBlock, mkAgentWaitForIPIPv6, false),
+	return agentWaitForIPConfigFromBlock(waitForIPBlock)
+}
+
+// agentWaitForIPConfigFromBlock translates a wait_for_ip block into a WaitForIPConfig.
+// enabled=false disables the agent IP wait entirely (Skip); otherwise nil means "wait for any".
+func agentWaitForIPConfigFromBlock(block map[string]any) *vms.WaitForIPConfig {
+	if !getBoolFromBlock(block, mkAgentWaitForIPEnabled, true) {
+		return &vms.WaitForIPConfig{Skip: true}
 	}
 
-	// if both are false, return nil for backward compatibility
+	config := &vms.WaitForIPConfig{
+		IPv4: getBoolFromBlock(block, mkAgentWaitForIPIPv4, false),
+		IPv6: getBoolFromBlock(block, mkAgentWaitForIPIPv6, false),
+	}
+
+	// if both are false, return nil for backward compatibility (wait for any)
 	if !config.IPv4 && !config.IPv6 {
 		return nil
 	}


### PR DESCRIPTION
### What does this PR do?

When the QEMU guest agent is enabled (`agent.enabled = true`) on the `proxmox_virtual_environment_vm` resource, the provider always polls the guest for an IP address during every `refresh` and at the end of each `apply`. There was no way to disable this lookup, which slows operations when the agent is not running or not yet available (e.g. installed at a later stage). `agent.wait_for_ip` only narrows _which_ address family to wait for — it can't turn the wait off.

This PR adds `agent.wait_for_ip.enabled` (bool, default `true`). When set to `false`, the provider skips the agent IP lookup entirely, so it no longer waits for the agent during `refresh`/`apply` and leaves `ipv4_addresses`, `ipv6_addresses`, and `network_interface_names` empty. The default of `true` preserves existing behavior — waiting remains the expected default when the agent is enabled.

### Usage Example

```hcl
resource "proxmox_virtual_environment_vm" "example" {
  node_name = "pve"
  started   = true

  agent {
    enabled = true
    wait_for_ip {
      enabled = false # do not block on the agent IP lookup during refresh/apply
    }
  }

  # ...disk, network_device, etc.
}
```

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

SDK-only change (the `agent` block exists only on `proxmox_virtual_environment_vm`; the Framework `proxmox_vm` has no agent block).

**Unit tests** (RED confirmed first — failed with `undefined: mkAgentWaitForIPEnabled / agentWaitForIPConfigFromBlock / WaitForIPConfig.Skip` before implementation):

```
$ go test ./proxmoxtf/resource/vm/ -run 'TestVMAgentWaitForIPEnabledSchema|TestAgentWaitForIPConfigFromBlock' -v
--- PASS: TestVMAgentWaitForIPEnabledSchema (0.00s)
--- PASS: TestAgentWaitForIPConfigFromBlock (0.00s)
    --- PASS: .../enabled_false_->_skip
    --- PASS: .../enabled_true,_no_family_->_wait_for_any_(nil)
    --- PASS: .../enabled_true,_ipv4_->_wait_for_ipv4
    --- PASS: .../enabled_false_wins_over_family
    --- PASS: .../enabled_absent_defaults_to_wait_(backward_compat)
    --- PASS: .../empty_block_waits_for_any_(nil)
ok  	github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm
```

**Acceptance test** (started VM, `agent.enabled = true`, `wait_for_ip { enabled = false }`; asserts the apply does not block and address attributes stay empty):

```
$ ./testacc 'TestAccResourceVMNetwork/disable_agent_IP_wait' -- -v
--- PASS: TestAccResourceVMNetwork (8.34s)
    --- PASS: TestAccResourceVMNetwork/disable_agent_IP_wait (21.14s)
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test

# asserts: agent.0.wait_for_ip.0.enabled = false, ipv4_addresses.# = 0,
#          ipv6_addresses.# = 0, network_interface_names.# = 0
```

**API verification (mitmproxy)** — the change's effect is the _absence_ of the agent IP request (`GET /api2/json/nodes/{node}/qemu/{vmid}/agent/network-get-interfaces`). Two runs with identical VM lifecycle, differing only in `wait_for_ip.enabled`:

| Scenario                                          | `network-get-interfaces` GET count |
| ------------------------------------------------- | ---------------------------------- |
| `wait_for_ip { enabled = false }` (this PR)       | **0**                              |
| Control — `wait_for_ip { ipv4 = true }` (waiting) | **7**                              |

Both captures contained the full VM lifecycle (create `POST`, `status/start`, `config` GET, `status/current` GET, resize, stop, destroy), confirming the proxy observed the traffic — so the 0-vs-7 result conclusively shows the agent IP call is eliminated when disabled.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2914

---

🤖 _This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.8). All changes have been reviewed and verified by a human._
