### PR TITLE
feat(vm): add queues option for scsi disks

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -318,6 +318,10 @@ output "ubuntu_vm_public_key" {
         the second, etc.
     - `iothread` - (Optional) Whether to use iothreads for this disk (defaults
         to `false`).
+    - `queues` - (Optional) The number of I/O queues for this disk, `2` or
+        greater. Only supported for SCSI disks, and applied by Proxmox only
+        when `scsi_hardware` is set to `virtio-scsi-single`. A change requires
+        a VM power cycle (or reboot via the Proxmox API) to take effect.
     - `replicate` - (Optional) Whether the drive should be considered for replication jobs (defaults to `true`).
     - `serial` - (Optional) The serial number of the disk, up to 20 bytes long.
     - `size` - (Optional) The disk size in gigabytes (defaults to `8`).

--- a/fwprovider/test/resource_vm_disks_test.go
+++ b/fwprovider/test/resource_vm_disks_test.go
@@ -1415,6 +1415,90 @@ func TestAccResourceVMDisks(t *testing.T) {
 				),
 			},
 		}, nil},
+		{"create scsi disk with queues, then change and remove it", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_disk" {
+					node_name     = "{{.NodeName}}"
+					started       = false
+					name          = "test-disk"
+					scsi_hardware = "virtio-scsi-single"
+
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi0"
+						size         = 8
+						queues       = 4
+					}
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_disk", map[string]string{
+						"disk.0.interface": "scsi0",
+						"disk.0.queues":    "4",
+					}),
+				),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_disk" {
+					node_name     = "{{.NodeName}}"
+					started       = false
+					name          = "test-disk"
+					scsi_hardware = "virtio-scsi-single"
+
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi0"
+						size         = 8
+						queues       = 8
+					}
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_disk", map[string]string{
+						"disk.0.queues": "8",
+					}),
+				),
+			},
+			{
+				// Removing queues falls back to the default 0, i.e. not set on the disk.
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_disk" {
+					node_name     = "{{.NodeName}}"
+					started       = false
+					name          = "test-disk"
+					scsi_hardware = "virtio-scsi-single"
+
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi0"
+						size         = 8
+					}
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_disk", map[string]string{
+						"disk.0.queues": "0",
+					}),
+				),
+			},
+		}, nil},
+		{"queues on a non-scsi disk is rejected", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_disk" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-disk"
+
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "virtio0"
+						size         = 8
+						queues       = 4
+					}
+				}`),
+				ExpectError: regexp.MustCompile(`queues are only supported for SCSI disks`),
+			},
+		}, nil},
 	}
 
 	for _, tt := range tests {

--- a/proxmox/nodes/vms/custom_storage_device.go
+++ b/proxmox/nodes/vms/custom_storage_device.go
@@ -45,6 +45,7 @@ type CustomStorageDevice struct {
 	MaxReadSpeedMbps        *int              `json:"mbps_rd,omitempty"     url:"mbps_rd,omitempty"`
 	MaxWriteSpeedMbps       *int              `json:"mbps_wr,omitempty"     url:"mbps_wr,omitempty"`
 	Media                   *string           `json:"media,omitempty"       url:"media,omitempty"`
+	Queues                  *int              `json:"queues,omitempty"      url:"queues,omitempty"`
 	Replicate               *types.CustomBool `json:"replicate,omitempty"   url:"replicate,omitempty,int"`
 	Serial                  *string           `json:"serial,omitempty"      url:"serial,omitempty"`
 	Size                    *types.DiskSize   `json:"size,omitempty"        url:"size,omitempty"`
@@ -151,6 +152,10 @@ func (d *CustomStorageDevice) EncodeOptions() string {
 		} else {
 			values = append(values, "iothread=0")
 		}
+	}
+
+	if d.Queues != nil {
+		values = append(values, fmt.Sprintf("queues=%d", *d.Queues))
 	}
 
 	if d.Serial != nil && *d.Serial != "" {
@@ -316,6 +321,10 @@ func (d *CustomStorageDevice) UnmarshalJSON(b []byte) error {
 				}
 			case "media":
 				d.Media = &v[1]
+			case "queues":
+				if d.Queues, err = ptr.ParseIntPtr(v[1], "queues"); err != nil {
+					return err
+				}
 			case "replicate":
 				d.Replicate = types.CustomBool(v[1] == "1").Pointer()
 			case "serial":
@@ -358,6 +367,7 @@ func (d *CustomStorageDevice) MergeWith(m CustomStorageDevice) bool {
 	updated = ptr.UpdateIfChanged(&d.MaxIopsWrite, m.MaxIopsWrite) || updated
 	updated = ptr.UpdateIfChanged(&d.MaxReadSpeedMbps, m.MaxReadSpeedMbps) || updated
 	updated = ptr.UpdateIfChanged(&d.MaxWriteSpeedMbps, m.MaxWriteSpeedMbps) || updated
+	updated = ptr.UpdateIfChanged(&d.Queues, m.Queues) || updated
 	updated = ptr.UpdateIfChanged(&d.Replicate, m.Replicate) || updated
 	updated = ptr.UpdateIfChanged(&d.SSD, m.SSD) || updated
 	updated = ptr.UpdateIfChanged(&d.Serial, m.Serial) || updated
@@ -423,6 +433,7 @@ func (d *CustomStorageDevice) Equals(other *CustomStorageDevice) bool {
 		ptr.Eq(d.MaxIopsWrite, other.MaxIopsWrite) &&
 		ptr.Eq(d.MaxReadSpeedMbps, other.MaxReadSpeedMbps) &&
 		ptr.Eq(d.MaxWriteSpeedMbps, other.MaxWriteSpeedMbps) &&
+		ptr.Eq(d.Queues, other.Queues) &&
 		ptr.Eq(d.Replicate, other.Replicate) &&
 		ptr.Eq(d.Serial, other.Serial) &&
 		ptr.Eq(d.Size, other.Size) &&

--- a/proxmox/nodes/vms/custom_storage_device_test.go
+++ b/proxmox/nodes/vms/custom_storage_device_test.go
@@ -61,6 +61,16 @@ func TestCustomStorageDevice_UnmarshalJSON(t *testing.T) {
 				SSD:        types.CustomBool(true).Pointer(),
 			},
 		},
+		{
+			name: "volume with queues",
+			line: `"local-lvm:vm-2041-disk-0,iothread=1,queues=8,size=8G"`,
+			want: &CustomStorageDevice{
+				FileVolume: "local-lvm:vm-2041-disk-0",
+				IOThread:   types.CustomBool(true).Pointer(),
+				Queues:     new(8),
+				Size:       ds8gig,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/proxmoxtf/resource/vm/disk/disk.go
+++ b/proxmoxtf/resource/vm/disk/disk.go
@@ -188,6 +188,7 @@ func GetDiskDeviceObjects(
 		fileID, _ := block[mkDiskFileID].(string)
 		importFrom, _ := block[mkDiskImportFrom].(string)
 		ioThread := types.CustomBool(block[mkDiskIOThread].(bool))
+		queues, _ := block[mkDiskQueues].(int)
 		replicate := types.CustomBool(block[mkDiskReplicate].(bool))
 		serial := block[mkDiskSerial].(string)
 		size, _ := block[mkDiskSize].(int)
@@ -234,6 +235,18 @@ func GetDiskDeviceObjects(
 
 		if !strings.HasPrefix(diskInterface, "sata") && !strings.HasPrefix(diskInterface, "ide") {
 			diskDevice.IOThread = &ioThread
+		}
+
+		if queues > 0 {
+			// PVE accepts the queues option for SCSI drives only, and applies it
+			// only when scsi_hardware is virtio-scsi-single.
+			if !strings.HasPrefix(diskInterface, "scsi") {
+				return diskDeviceObjects, fmt.Errorf(
+					"disk queues are only supported for SCSI disks, but disk interface was %s", diskInterface,
+				)
+			}
+
+			diskDevice.Queues = &queues
 		}
 
 		if len(speedBlock) > 0 {
@@ -466,6 +479,12 @@ func Read(
 			disk[mkDiskIOThread] = false
 		}
 
+		if dd.Queues != nil {
+			disk[mkDiskQueues] = *dd.Queues
+		} else {
+			disk[mkDiskQueues] = 0
+		}
+
 		if dd.Replicate != nil {
 			disk[mkDiskReplicate] = *dd.Replicate
 		} else {
@@ -658,6 +677,11 @@ func Update(
 				tmp.AIO = disk.AIO
 			}
 
+			// PVE applies a queues change as a pending change, it takes effect at the next power cycle.
+			if !ptr.Eq(tmp.Queues, disk.Queues) {
+				rebootRequired = true
+			}
+
 			// Never re-import existing disks - import_from is only for initial disk creation.
 			// See https://github.com/bpg/terraform-provider-proxmox/issues/2385
 
@@ -673,6 +697,7 @@ func Update(
 			tmp.MaxIopsWrite = disk.MaxIopsWrite
 			tmp.MaxReadSpeedMbps = disk.MaxReadSpeedMbps
 			tmp.MaxWriteSpeedMbps = disk.MaxWriteSpeedMbps
+			tmp.Queues = disk.Queues
 			tmp.Replicate = disk.Replicate
 			tmp.Serial = disk.Serial
 			tmp.SSD = disk.SSD

--- a/proxmoxtf/resource/vm/disk/disk_test.go
+++ b/proxmoxtf/resource/vm/disk/disk_test.go
@@ -275,6 +275,17 @@ func TestDiskDevicesEqual(t *testing.T) {
 		DatastoreID: &datastore2,
 	}
 	require.True(t, disk1.Equals(disk2ImportFromNil))
+
+	// Test different queues
+	queues2Changed := 8
+	disk2QueuesChanged := &vms.CustomStorageDevice{
+		AIO:         &aio2,
+		Cache:       &cache2,
+		Size:        size2,
+		DatastoreID: &datastore2,
+		Queues:      &queues2Changed,
+	}
+	require.False(t, disk1.Equals(disk2QueuesChanged))
 }
 
 // TestDiskUpdateSkipsUnchangedDisks tests that the Update function only updates changed disks.
@@ -960,4 +971,85 @@ func TestDiskSpeedSettingsPerDisk(t *testing.T) {
 	require.Nil(t, scsi2.MaxWriteSpeedMbps, "scsi2 should NOT have MaxWriteSpeedMbps (empty speed block)")
 	require.Nil(t, scsi2.BurstableReadSpeedMbps, "scsi2 should NOT have BurstableReadSpeedMbps (empty speed block)")
 	require.Nil(t, scsi2.BurstableWriteSpeedMbps, "scsi2 should NOT have BurstableWriteSpeedMbps (empty speed block)")
+}
+
+// TestDiskQueuesSettings tests that the queues option is mapped for SCSI disks only.
+func TestDiskQueuesSettings(t *testing.T) {
+	t.Parallel()
+
+	diskSchema := Schema()
+	resource := &schema.Resource{Schema: diskSchema}
+
+	diskList := []any{
+		map[string]any{
+			mkDiskInterface:   "scsi0",
+			mkDiskDatastoreID: "local",
+			mkDiskSize:        50,
+			mkDiskAIO:         "io_uring",
+			mkDiskBackup:      true,
+			mkDiskCache:       "none",
+			mkDiskDiscard:     "ignore",
+			mkDiskIOThread:    true,
+			mkDiskQueues:      8,
+			mkDiskReplicate:   true,
+			mkDiskSerial:      "",
+			mkDiskSSD:         false,
+			mkDiskSpeed:       []any{},
+		},
+		map[string]any{
+			mkDiskInterface:   "scsi1",
+			mkDiskDatastoreID: "local",
+			mkDiskSize:        50,
+			mkDiskAIO:         "io_uring",
+			mkDiskBackup:      true,
+			mkDiskCache:       "none",
+			mkDiskDiscard:     "ignore",
+			mkDiskIOThread:    false,
+			mkDiskQueues:      0,
+			mkDiskReplicate:   true,
+			mkDiskSerial:      "",
+			mkDiskSSD:         false,
+			mkDiskSpeed:       []any{},
+		},
+	}
+
+	resourceData := schema.TestResourceDataRaw(t, diskSchema, map[string]any{
+		MkDisk: diskList,
+	})
+
+	diskDevices, err := GetDiskDeviceObjects(resourceData, resource, diskList)
+	require.NoError(t, err)
+	require.Len(t, diskDevices, 2)
+
+	scsi0 := diskDevices["scsi0"]
+	require.NotNil(t, scsi0)
+	require.NotNil(t, scsi0.Queues, "scsi0 should have Queues")
+	require.Equal(t, 8, *scsi0.Queues)
+
+	// queues=0 means "not set" and must not be sent to the API
+	scsi1 := diskDevices["scsi1"]
+	require.NotNil(t, scsi1)
+	require.Nil(t, scsi1.Queues, "scsi1 should NOT have Queues (queues=0)")
+
+	// queues on a non-SCSI disk must be rejected
+	virtioDiskList := []any{
+		map[string]any{
+			mkDiskInterface:   "virtio0",
+			mkDiskDatastoreID: "local",
+			mkDiskSize:        50,
+			mkDiskAIO:         "io_uring",
+			mkDiskBackup:      true,
+			mkDiskCache:       "none",
+			mkDiskDiscard:     "ignore",
+			mkDiskIOThread:    false,
+			mkDiskQueues:      4,
+			mkDiskReplicate:   true,
+			mkDiskSerial:      "",
+			mkDiskSSD:         false,
+			mkDiskSpeed:       []any{},
+		},
+	}
+
+	_, err = GetDiskDeviceObjects(resourceData, resource, virtioDiskList)
+	require.ErrorContains(t, err, "queues are only supported for SCSI disks")
 }

--- a/proxmoxtf/resource/vm/disk/schema.go
+++ b/proxmoxtf/resource/vm/disk/schema.go
@@ -43,6 +43,7 @@ const (
 	mkDiskIopsWriteBurstable  = "iops_write_burstable"
 	mkDiskIOThread            = "iothread"
 	mkDiskPathInDatastore     = "path_in_datastore"
+	mkDiskQueues              = "queues"
 	mkDiskReplicate           = "replicate"
 	mkDiskSerial              = "serial"
 	mkDiskSize                = "size"
@@ -74,6 +75,7 @@ func Schema() map[string]*schema.Schema {
 						mkDiskInterface:       dvDiskInterface,
 						mkDiskIOThread:        false,
 						mkDiskPathInDatastore: nil,
+						mkDiskQueues:          0,
 						mkDiskReplicate:       true,
 						mkDiskSerial:          "",
 						mkDiskSize:            dvDiskSize,
@@ -170,6 +172,19 @@ func Schema() map[string]*schema.Schema {
 						Description: "Whether to use iothreads for this disk drive",
 						Optional:    true,
 						Default:     false,
+					},
+					mkDiskQueues: {
+						Type: schema.TypeInt,
+						Description: "Number of I/O queues for this disk, requires SCSI interface " +
+							"and `virtio-scsi-single` SCSI controller",
+						Optional: true,
+						Default:  0,
+						ValidateDiagFunc: validation.ToDiagFunc(
+							validation.Any(
+								validation.IntInSlice([]int{0}),
+								validation.IntAtLeast(2),
+							),
+						),
 					},
 					mkDiskReplicate: {
 						Type:        schema.TypeBool,

--- a/proxmoxtf/resource/vm/disk/schema_test.go
+++ b/proxmoxtf/resource/vm/disk/schema_test.go
@@ -21,6 +21,7 @@ func TestVMSchema(t *testing.T) {
 		mkDiskFileFormat,
 		mkDiskFileID,
 		mkDiskImportFrom,
+		mkDiskQueues,
 		mkDiskSize,
 	})
 
@@ -36,6 +37,7 @@ func TestVMSchema(t *testing.T) {
 		mkDiskFileFormat:      schema.TypeString,
 		mkDiskFileID:          schema.TypeString,
 		mkDiskImportFrom:      schema.TypeString,
+		mkDiskQueues:          schema.TypeInt,
 		mkDiskSize:            schema.TypeInt,
 	})
 


### PR DESCRIPTION
### What does this PR do?

Adds an optional `queues` argument to the `disk` block of `proxmox_virtual_environment_vm` (SDK), mapped to the PVE per-disk `queues=<N>` option (virtio-scsi multiqueue).

VM SCSI disks are single-queue by default, so all disk completion IRQs land on one vCPU; on I/O-heavy workloads that core saturates while others idle. With `scsi_hardware = "virtio-scsi-single"` PVE passes `num_queues=<N>` to the per-disk controller, spreading disk IRQs across vCPUs.

```hcl
scsi_hardware = "virtio-scsi-single"

disk {
  interface = "scsi0"
  iothread  = true
  queues    = 8
}
```

Implementation follows PVE semantics:

- `queues` is accepted for SCSI disks only (PVE includes `%queues_fmt` only in `$scsi_fmt`); a non-SCSI interface with `queues` set fails fast at plan/apply with a clear error instead of a late PVE 400.
- Validated as `0` (unset, default) or `>= 2` (PVE schema minimum).
- Read back from the VM config, so out-of-band `qm set` changes show up as drift.
- A `queues` change marks the VM as reboot-required (PVE applies it as a pending change), same as `aio`.
- `CustomStorageDevice`: new `Queues *int` wired into `EncodeOptions`, `UnmarshalJSON`, `MergeWith` and `Equals`, so the value survives clone-update and disk-rewrite paths.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

Not a new resource / bug fix — this is an attribute addition to the existing SDK VM resource, covered by unit tests below. Happy to add a `queues` step to `TestAccResourceVMDisks` if you'd like it as part of this PR.

### Proof of Work

`make build` — OK; `make lint` — 0 issues; `make test` — all packages pass.

New/updated unit tests:

```text
=== RUN   TestCustomStorageDevice_UnmarshalJSON
=== RUN   TestCustomStorageDevice_UnmarshalJSON/volume_with_queues
--- PASS: TestCustomStorageDevice_UnmarshalJSON (0.00s)
ok      github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms    0.194s

=== RUN   TestDiskDevicesEqual
=== RUN   TestDiskQueuesSettings
=== RUN   TestVMSchema
--- PASS: TestDiskDevicesEqual (0.00s)
--- PASS: TestVMSchema (0.00s)
--- PASS: TestDiskQueuesSettings (0.00s)
ok      github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/disk   0.288s
```

Real-world usage (provider built from this branch via `dev_overrides`, plan against a production-like Proxmox 8 cluster config):

```text
  # proxmox_virtual_environment_vm.test_queues will be created
      + scsi_hardware = "virtio-scsi-single"
      + disk {
          + datastore_id      = "thin"
          + interface         = "scsi0"
          + iothread          = true
          + queues            = 4
          + size              = 25
          + ssd               = true
          ...
        }
Plan: 1 to add, 0 to change, 0 to destroy.
```

Schema validation rejects invalid values:

```text
│ Error: expected queues to be at least (2), got 1
```

Runtime verification — the configuration above applied to a real Proxmox VE 8 cluster (`terragrunt apply`, provider built from this branch). VM created cleanly, no agent-wait hang with `virtio-scsi-single` + `agent.enabled = true`.

Resulting VM config on the PVE side (via API, `/nodes/<node>/qemu/237/config`):

```text
scsihw: virtio-scsi-single
scsi0:  thin:vm-237-disk-0,aio=io_uring,backup=1,cache=none,discard=on,iothread=1,queues=4,replicate=1,size=25G,ssd=1
cores:  4
```

Inside the guest — 4 I/O queues instead of the default single queue, completion IRQs spread across all 4 vCPUs:

```text
$ ls /sys/block/sda/mq/
0  1  2  3

$ lspci | grep -i scsi
01:01.0 SCSI storage controller: Red Hat, Inc. Virtio SCSI   # dedicated per-disk controller

$ grep 'virtio.*request' /proc/interrupts
 27:   1052      0      0      0   PCI-MSI 540675-edge   virtio2-request
 28:      0    811      0      0   PCI-MSI 540676-edge   virtio2-request
 29:      0      0   1956      0   PCI-MSI 540677-edge   virtio2-request
 30:      0      0      0   1599   PCI-MSI 540678-edge   virtio2-request
```

A follow-up `terraform plan` after apply shows no drift — the value is read back from the VM config correctly.

Closes #2930
