### PR TITLE
feat(file): add ImportState to `proxmox_virtual_environment_download_file`

### DIFF
--- a/docs/resources/download_file.md
+++ b/docs/resources/download_file.md
@@ -113,3 +113,13 @@ resource "proxmox_download_file" "latest_ubuntu_22_jammy_lxc_img" {
 
 - `id` (String) The unique identifier of this resource.
 - `size` (Number) The file size in PVE.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+#!/usr/bin/env sh
+# A download file can be imported using its identifier in the format: node_name/datastore_id:content_type/file_name, e.g.:
+terraform import proxmox_download_file.ubuntu_iso pve/local:iso/ubuntu-24.04-server.iso
+```

--- a/docs/resources/virtual_environment_download_file.md
+++ b/docs/resources/virtual_environment_download_file.md
@@ -115,3 +115,13 @@ resource "proxmox_virtual_environment_download_file" "latest_ubuntu_22_jammy_lxc
 
 - `id` (String) The unique identifier of this resource.
 - `size` (Number) The file size in PVE.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+#!/usr/bin/env sh
+# A download file can be imported using its identifier in the format: node_name/datastore_id:content_type/file_name, e.g.:
+terraform import proxmox_virtual_environment_download_file.ubuntu_iso pve/local:iso/ubuntu-24.04-server.iso
+```

--- a/examples/resources/proxmox_download_file/import.sh
+++ b/examples/resources/proxmox_download_file/import.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+# A download file can be imported using its identifier in the format: node_name/datastore_id:content_type/file_name, e.g.:
+terraform import proxmox_download_file.ubuntu_iso pve/local:iso/ubuntu-24.04-server.iso

--- a/examples/resources/proxmox_virtual_environment_download_file/import.sh
+++ b/examples/resources/proxmox_virtual_environment_download_file/import.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+# A download file can be imported using its identifier in the format: node_name/datastore_id:content_type/file_name, e.g.:
+terraform import proxmox_virtual_environment_download_file.ubuntu_iso pve/local:iso/ubuntu-24.04-server.iso

--- a/fwprovider/nodes/resource_download_file.go
+++ b/fwprovider/nodes/resource_download_file.go
@@ -737,9 +737,14 @@ func (r *downloadFileResource) ImportState(
 
 	id := datastoreID + ":" + filePart
 
-	if nodeName != "" {
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("node_name"), nodeName)...)
+	if nodeName == "" {
+		resp.Diagnostics.AddError(
+			"Missing Node Name in Import Identifier",
+			fmt.Sprintf("The node name is required for import. Expected format: node_name:datastore_id:content_type/file_name. Got: %q", req.ID),
+		)
+		return
 	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("node_name"), nodeName)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("datastore_id"), datastoreID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("content_type"), contentType)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("file_name"), fileName)...)

--- a/fwprovider/nodes/resource_download_file.go
+++ b/fwprovider/nodes/resource_download_file.go
@@ -41,9 +41,10 @@ import (
 )
 
 var (
-	_         resource.Resource              = &downloadFileResource{}
-	_         resource.ResourceWithConfigure = &downloadFileResource{}
-	httpRegex                                = regexp.MustCompile(`https?://.*`)
+	_         resource.Resource                = &downloadFileResource{}
+	_         resource.ResourceWithConfigure   = &downloadFileResource{}
+	_         resource.ResourceWithImportState = &downloadFileResource{}
+	httpRegex                                  = regexp.MustCompile(`https?://.*`)
 )
 
 type sizeRequiresReplaceModifier struct{}
@@ -685,4 +686,62 @@ func isErrFileAlreadyExists(err error) bool {
 	}
 
 	return strings.Contains(err.Error(), "refusing to override existing file")
+}
+
+// ImportState imports a download file resource by its identifier.
+func (r *downloadFileResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
+	// Accept either node_name:datastore_id:content_type/file_name or datastore_id:content_type/file_name
+	parts := strings.SplitN(req.ID, ":", 3)
+
+	var nodeName, datastoreID, filePart string
+
+	if len(parts) == 3 {
+		nodeName = parts[0]
+		datastoreID = parts[1]
+		filePart = parts[2]
+	} else if len(parts) == 2 {
+		// Try parsing as node/datastore_id:content_type/file_name for backward compatibility
+		slashParts := strings.SplitN(parts[0], "/", 2)
+		if len(slashParts) == 2 {
+			nodeName = slashParts[0]
+			datastoreID = slashParts[1]
+			filePart = parts[1]
+		} else {
+			// Tests and newer TF import block might use datastore_id:content_type/file_name
+			datastoreID = parts[0]
+			filePart = parts[1]
+		}
+	} else {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected import identifier with format: node_name:datastore_id:content_type/file_name. Got: %q", req.ID),
+		)
+		return
+	}
+
+	fileParts := strings.SplitN(filePart, "/", 2)
+	if len(fileParts) != 2 {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected import identifier with format: content_type/file_name in the file part. Got: %q", filePart),
+		)
+		return
+	}
+
+	contentType := fileParts[0]
+	fileName := fileParts[1]
+
+	id := datastoreID + ":" + filePart
+
+	if nodeName != "" {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("node_name"), nodeName)...)
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("datastore_id"), datastoreID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("content_type"), contentType)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("file_name"), fileName)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/fwprovider/nodes/resource_download_file.go
+++ b/fwprovider/nodes/resource_download_file.go
@@ -688,62 +688,45 @@ func isErrFileAlreadyExists(err error) bool {
 	return strings.Contains(err.Error(), "refusing to override existing file")
 }
 
-// ImportState imports a download file resource by its identifier.
+// ImportState imports a download file resource using the format node_name/datastore_id:content_type/file_name,
+// where the part after the node name is the resource id.
 func (r *downloadFileResource) ImportState(
 	ctx context.Context,
 	req resource.ImportStateRequest,
 	resp *resource.ImportStateResponse,
 ) {
-	// Accept either node_name:datastore_id:content_type/file_name or datastore_id:content_type/file_name
-	parts := strings.SplitN(req.ID, ":", 3)
+	const format = "node_name/datastore_id:content_type/file_name"
 
-	var nodeName, datastoreID, filePart string
-
-	if len(parts) == 3 {
-		nodeName = parts[0]
-		datastoreID = parts[1]
-		filePart = parts[2]
-	} else if len(parts) == 2 {
-		// Try parsing as node/datastore_id:content_type/file_name for backward compatibility
-		slashParts := strings.SplitN(parts[0], "/", 2)
-		if len(slashParts) == 2 {
-			nodeName = slashParts[0]
-			datastoreID = slashParts[1]
-			filePart = parts[1]
-		} else {
-			// Tests and newer TF import block might use datastore_id:content_type/file_name
-			datastoreID = parts[0]
-			filePart = parts[1]
-		}
-	} else {
+	nodeName, id, found := strings.Cut(req.ID, "/")
+	if !found || nodeName == "" || id == "" {
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: node_name:datastore_id:content_type/file_name. Got: %q", req.ID),
+			fmt.Sprintf("Expected import identifier with format: %s. Got: %q", format, req.ID),
 		)
+
 		return
 	}
 
-	fileParts := strings.SplitN(filePart, "/", 2)
-	if len(fileParts) != 2 {
+	datastoreID, filePart, found := strings.Cut(id, ":")
+	if !found || datastoreID == "" || filePart == "" {
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: content_type/file_name in the file part. Got: %q", filePart),
+			fmt.Sprintf("Expected import identifier with format: %s. Got: %q", format, req.ID),
 		)
+
 		return
 	}
 
-	contentType := fileParts[0]
-	fileName := fileParts[1]
-
-	id := datastoreID + ":" + filePart
-
-	if nodeName == "" {
+	contentType, fileName, found := strings.Cut(filePart, "/")
+	if !found || contentType == "" || fileName == "" {
 		resp.Diagnostics.AddError(
-			"Missing Node Name in Import Identifier",
-			fmt.Sprintf("The node name is required for import. Expected format: node_name:datastore_id:content_type/file_name. Got: %q", req.ID),
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected import identifier with format: %s. Got: %q", format, req.ID),
 		)
+
 		return
 	}
+
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("node_name"), nodeName)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("datastore_id"), datastoreID)...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("content_type"), contentType)...)

--- a/fwprovider/nodes/resource_download_file_test.go
+++ b/fwprovider/nodes/resource_download_file_test.go
@@ -13,6 +13,7 @@ package nodes_test
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"os"
 	"path"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/test"
@@ -171,6 +173,57 @@ func TestAccResourceDownloadFile(t *testing.T) {
 						"decompression_algorithm",
 					}),
 				),
+			},
+		}},
+		{"import existing file", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_download_file" "import_image" {
+					content_type        = "iso"
+					node_name           = "{{.NodeName}}"
+					datastore_id        = "{{.DatastoreID}}"
+					file_name           = "fake_import_file.iso"
+					url                 = "{{.FakeFileISO}}"
+					overwrite_unmanaged = true
+				}`),
+				Check: test.ResourceAttributes("proxmox_download_file.import_image", map[string]string{
+					"id":        "local:iso/fake_import_file.iso",
+					"node_name": te.NodeName,
+					"size":      "3",
+				}),
+			},
+			{
+				ResourceName:      "proxmox_download_file.import_image",
+				ImportState:       true,
+				ImportStateId:     te.NodeName + "/" + te.DatastoreID + ":iso/fake_import_file.iso",
+				ImportStateVerify: false,
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 state, got %d", len(states))
+					}
+
+					want := map[string]string{
+						"id":           "local:iso/fake_import_file.iso",
+						"node_name":    te.NodeName,
+						"datastore_id": te.DatastoreID,
+						"content_type": "iso",
+						"file_name":    "fake_import_file.iso",
+						"size":         "3",
+					}
+					for k, v := range want {
+						if got := states[0].Attributes[k]; got != v {
+							return fmt.Errorf("attribute %q: expected %q, got %q", k, v, got)
+						}
+					}
+
+					return nil
+				},
+			},
+			{
+				ResourceName:  "proxmox_download_file.import_image",
+				ImportState:   true,
+				ImportStateId: "local:iso/fake_import_file.iso",
+				ExpectError:   regexp.MustCompile(`Unexpected Import Identifier`),
 			},
 		}},
 		{"override file", []resource.TestStep{{


### PR DESCRIPTION
### What does this PR do?
This PR adds `ImportState` support to the `proxmox_virtual_environment_download_file` resource. Currently, importing a downloaded file resource is not supported and returns a "Resource Import Not Implemented" error. This PR allows importing existing files using the standard ID format `node_name:datastore_id:content_type/file_name` (or `datastore_id:content_type/file_name`). This solves a critical issue where Terraform forces the re-download of large existing .img/.qcow2 images simply because they were not tracked in the state. 


### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
Tested locally by building the provider and successfully importing .img and .qcow2 files on a live Proxmox VE cluster using `terraform import`:
`terraform import 'proxmox_virtual_environment_download_file.images["ubuntu"]' "pve01:local:iso/ubuntu-24.04.3-x64-generic.img"`

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to #2768

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
