### PR TITLE
fix(core): bound SSH dial and handshake with a timeout, improve concurrent sudo checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.55.0
+	golang.org/x/sync v0.20.0
 )
 
 require (
@@ -89,7 +90,6 @@ require (
 	go.abhg.dev/goldmark/frontmatter v0.2.0 // indirect
 	golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect

--- a/proxmox/ssh/client.go
+++ b/proxmox/ssh/client.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/pkg/sftp"
@@ -26,6 +27,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/net/proxy"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
 	"github.com/bpg/terraform-provider-proxmox/utils"
@@ -49,6 +51,8 @@ const (
 		`fi; ` +
 		`}`
 )
+
+const defaultDialTimeout = 30 * time.Second
 
 // NewErrUserHasNoPermission creates a new error indicating that the SSH user does not have required permissions.
 func NewErrUserHasNoPermission(username string) error {
@@ -87,6 +91,7 @@ type client struct {
 	nodeResolver    NodeResolver
 	sudoCache       map[string]bool
 	sudoCacheMu     sync.RWMutex
+	sudoProbe       singleflight.Group
 }
 
 // NewClient creates a new SSH client.
@@ -137,8 +142,8 @@ func (c *client) Username() string {
 }
 
 // getSudoAvailability gets the cached sudo availability or checks and caches it.
-// Uses double-checked locking to prevent race conditions when multiple goroutines
-// check the same uncached node simultaneously.
+// The cache lock guards only the map ops; the probe runs outside it via singleflight,
+// so concurrent checks for the same node share one round trip without blocking others.
 func (c *client) getSudoAvailability(ctx context.Context, nodeName string) (bool, error) {
 	c.sudoCacheMu.RLock()
 	cached, found := c.sudoCache[nodeName]
@@ -148,16 +153,31 @@ func (c *client) getSudoAvailability(ctx context.Context, nodeName string) (bool
 		return cached, nil
 	}
 
-	c.sudoCacheMu.Lock()
-	defer c.sudoCacheMu.Unlock()
+	// WithoutCancel detaches the shared probe from any single caller's cancellation,
+	// so one caller cancelling can't fail the probe for the other concurrent waiters.
+	ch := c.sudoProbe.DoChan(nodeName, func() (any, error) {
+		return c.probeSudo(context.WithoutCancel(ctx), nodeName)
+	})
 
-	// Re-check the cache after acquiring the write lock in case another goroutine
-	// populated it while we were waiting.
-	cached, found = c.sudoCache[nodeName]
-	if found {
-		return cached, nil
+	select {
+	case <-ctx.Done():
+		return false, fmt.Errorf("sudo availability check cancelled for node %q: %w", nodeName, ctx.Err())
+	case res := <-ch:
+		if res.Err != nil {
+			return false, fmt.Errorf("failed to probe sudo availability for node %q: %w", nodeName, res.Err)
+		}
+
+		shouldUseSudo, _ := res.Val.(bool)
+
+		c.sudoCacheMu.Lock()
+		c.sudoCache[nodeName] = shouldUseSudo
+		c.sudoCacheMu.Unlock()
+
+		return shouldUseSudo, nil
 	}
+}
 
+func (c *client) probeSudo(ctx context.Context, nodeName string) (bool, error) {
 	checkCmd := `if [ "$(id -u)" = "0" ]; then echo "0"; ` +
 		`elif [ $(sudo -n /usr/sbin/pvesm apiinfo 2>&1 | grep "APIVER" | wc -l) -gt 0 ] ` +
 		`|| sudo -n /usr/sbin/qm --help >/dev/null 2>&1; then echo "1"; else echo "0"; fi`
@@ -183,10 +203,7 @@ func (c *client) getSudoAvailability(ctx context.Context, nodeName string) (bool
 		return false, fmt.Errorf("failed to check sudo availability: %w", err)
 	}
 
-	shouldUseSudo := strings.TrimSpace(string(output)) == "1"
-	c.sudoCache[nodeName] = shouldUseSudo
-
-	return shouldUseSudo, nil
+	return strings.TrimSpace(string(output)) == "1", nil
 }
 
 // ExecuteNodeCommands executes commands on a given node.
@@ -787,35 +804,87 @@ func (c *client) createSSHClientWithPrivateKey(
 }
 
 func (c *client) connect(ctx context.Context, sshHost string, sshConfig *ssh.ClientConfig) (*ssh.Client, error) {
-	if c.socks5Server != "" {
-		sshClient, err := c.socks5SSHClient(sshHost, sshConfig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to dial %s via SOCKS5 proxy %s: %w", sshHost, c.socks5Server, err)
-		}
+	dialCtx, cancel := dialContext(ctx)
+	defer cancel()
 
-		tflog.Debug(ctx, "SSH connection via SOCKS5 established", map[string]any{
-			"host":          sshHost,
-			"socks5_server": c.socks5Server,
-			"user":          c.username,
-		})
-
-		return sshClient, nil
-	}
-
-	sshClient, err := ssh.Dial("tcp", sshHost, sshConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial %s: %w", sshHost, err)
-	}
-
-	tflog.Debug(ctx, "SSH connection established", map[string]any{
-		"host": sshHost,
-		"user": c.username,
+	tflog.Trace(ctx, "bounding SSH dial and handshake so a stalled pre-auth handshake fails fast", map[string]any{
+		"host":         sshHost,
+		"dial_timeout": defaultDialTimeout.String(),
 	})
 
-	return sshClient, nil
+	conn, err := c.dial(dialCtx, sshHost)
+	if err != nil {
+		return nil, err
+	}
+
+	type result struct {
+		client *ssh.Client
+		err    error
+	}
+
+	ch := make(chan result, 1)
+
+	go func() {
+		sshConn, chans, reqs, herr := ssh.NewClientConn(conn, sshHost, sshConfig)
+		if herr != nil {
+			ch <- result{err: herr}
+
+			return
+		}
+
+		ch <- result{client: ssh.NewClient(sshConn, chans, reqs)}
+	}()
+
+	select {
+	case <-dialCtx.Done():
+		_ = conn.Close()
+
+		// join the handshake goroutine; close the client if it connected in the photo-finish
+		if r := <-ch; r.client != nil {
+			_ = r.client.Close()
+		}
+
+		tflog.Debug(ctx, "SSH handshake aborted: dial deadline exceeded", map[string]any{"host": sshHost})
+
+		return nil, fmt.Errorf("SSH handshake to %s timed out (dial timeout %s): %w", sshHost, defaultDialTimeout, dialCtx.Err())
+	case r := <-ch:
+		if r.err != nil {
+			_ = conn.Close()
+
+			return nil, fmt.Errorf("failed SSH handshake to %s: %w", sshHost, r.err)
+		}
+
+		tflog.Debug(ctx, "SSH connection established", map[string]any{
+			"host":          sshHost,
+			"user":          c.username,
+			"socks5_server": c.socks5Server,
+		})
+
+		return r.client, nil
+	}
 }
 
-func (c *client) socks5SSHClient(sshServerAddress string, sshConfig *ssh.ClientConfig) (*ssh.Client, error) {
+func dialContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	deadline := time.Now().Add(defaultDialTimeout)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+
+	return context.WithDeadline(ctx, deadline)
+}
+
+func (c *client) dial(ctx context.Context, sshHost string) (net.Conn, error) {
+	if c.socks5Server == "" {
+		var dialer net.Dialer
+
+		conn, err := dialer.DialContext(ctx, "tcp", sshHost)
+		if err != nil {
+			return nil, fmt.Errorf("failed to dial %s: %w", sshHost, err)
+		}
+
+		return conn, nil
+	}
+
 	dialer, err := proxy.SOCKS5("tcp", c.socks5Server, &proxy.Auth{
 		User:     c.socks5Username,
 		Password: c.socks5Password,
@@ -824,15 +893,20 @@ func (c *client) socks5SSHClient(sshServerAddress string, sshConfig *ssh.ClientC
 		return nil, fmt.Errorf("failed to create SOCKS5 proxy dialer: %w", err)
 	}
 
-	conn, err := dialer.Dial("tcp", sshServerAddress)
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial %s via SOCKS5 proxy %s: %w", sshServerAddress, c.socks5Server, err)
+	cd, ok := dialer.(proxy.ContextDialer)
+	if !ok {
+		return nil, fmt.Errorf("SOCKS5 dialer for %s does not support context-aware dialing", c.socks5Server)
 	}
 
-	sshConn, ch, reqs, err := ssh.NewClientConn(conn, sshServerAddress, sshConfig)
+	tflog.Trace(ctx, "dialing SSH via SOCKS5 proxy", map[string]any{
+		"host":          sshHost,
+		"socks5_server": c.socks5Server,
+	})
+
+	conn, err := cd.DialContext(ctx, "tcp", sshHost)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create SSH client connection: %w", err)
+		return nil, fmt.Errorf("failed to dial %s via SOCKS5 proxy %s: %w", sshHost, c.socks5Server, err)
 	}
 
-	return ssh.NewClient(sshConn, ch, reqs), nil
+	return conn, nil
 }

--- a/proxmox/ssh/client.go
+++ b/proxmox/ssh/client.go
@@ -804,12 +804,12 @@ func (c *client) createSSHClientWithPrivateKey(
 }
 
 func (c *client) connect(ctx context.Context, sshHost string, sshConfig *ssh.ClientConfig) (*ssh.Client, error) {
-	dialCtx, cancel := dialContext(ctx)
+	dialCtx, cancel, timeout := dialContext(ctx)
 	defer cancel()
 
 	tflog.Trace(ctx, "bounding SSH dial and handshake so a stalled pre-auth handshake fails fast", map[string]any{
 		"host":         sshHost,
-		"dial_timeout": defaultDialTimeout.String(),
+		"dial_timeout": timeout.String(),
 	})
 
 	conn, err := c.dial(dialCtx, sshHost)
@@ -846,7 +846,7 @@ func (c *client) connect(ctx context.Context, sshHost string, sshConfig *ssh.Cli
 
 		tflog.Debug(ctx, "SSH handshake aborted: dial deadline exceeded", map[string]any{"host": sshHost})
 
-		return nil, fmt.Errorf("SSH handshake to %s timed out (dial timeout %s): %w", sshHost, defaultDialTimeout, dialCtx.Err())
+		return nil, fmt.Errorf("SSH handshake to %s timed out (dial timeout %s): %w", sshHost, timeout, dialCtx.Err())
 	case r := <-ch:
 		if r.err != nil {
 			_ = conn.Close()
@@ -864,13 +864,21 @@ func (c *client) connect(ctx context.Context, sshHost string, sshConfig *ssh.Cli
 	}
 }
 
-func dialContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	deadline := time.Now().Add(defaultDialTimeout)
+// dialContext bounds the dial+handshake to defaultDialTimeout, or to the caller's
+// own deadline when that is sooner. It returns the effective timeout so callers can
+// report the bound that actually applied rather than the nominal default.
+func dialContext(ctx context.Context) (context.Context, context.CancelFunc, time.Duration) {
+	timeout := defaultDialTimeout
+	deadline := time.Now().Add(timeout)
+
 	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
 		deadline = d
+		timeout = time.Until(d).Round(time.Millisecond)
 	}
 
-	return context.WithDeadline(ctx, deadline)
+	dialCtx, cancel := context.WithDeadline(ctx, deadline)
+
+	return dialCtx, cancel, timeout
 }
 
 func (c *client) dial(ctx context.Context, sshHost string) (net.Conn, error) {

--- a/proxmox/ssh/connect_timeout_test.go
+++ b/proxmox/ssh/connect_timeout_test.go
@@ -1,0 +1,103 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package ssh
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func stallingListener(t *testing.T) (string, func()) {
+	t.Helper()
+
+	var lc net.ListenConfig
+
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to open stalling listener: %v", err)
+	}
+
+	var (
+		mu    sync.Mutex
+		conns []net.Conn
+	)
+
+	go func() {
+		for {
+			conn, aerr := ln.Accept()
+			if aerr != nil {
+				return
+			}
+
+			mu.Lock()
+
+			conns = append(conns, conn)
+			mu.Unlock()
+		}
+	}()
+
+	return ln.Addr().String(), func() {
+		_ = ln.Close()
+
+		mu.Lock()
+		for _, c := range conns {
+			_ = c.Close()
+		}
+		mu.Unlock()
+	}
+}
+
+func TestConnectHonorsContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	addr, closeFn := stallingListener(t)
+	defer closeFn()
+
+	c := &client{username: "root"}
+
+	cfg := &ssh.ClientConfig{
+		User:            "root",
+		Auth:            []ssh.AuthMethod{ssh.Password("irrelevant")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	type result struct {
+		err     error
+		elapsed time.Duration
+	}
+
+	done := make(chan result, 1)
+	start := time.Now()
+
+	go func() {
+		_, err := c.connect(ctx, addr, cfg)
+		done <- result{err: err, elapsed: time.Since(start)}
+	}()
+
+	select {
+	case r := <-done:
+		if r.err == nil {
+			t.Fatalf("expected connect to fail against a stalling server, got nil error")
+		}
+
+		t.Logf("connect returned after %s with error: %v", r.elapsed, r.err)
+
+		if r.elapsed > 5*time.Second {
+			t.Fatalf("connect took %s — far past the 2s context deadline", r.elapsed)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatalf("connect did not return within 10s: it ignored the 2s context deadline (issue #2915)")
+	}
+}


### PR DESCRIPTION
### What does this PR do?
<!--- Clearly state the problem and how this PR solves it. -->
Bounds the SSH dial and pre-auth handshake with a 30s timeout (or the caller's earlier deadline) so a stalled handshake fails fast instead of hanging uploads forever (#2915). Also refactors `getSudoAvailability` from double-checked locking to `singleflight.DoChan` + `context.WithoutCancel`, and makes both the direct and SOCKS5 dial paths context-aware.


### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [X] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [X] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [X] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

Unit test (`proxmox/ssh/connect_timeout_test.go`) points `connect()` at a listener that accepts
TCP but never completes the handshake, with a 2s context deadline:

```text
$ go test ./proxmox/ssh/ -run TestConnectHonorsContextDeadline -v -timeout 60s

# WITHOUT the fix: connect() ignores the context and blocks; the test's 10s watchdog fires:
--- FAIL: TestConnectHonorsContextDeadline (10.01s)
    connect_timeout_test.go: connect did not return within 10s: it ignored the 2s context deadline (issue #2915)

# WITH the fix: connect() returns at the deadline with an actionable error:
=== RUN   TestConnectHonorsContextDeadline
    connect_timeout_test.go: connect returned after 2.0017s with error: SSH handshake to 127.0.0.1:43171 timed out (dial timeout 30s): context deadline exceeded
--- PASS: TestConnectHonorsContextDeadline (2.00s)
ok      github.com/bpg/terraform-provider-proxmox/proxmox/ssh   2.008s
```


`make lint` (golangci-lint v2.12.2), `go build ./...`, and `go vet ./proxmox/ssh/...` all pass.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2915

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
