### PR TITLE
fix(vm)!: restore ipv4_addresses on refresh for existing VMs

### DIFF
--- a/docs/guides/upgrade.md
+++ b/docs/guides/upgrade.md
@@ -3,7 +3,7 @@ layout: page
 page_title: "Upgrade Guide"
 subcategory: Guides
 description: |-
-    Breaking changes and migration steps across provider versions.
+  Breaking changes and migration steps across provider versions.
 ---
 
 # Upgrade Guide
@@ -36,6 +36,38 @@ This guide documents breaking changes across provider versions and the recommend
 6. Apply when satisfied.
 
 -> **Tip:** Upgrade one minor version at a time when crossing multiple breaking changes. This makes it easier to isolate issues.
+
+## v0.109.0
+
+### `vm` `agent.wait_for_ip.enabled` replaced by `agent.wait_for_ip.disabled`
+
+The `agent.wait_for_ip.enabled` attribute on `proxmox_virtual_environment_vm` (introduced in v0.108.0) has been replaced by `agent.wait_for_ip.disabled` with inverted semantics. The previous attribute defaulted to `true`, which caused `ipv4_addresses`, `ipv6_addresses`, and `network_interface_names` to become empty on `refresh`/`plan` for VMs created before v0.108.0: their stored state had no value for the new switch, so it read back as `false` ("disabled") and the provider skipped the agent IP lookup.
+
+**Before (v0.108.0):**
+
+```terraform
+agent {
+  enabled = true
+  wait_for_ip {
+    enabled = false # skip the agent IP lookup
+  }
+}
+```
+
+**After (v0.109.0):**
+
+```terraform
+agent {
+  enabled = true
+  wait_for_ip {
+    disabled = true # skip the agent IP lookup
+  }
+}
+```
+
+The new switch defaults to `false` (do not skip), so its zero value preserves the original behavior — VMs upgraded from any earlier version keep reading IP addresses from the guest agent without any configuration change.
+
+**Action required:** Only if you set `wait_for_ip.enabled = false` (added in v0.108.0). Replace it with `wait_for_ip.disabled = true`. The stale `enabled` value in state is dropped automatically. If you never set `wait_for_ip.enabled`, no action is needed and the `ipv4_addresses`/`ipv6_addresses` regression is resolved.
 
 ## v0.102.0
 
@@ -121,7 +153,7 @@ All existing Framework resources now have shorter aliases using the `proxmox_` p
 Examples of the new short names:
 
 | Old name                                           | New name                       |
-|----------------------------------------------------|--------------------------------|
+| -------------------------------------------------- | ------------------------------ |
 | `proxmox_virtual_environment_vm2` (resource)       | `proxmox_vm`                   |
 | `proxmox_virtual_environment_download_file`        | `proxmox_download_file`        |
 | `proxmox_virtual_environment_network_linux_bridge` | `proxmox_network_linux_bridge` |
@@ -310,9 +342,9 @@ The deprecated `vga.enabled` attribute was removed from the `proxmox_virtual_env
 
 ## Earlier versions
 
-| Version | Breaking change | Action |
-| ------- | --------------- | ------ |
-| v0.48.0 | File snippets now upload via SSH input stream instead of SCP | No config change; ensure SSH connectivity to nodes |
-| v0.40.0 | LXC `features` block is now updatable; mount type support added | Review LXC `features` blocks — previously ignored updates now apply |
-| v0.4.0 | `disk.interface` is now required | Add `interface` to all `disk` blocks |
-| v0.2.0 | `cloud_init` renamed to `initialization`; `os_type` renamed to `operating_system.type` | Rename attributes in configuration |
+| Version | Breaking change                                                                        | Action                                                              |
+| ------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| v0.48.0 | File snippets now upload via SSH input stream instead of SCP                           | No config change; ensure SSH connectivity to nodes                  |
+| v0.40.0 | LXC `features` block is now updatable; mount type support added                        | Review LXC `features` blocks — previously ignored updates now apply |
+| v0.4.0  | `disk.interface` is now required                                                       | Add `interface` to all `disk` blocks                                |
+| v0.2.0  | `cloud_init` renamed to `initialization`; `os_type` renamed to `operating_system.type` | Rename attributes in configuration                                  |

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -138,11 +138,11 @@ output "ubuntu_vm_public_key" {
         - `isa` - ISA Serial Port.
         - `virtio` - VirtIO (paravirtualized).
     - `wait_for_ip` - (Optional) Configuration for waiting for specific IP address types when the VM starts.
-        - `enabled` - (Optional) Whether to wait for the agent to report an IP address (defaults to `true`). Set to `false` to disable the IP lookup entirely, so the provider does not wait for the agent during `refresh` and at the end of `apply`. Useful when the guest agent is slow to start, not yet installed, or not running, to avoid blocking those operations. When disabled, `ipv4_addresses`, `ipv6_addresses`, and `network_interface_names` are left empty.
+        - `disabled` - (Optional) Whether to disable waiting for the agent to report an IP address (defaults to `false`). Set to `true` to skip the IP lookup entirely, so the provider does not wait for the agent during `refresh` and at the end of `apply`. Useful when the guest agent is slow to start, not yet installed, or not running, to avoid blocking those operations. When disabled, `ipv4_addresses`, `ipv6_addresses`, and `network_interface_names` are left empty.
         - `ipv4` - (Optional) Wait for at least one IPv4 address (non-loopback, non-link-local) (defaults to `false`).
         - `ipv6` - (Optional) Wait for at least one IPv6 address (non-loopback, non-link-local) (defaults to `false`).
 
-        When `wait_for_ip` is not specified or both `ipv4` and `ipv6` are `false` (and `enabled` is `true`), the provider waits for any valid global unicast address (IPv4 or IPv6). In dual-stack networks where DHCPv6 responds faster, this may result in only IPv6 addresses being available. Set `ipv4 = true` to ensure IPv4 address availability.
+        When `wait_for_ip` is not specified or both `ipv4` and `ipv6` are `false` (and `disabled` is `false`), the provider waits for any valid global unicast address (IPv4 or IPv6). In dual-stack networks where DHCPv6 responds faster, this may result in only IPv6 addresses being available. Set `ipv4 = true` to ensure IPv4 address availability.
 - `amd_sev` - (Optional) Secure Encrypted Virtualization (SEV) features by AMD CPUs.
     - `type` - (Optional) Enable standard SEV with `std` or enable experimental SEV-ES with the `es` option or enable experimental SEV-SNP with the `snp` option (defaults to `std`).
     - `allow_smt` - (Optional) Sets policy bit to allow Simultaneous Multi Threading (SMT)

--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -1389,7 +1389,7 @@ func TestAccResourceVMNetwork(t *testing.T) {
 				agent {
 					enabled = true
 					wait_for_ip {
-						enabled = false
+						disabled = true
 					}
 				}
 				cpu {
@@ -1419,13 +1419,13 @@ func TestAccResourceVMNetwork(t *testing.T) {
 				}
 			}`),
 			Check: resource.ComposeTestCheckFunc(
-				// wait_for_ip.enabled = false: the provider skips the agent IP lookup, so the
+				// wait_for_ip.disabled = true: the provider skips the agent IP lookup, so the
 				// address attributes stay empty even though the guest agent is running.
 				ResourceAttributes("proxmox_virtual_environment_vm.test_vm_no_wait", map[string]string{
-					"agent.0.wait_for_ip.0.enabled": "false",
-					"ipv4_addresses.#":              "0",
-					"ipv6_addresses.#":              "0",
-					"network_interface_names.#":     "0",
+					"agent.0.wait_for_ip.0.disabled": "true",
+					"ipv4_addresses.#":               "0",
+					"ipv6_addresses.#":               "0",
+					"network_interface_names.#":      "0",
 				}),
 			),
 		}}},

--- a/proxmoxtf/resource/vm/agent_test.go
+++ b/proxmoxtf/resource/vm/agent_test.go
@@ -10,14 +10,17 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
 )
 
-// TestVMAgentWaitForIPEnabledSchema verifies the agent.wait_for_ip block exposes an
-// `enabled` master switch that defaults to true (waiting stays the default behavior).
-func TestVMAgentWaitForIPEnabledSchema(t *testing.T) {
+// TestVMAgentWaitForIPDisabledSchema verifies the agent.wait_for_ip block exposes a `disabled`
+// master switch that defaults to false (waiting stays the default behavior). The switch is phrased
+// so its zero value means "do not skip", which keeps VMs upgraded from older provider versions —
+// whose stored state lacks the key — querying the agent (see #2928).
+func TestVMAgentWaitForIPDisabledSchema(t *testing.T) {
 	t.Parallel()
 
 	agentBlock, ok := VM().Schema[mkAgent].Elem.(*schema.Resource)
@@ -26,10 +29,42 @@ func TestVMAgentWaitForIPEnabledSchema(t *testing.T) {
 	waitForIP, ok := agentBlock.Schema[mkAgentWaitForIP].Elem.(*schema.Resource)
 	require.True(t, ok, "wait_for_ip block must be a *schema.Resource")
 
-	enabled, ok := waitForIP.Schema[mkAgentWaitForIPEnabled]
-	require.True(t, ok, "wait_for_ip must expose an `enabled` attribute")
-	require.Equal(t, schema.TypeBool, enabled.Type)
-	require.Equal(t, true, enabled.Default, "wait_for_ip.enabled must default to true")
+	disabled, ok := waitForIP.Schema[mkAgentWaitForIPDisabled]
+	require.True(t, ok, "wait_for_ip must expose a `disabled` attribute")
+	require.Equal(t, schema.TypeBool, disabled.Type)
+	require.Equal(t, false, disabled.Default, "wait_for_ip.disabled must default to false")
+}
+
+// TestVMAgentWaitForIPConfigUpgradedStateDoesNotSkip reproduces #2928: a VM whose state was
+// written by a provider version predating the wait_for_ip master switch has a wait_for_ip block
+// with no explicit switch value. The SDK reads that absent bool back as its zero value, so the
+// read path must not interpret it as "skip" — otherwise ipv4_addresses/ipv6_addresses become
+// null on refresh for every existing VM.
+func TestVMAgentWaitForIPConfigUpgradedStateDoesNotSkip(t *testing.T) {
+	t.Parallel()
+
+	// Simulate state stored by a provider version predating the wait_for_ip master switch: the
+	// wait_for_ip block exists (ipv4 = true) but the flatmap has no switch key. Building
+	// ResourceData straight from the InstanceState mirrors the refresh read path, where Terraform
+	// core feeds stored state without applying schema defaults.
+	is := &terraform.InstanceState{
+		ID: "100",
+		Attributes: map[string]string{
+			"agent.#":                    "1",
+			"agent.0.enabled":            "true",
+			"agent.0.wait_for_ip.#":      "1",
+			"agent.0.wait_for_ip.0.ipv4": "true",
+		},
+	}
+
+	d := VM().Data(is)
+
+	cfg := getAgentWaitForIPConfig(d)
+
+	require.NotNil(t, cfg)
+	require.False(t, cfg.Skip,
+		"agent IP lookup must not be skipped for VMs upgraded from a provider without the wait_for_ip master switch")
+	require.True(t, cfg.IPv4)
 }
 
 // TestAgentWaitForIPConfigFromBlock verifies the wait_for_ip block is translated into the
@@ -43,27 +78,27 @@ func TestAgentWaitForIPConfigFromBlock(t *testing.T) {
 		want  *vms.WaitForIPConfig
 	}{
 		{
-			name:  "enabled false -> skip",
-			block: map[string]any{mkAgentWaitForIPEnabled: false},
+			name:  "disabled true -> skip",
+			block: map[string]any{mkAgentWaitForIPDisabled: true},
 			want:  &vms.WaitForIPConfig{Skip: true},
 		},
 		{
-			name:  "enabled true, no family -> wait for any (nil)",
-			block: map[string]any{mkAgentWaitForIPEnabled: true},
+			name:  "disabled false, no family -> wait for any (nil)",
+			block: map[string]any{mkAgentWaitForIPDisabled: false},
 			want:  nil,
 		},
 		{
-			name:  "enabled true, ipv4 -> wait for ipv4",
-			block: map[string]any{mkAgentWaitForIPEnabled: true, mkAgentWaitForIPIPv4: true},
+			name:  "disabled false, ipv4 -> wait for ipv4",
+			block: map[string]any{mkAgentWaitForIPDisabled: false, mkAgentWaitForIPIPv4: true},
 			want:  &vms.WaitForIPConfig{IPv4: true},
 		},
 		{
-			name:  "enabled false wins over family",
-			block: map[string]any{mkAgentWaitForIPEnabled: false, mkAgentWaitForIPIPv4: true},
+			name:  "disabled true wins over family",
+			block: map[string]any{mkAgentWaitForIPDisabled: true, mkAgentWaitForIPIPv4: true},
 			want:  &vms.WaitForIPConfig{Skip: true},
 		},
 		{
-			name:  "enabled absent defaults to wait (backward compat)",
+			name:  "disabled absent (zero value) defaults to wait -> #2928 upgraded state",
 			block: map[string]any{mkAgentWaitForIPIPv4: true},
 			want:  &vms.WaitForIPConfig{IPv4: true},
 		},

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -44,40 +44,40 @@ import (
 )
 
 const (
-	dvRebootAfterCreation   = false
-	dvRebootAfterUpdate     = true
-	dvOnBoot                = true
-	dvACPI                  = true
-	dvAgentEnabled          = false
-	dvAgentTimeout          = "15m"
-	dvAgentTrim             = false
-	dvAgentType             = "virtio"
-	dvAgentWaitForIPEnabled = true
-	dvAMDSEVType            = "std"
-	dvAMDSEVAllowSMT        = true
-	dvAMDSEVKernelHashes    = false
-	dvAMDSEVNoDebug         = false
-	dvAMDSEVNoKeySharing    = false
-	dvAudioDeviceDevice     = "intel-hda"
-	dvAudioDeviceDriver     = "spice"
-	dvAudioDeviceEnabled    = true
-	dvBIOS                  = "seabios"
-	dvCDROMEnabled          = false
-	dvCDROMFileID           = ""
-	dvCDROMInterface        = "ide3"
-	dvCloneDatastoreID      = ""
-	dvCloneNodeName         = ""
-	dvCloneFull             = true
-	dvCloneRetries          = 1
-	dvCPUArchitecture       = ""
-	dvCPUCores              = 1
-	dvCPUHotplugged         = 0
-	dvCPULimit              = float64(0)
-	dvCPUNUMA               = false
-	dvCPUSockets            = 1
-	dvCPUType               = "qemu64"
-	dvCPUAffinity           = ""
-	dvDescription           = ""
+	dvRebootAfterCreation    = false
+	dvRebootAfterUpdate      = true
+	dvOnBoot                 = true
+	dvACPI                   = true
+	dvAgentEnabled           = false
+	dvAgentTimeout           = "15m"
+	dvAgentTrim              = false
+	dvAgentType              = "virtio"
+	dvAgentWaitForIPDisabled = false
+	dvAMDSEVType             = "std"
+	dvAMDSEVAllowSMT         = true
+	dvAMDSEVKernelHashes     = false
+	dvAMDSEVNoDebug          = false
+	dvAMDSEVNoKeySharing     = false
+	dvAudioDeviceDevice      = "intel-hda"
+	dvAudioDeviceDriver      = "spice"
+	dvAudioDeviceEnabled     = true
+	dvBIOS                   = "seabios"
+	dvCDROMEnabled           = false
+	dvCDROMFileID            = ""
+	dvCDROMInterface         = "ide3"
+	dvCloneDatastoreID       = ""
+	dvCloneNodeName          = ""
+	dvCloneFull              = true
+	dvCloneRetries           = 1
+	dvCPUArchitecture        = ""
+	dvCPUCores               = 1
+	dvCPUHotplugged          = 0
+	dvCPULimit               = float64(0)
+	dvCPUNUMA                = false
+	dvCPUSockets             = 1
+	dvCPUType                = "qemu64"
+	dvCPUAffinity            = ""
+	dvDescription            = ""
 
 	// dvHotplug is the Proxmox VE default hotplug value.
 	// When hotplug is not explicitly configured, PVE uses "network,disk,usb".
@@ -159,53 +159,53 @@ const (
 	maxResourceVirtualEnvironmentVMNUMADevices  = 8
 	maxResourceVirtualEnvironmentVirtiofsShares = 8
 
-	mkRebootAfterCreation   = "reboot"
-	mkRebootAfterUpdate     = "reboot_after_update"
-	mkOnBoot                = "on_boot"
-	mkBootOrder             = "boot_order"
-	mkACPI                  = "acpi"
-	mkAgent                 = "agent"
-	mkAgentEnabled          = "enabled"
-	mkAgentTimeout          = "timeout"
-	mkAgentTrim             = "trim"
-	mkAgentType             = "type"
-	mkAgentWaitForIP        = "wait_for_ip"
-	mkAgentWaitForIPEnabled = "enabled"
-	mkAgentWaitForIPIPv4    = "ipv4"
-	mkAgentWaitForIPIPv6    = "ipv6"
-	mkAMDSEV                = "amd_sev"
-	mkAMDSEVType            = "type"
-	mkAMDSEVAllowSMT        = "allow_smt"
-	mkAMDSEVKernelHashes    = "kernel_hashes"
-	mkAMDSEVNoDebug         = "no_debug"
-	mkAMDSEVNoKeySharing    = "no_key_sharing"
-	mkAudioDevice           = "audio_device"
-	mkAudioDeviceDevice     = "device"
-	mkAudioDeviceDriver     = "driver"
-	mkAudioDeviceEnabled    = "enabled"
-	mkBIOS                  = "bios"
-	mkCDROM                 = "cdrom"
-	mkCDROMEnabled          = "enabled"
-	mkCDROMFileID           = "file_id"
-	mkCDROMInterface        = "interface"
-	mkClone                 = "clone"
-	mkCloneRetries          = "retries"
-	mkCloneDatastoreID      = "datastore_id"
-	mkCloneNodeName         = "node_name"
-	mkCloneVMID             = "vm_id"
-	mkCloneFull             = "full"
-	mkCPU                   = "cpu"
-	mkCPUArchitecture       = "architecture"
-	mkCPUCores              = "cores"
-	mkCPUFlags              = "flags"
-	mkCPUHotplugged         = "hotplugged"
-	mkCPULimit              = "limit"
-	mkCPUNUMA               = "numa"
-	mkCPUSockets            = "sockets"
-	mkCPUType               = "type"
-	mkCPUUnits              = "units"
-	mkCPUAffinity           = "affinity"
-	mkDescription           = "description"
+	mkRebootAfterCreation    = "reboot"
+	mkRebootAfterUpdate      = "reboot_after_update"
+	mkOnBoot                 = "on_boot"
+	mkBootOrder              = "boot_order"
+	mkACPI                   = "acpi"
+	mkAgent                  = "agent"
+	mkAgentEnabled           = "enabled"
+	mkAgentTimeout           = "timeout"
+	mkAgentTrim              = "trim"
+	mkAgentType              = "type"
+	mkAgentWaitForIP         = "wait_for_ip"
+	mkAgentWaitForIPDisabled = "disabled"
+	mkAgentWaitForIPIPv4     = "ipv4"
+	mkAgentWaitForIPIPv6     = "ipv6"
+	mkAMDSEV                 = "amd_sev"
+	mkAMDSEVType             = "type"
+	mkAMDSEVAllowSMT         = "allow_smt"
+	mkAMDSEVKernelHashes     = "kernel_hashes"
+	mkAMDSEVNoDebug          = "no_debug"
+	mkAMDSEVNoKeySharing     = "no_key_sharing"
+	mkAudioDevice            = "audio_device"
+	mkAudioDeviceDevice      = "device"
+	mkAudioDeviceDriver      = "driver"
+	mkAudioDeviceEnabled     = "enabled"
+	mkBIOS                   = "bios"
+	mkCDROM                  = "cdrom"
+	mkCDROMEnabled           = "enabled"
+	mkCDROMFileID            = "file_id"
+	mkCDROMInterface         = "interface"
+	mkClone                  = "clone"
+	mkCloneRetries           = "retries"
+	mkCloneDatastoreID       = "datastore_id"
+	mkCloneNodeName          = "node_name"
+	mkCloneVMID              = "vm_id"
+	mkCloneFull              = "full"
+	mkCPU                    = "cpu"
+	mkCPUArchitecture        = "architecture"
+	mkCPUCores               = "cores"
+	mkCPUFlags               = "flags"
+	mkCPUHotplugged          = "hotplugged"
+	mkCPULimit               = "limit"
+	mkCPUNUMA                = "numa"
+	mkCPUSockets             = "sockets"
+	mkCPUType                = "type"
+	mkCPUUnits               = "units"
+	mkCPUAffinity            = "affinity"
+	mkDescription            = "description"
 
 	mkNUMA              = "numa"
 	mkNUMADevice        = "device"
@@ -425,11 +425,11 @@ func VM() *schema.Resource {
 						MinItems:    0,
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{
-								mkAgentWaitForIPEnabled: {
+								mkAgentWaitForIPDisabled: {
 									Type:        schema.TypeBool,
-									Description: "Whether to wait for the agent to report an IP address; set to false to skip the lookup entirely",
+									Description: "Disable waiting for the agent to report an IP address; set to true to skip the lookup entirely",
 									Optional:    true,
-									Default:     dvAgentWaitForIPEnabled,
+									Default:     dvAgentWaitForIPDisabled,
 								},
 								mkAgentWaitForIPIPv4: {
 									Type:        schema.TypeBool,
@@ -4226,12 +4226,12 @@ func getStringFromBlock(block map[string]any, key string, defaultValue string) s
 	return defaultValue
 }
 
-func getBoolFromBlock(block map[string]any, key string, defaultValue bool) bool {
+func getBoolFromBlock(block map[string]any, key string) bool {
 	if val, ok := block[key].(bool); ok {
 		return val
 	}
 
-	return defaultValue
+	return false
 }
 
 // hotplugContains checks whether a specific feature is enabled in a hotplug setting string.
@@ -6399,7 +6399,7 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 
 		oldCPUType := getStringFromBlock(oldCPUBlock, mkCPUType, "")
 		oldCPUArchitecture := getStringFromBlock(oldCPUBlock, mkCPUArchitecture, "")
-		oldCPUNUMA := getBoolFromBlock(oldCPUBlock, mkCPUNUMA, false)
+		oldCPUNUMA := getBoolFromBlock(oldCPUBlock, mkCPUNUMA)
 
 		// Only vcpus (hotplugged) changes are hotpluggable for CPU, and only when
 		// "cpu" is in the VM's hotplug setting. Changing cores or sockets always requires a reboot.
@@ -7599,15 +7599,17 @@ func getAgentWaitForIPConfig(d *schema.ResourceData) *vms.WaitForIPConfig {
 }
 
 // agentWaitForIPConfigFromBlock translates a wait_for_ip block into a WaitForIPConfig.
-// enabled=false disables the agent IP wait entirely (Skip); otherwise nil means "wait for any".
+// disabled=true disables the agent IP wait entirely (Skip); otherwise nil means "wait for any".
+// The switch defaults to false (do not skip) so that state written before the switch existed —
+// where the key reads back as its zero value — keeps querying the agent (see #2928).
 func agentWaitForIPConfigFromBlock(block map[string]any) *vms.WaitForIPConfig {
-	if !getBoolFromBlock(block, mkAgentWaitForIPEnabled, true) {
+	if getBoolFromBlock(block, mkAgentWaitForIPDisabled) {
 		return &vms.WaitForIPConfig{Skip: true}
 	}
 
 	config := &vms.WaitForIPConfig{
-		IPv4: getBoolFromBlock(block, mkAgentWaitForIPIPv4, false),
-		IPv6: getBoolFromBlock(block, mkAgentWaitForIPIPv6, false),
+		IPv4: getBoolFromBlock(block, mkAgentWaitForIPIPv4),
+		IPv6: getBoolFromBlock(block, mkAgentWaitForIPIPv6),
 	}
 
 	// if both are false, return nil for backward compatibility (wait for any)


### PR DESCRIPTION
### What does this PR do?

Since v0.108.0, `proxmox_virtual_environment_vm.ipv4_addresses` (and `ipv6_addresses` / `network_interface_names`) became `null` on `refresh`/`plan` for VMs that already existed in state, even with a working guest agent — breaking any configuration that references those computed attributes.

The regression came from the `agent.wait_for_ip.enabled` switch added in v0.108.0. It defaults to `true`, but the SDK applies schema defaults only when diffing config — never when reading stored state. VMs whose state predates the switch had no value for it, so the read path saw the bool's zero value (`false`), interpreted it as "disabled", and skipped the agent IP lookup.

The fix inverts the switch: `wait_for_ip.enabled` (default `true`) is replaced by `wait_for_ip.disabled` (default `false`). Now the zero value read from older state means "do not skip", so existing VMs keep querying the agent with no config change, while an explicit `disabled = true` is honored at both refresh and apply (it is stored as `true`, which never collides with a zero value).

### Usage Example

```hcl
resource "proxmox_virtual_environment_vm" "example" {
  node_name = "pve"
  # ...

  agent {
    enabled = true
    wait_for_ip {
      disabled = true # skip the agent IP lookup entirely (was: enabled = false)
    }
  }
}
```

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

#### ⚠ BREAKING CHANGES

The `agent.wait_for_ip.enabled` attribute (introduced in v0.108.0) is removed and replaced by `agent.wait_for_ip.disabled` with inverted semantics.

- **Before (v0.108.0):** `wait_for_ip { enabled = false }` to skip the agent IP lookup.
- **After:** `wait_for_ip { disabled = true }` to skip the agent IP lookup.

**Action required:** only for users who set `wait_for_ip.enabled = false` in v0.108.0 — replace it with `wait_for_ip.disabled = true`. The stale `enabled` value in state is dropped automatically; absent `disabled` reads as `false`, which restores the pre-0.108 behavior. Users who never set `enabled` need no changes and get the regression fixed. See [docs/guides/upgrade.md](docs/guides/upgrade.md).

### Proof of Work

**Regression reproduction (unit, RED → GREEN).** `TestVMAgentWaitForIPConfigUpgradedStateDoesNotSkip` builds `ResourceData` directly from a flatmap `terraform.InstanceState` lacking the switch key — the faithful refresh-read path (Terraform core feeds stored state without applying schema defaults). It fails on the unfixed code (`cfg.Skip == true`, reproducing the bug) and passes after the fix.

```
$ go test ./proxmoxtf/resource/vm/ -run 'TestVMAgentWaitForIP|TestAgentWaitForIPConfigFromBlock' -v
--- PASS: TestVMAgentWaitForIPDisabledSchema
--- PASS: TestVMAgentWaitForIPConfigUpgradedStateDoesNotSkip
--- PASS: TestAgentWaitForIPConfigFromBlock
    --- PASS: .../disabled_true_->_skip
    --- PASS: .../disabled_false,_no_family_->_wait_for_any_(nil)
    --- PASS: .../disabled_false,_ipv4_->_wait_for_ipv4
    --- PASS: .../disabled_true_wins_over_family
    --- PASS: .../disabled_absent_(zero_value)_defaults_to_wait_->_#2928_upgraded_state
    --- PASS: .../empty_block_waits_for_any_(nil)
ok  github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm
```

**Acceptance test.** Full clean run of `TestAccResourceVMNetwork`, including `disable_agent_IP_wait` (updated to the new `wait_for_ip { disabled = true }`):

```
$ ./testacc TestAccResourceVMNetwork -- -v
--- PASS: TestAccResourceVMNetwork (7.29s)
    --- PASS: TestAccResourceVMNetwork/remove_network_device (3.79s)
    --- PASS: TestAccResourceVMNetwork/network_device_disconnected (3.82s)
    --- PASS: TestAccResourceVMNetwork/network_device_state_consistency (5.38s)
    --- PASS: TestAccResourceVMNetwork/multiple_network_devices_removal (4.46s)
    --- PASS: TestAccResourceVMNetwork/disable_agent_IP_wait (18.36s)
    --- PASS: TestAccResourceVMNetwork/wait_for_IPv4_address (42.24s)
    --- PASS: TestAccResourceVMNetwork/network_interfaces (46.51s)
ok  github.com/bpg/terraform-provider-proxmox/fwprovider/test  54.321s
```

`disable_agent_IP_wait` asserts `ipv4_addresses.# = 0` / `ipv6_addresses.# = 0` / `network_interface_names.# = 0` while the guest agent runs (skip path), and the default path populates `ipv4_addresses` from the agent (`172.17.223.253` observed).

**Before / after.** Before: on a VM created with v0.107.0 and a `wait_for_ip` block, upgrading to v0.108.0 made `plan` report `ipv4_addresses` as `null` and a phantom `wait_for_ip.enabled = false -> true` diff. After: the agent IP lookup runs on refresh and the addresses stay populated, with no spurious diff.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2928

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.8). All changes have been reviewed and verified by a human.*
