### PR TITLE
feat(cluster): add dynamic crs ha scheduler and auto-rebalance options

### DIFF
--- a/docs/resources/cluster_options.md
+++ b/docs/resources/cluster_options.md
@@ -49,7 +49,12 @@ resource "proxmox_cluster_options" "options" {
 - `bandwidth_limit_move` (Number) Move I/O bandwidth limit in KiB/s.
 - `bandwidth_limit_restore` (Number) Restore I/O bandwidth limit in KiB/s.
 - `console` (String) Select the default Console viewer. Must be `applet` | `vv`| `html5` | `xtermjs`. You can either use the builtin java applet (VNC; deprecated and maps to html5), an external virt-viewer compatible application (SPICE), an HTML5 based vnc viewer (noVNC), or an HTML5 based console client (xtermjs). If the selected viewer is not available (e.g. SPICE not activated for the VM), the fallback is noVNC.
-- `crs_ha` (String) Cluster resource scheduling setting for HA. Must be `static` | `basic` (default is `basic`).
+- `crs_ha` (String) Cluster resource scheduling setting for HA. Must be `static` | `basic` | `dynamic` (default is `basic`). `dynamic` requires Proxmox VE 9.2+.
+- `crs_ha_auto_rebalance` (Boolean) Whether to use CRS for balancing HA resources automatically depending on the current node imbalance. Requires Proxmox VE 9.2+.
+- `crs_ha_auto_rebalance_hold_duration` (Number) The number of HA rounds for which the cluster node imbalance threshold must be exceeded before triggering an automatic resource balancing migration (default is `3`). Requires Proxmox VE 9.2+.
+- `crs_ha_auto_rebalance_margin` (Number) The minimum relative improvement in cluster node imbalance, in percent, to commit to a resource balancing migration. Must be between `0` and `100` (default is `10`). Requires Proxmox VE 9.2+.
+- `crs_ha_auto_rebalance_method` (String) The method to use for the scoring of balancing migrations. Must be `bruteforce` | `topsis` (default is `bruteforce`). Requires Proxmox VE 9.2+.
+- `crs_ha_auto_rebalance_threshold` (Number) The cluster node imbalance, in percent, which will trigger the automatic resource balancing system if exceeded. Must be between `0` and `100` (default is `30`). Requires Proxmox VE 9.2+.
 - `crs_ha_rebalance_on_start` (Boolean) Cluster resource scheduling setting for HA rebalance on start.
 - `description` (String) Datacenter description. Shown in the web-interface datacenter notes panel. This is saved as comment inside the configuration file.
 - `email_from` (String) email address to send notification from (default is root@$hostname).

--- a/docs/resources/virtual_environment_cluster_options.md
+++ b/docs/resources/virtual_environment_cluster_options.md
@@ -51,7 +51,12 @@ resource "proxmox_virtual_environment_cluster_options" "options" {
 - `bandwidth_limit_move` (Number) Move I/O bandwidth limit in KiB/s.
 - `bandwidth_limit_restore` (Number) Restore I/O bandwidth limit in KiB/s.
 - `console` (String) Select the default Console viewer. Must be `applet` | `vv`| `html5` | `xtermjs`. You can either use the builtin java applet (VNC; deprecated and maps to html5), an external virt-viewer compatible application (SPICE), an HTML5 based vnc viewer (noVNC), or an HTML5 based console client (xtermjs). If the selected viewer is not available (e.g. SPICE not activated for the VM), the fallback is noVNC.
-- `crs_ha` (String) Cluster resource scheduling setting for HA. Must be `static` | `basic` (default is `basic`).
+- `crs_ha` (String) Cluster resource scheduling setting for HA. Must be `static` | `basic` | `dynamic` (default is `basic`). `dynamic` requires Proxmox VE 9.2+.
+- `crs_ha_auto_rebalance` (Boolean) Whether to use CRS for balancing HA resources automatically depending on the current node imbalance. Requires Proxmox VE 9.2+.
+- `crs_ha_auto_rebalance_hold_duration` (Number) The number of HA rounds for which the cluster node imbalance threshold must be exceeded before triggering an automatic resource balancing migration (default is `3`). Requires Proxmox VE 9.2+.
+- `crs_ha_auto_rebalance_margin` (Number) The minimum relative improvement in cluster node imbalance, in percent, to commit to a resource balancing migration. Must be between `0` and `100` (default is `10`). Requires Proxmox VE 9.2+.
+- `crs_ha_auto_rebalance_method` (String) The method to use for the scoring of balancing migrations. Must be `bruteforce` | `topsis` (default is `bruteforce`). Requires Proxmox VE 9.2+.
+- `crs_ha_auto_rebalance_threshold` (Number) The cluster node imbalance, in percent, which will trigger the automatic resource balancing system if exceeded. Must be between `0` and `100` (default is `30`). Requires Proxmox VE 9.2+.
 - `crs_ha_rebalance_on_start` (Boolean) Cluster resource scheduling setting for HA rebalance on start.
 - `description` (String) Datacenter description. Shown in the web-interface datacenter notes panel. This is saved as comment inside the configuration file.
 - `email_from` (String) email address to send notification from (default is root@$hostname).

--- a/fwprovider/cluster/options/model_options.go
+++ b/fwprovider/cluster/options/model_options.go
@@ -37,27 +37,32 @@ const (
 )
 
 type clusterOptionsModel struct {
-	ID                      types.String               `tfsdk:"id"`
-	BandwidthLimitClone     types.Int64                `tfsdk:"bandwidth_limit_clone"`
-	BandwidthLimitDefault   types.Int64                `tfsdk:"bandwidth_limit_default"`
-	BandwidthLimitMigration types.Int64                `tfsdk:"bandwidth_limit_migration"`
-	BandwidthLimitMove      types.Int64                `tfsdk:"bandwidth_limit_move"`
-	BandwidthLimitRestore   types.Int64                `tfsdk:"bandwidth_limit_restore"`
-	Console                 types.String               `tfsdk:"console"`
-	CrsHA                   types.String               `tfsdk:"crs_ha"`
-	CrsHARebalanceOnStart   types.Bool                 `tfsdk:"crs_ha_rebalance_on_start"`
-	Description             types.String               `tfsdk:"description"`
-	EmailFrom               types.String               `tfsdk:"email_from"`
-	HAShutdownPolicy        types.String               `tfsdk:"ha_shutdown_policy"`
-	HTTPProxy               types.String               `tfsdk:"http_proxy"`
-	Keyboard                types.String               `tfsdk:"keyboard"`
-	Language                types.String               `tfsdk:"language"`
-	MacPrefix               types.String               `tfsdk:"mac_prefix"`
-	MaxWorkers              types.Int64                `tfsdk:"max_workers"`
-	MigrationNetwork        customtypes.IPCIDRValue    `tfsdk:"migration_cidr"`
-	MigrationType           types.String               `tfsdk:"migration_type"`
-	NextID                  *clusterOptionsNextIDModel `tfsdk:"next_id"`
-	Notify                  *clusterOptionsNotifyModel `tfsdk:"notify"`
+	ID                             types.String               `tfsdk:"id"`
+	BandwidthLimitClone            types.Int64                `tfsdk:"bandwidth_limit_clone"`
+	BandwidthLimitDefault          types.Int64                `tfsdk:"bandwidth_limit_default"`
+	BandwidthLimitMigration        types.Int64                `tfsdk:"bandwidth_limit_migration"`
+	BandwidthLimitMove             types.Int64                `tfsdk:"bandwidth_limit_move"`
+	BandwidthLimitRestore          types.Int64                `tfsdk:"bandwidth_limit_restore"`
+	Console                        types.String               `tfsdk:"console"`
+	CrsHA                          types.String               `tfsdk:"crs_ha"`
+	CrsHAAutoRebalance             types.Bool                 `tfsdk:"crs_ha_auto_rebalance"`
+	CrsHAAutoRebalanceHoldDuration types.Int64                `tfsdk:"crs_ha_auto_rebalance_hold_duration"`
+	CrsHAAutoRebalanceMargin       types.Int64                `tfsdk:"crs_ha_auto_rebalance_margin"`
+	CrsHAAutoRebalanceMethod       types.String               `tfsdk:"crs_ha_auto_rebalance_method"`
+	CrsHAAutoRebalanceThreshold    types.Int64                `tfsdk:"crs_ha_auto_rebalance_threshold"`
+	CrsHARebalanceOnStart          types.Bool                 `tfsdk:"crs_ha_rebalance_on_start"`
+	Description                    types.String               `tfsdk:"description"`
+	EmailFrom                      types.String               `tfsdk:"email_from"`
+	HAShutdownPolicy               types.String               `tfsdk:"ha_shutdown_policy"`
+	HTTPProxy                      types.String               `tfsdk:"http_proxy"`
+	Keyboard                       types.String               `tfsdk:"keyboard"`
+	Language                       types.String               `tfsdk:"language"`
+	MacPrefix                      types.String               `tfsdk:"mac_prefix"`
+	MaxWorkers                     types.Int64                `tfsdk:"max_workers"`
+	MigrationNetwork               customtypes.IPCIDRValue    `tfsdk:"migration_cidr"`
+	MigrationType                  types.String               `tfsdk:"migration_type"`
+	NextID                         *clusterOptionsNextIDModel `tfsdk:"next_id"`
+	Notify                         *clusterOptionsNotifyModel `tfsdk:"notify"`
 }
 
 type clusterOptionsNextIDModel struct {
@@ -191,26 +196,36 @@ func (m *clusterOptionsModel) notifyData() string {
 func (m *clusterOptionsModel) crsData() string {
 	var crsDataParams []string
 
-	if attribute.IsDefined(m.CrsHA) {
-		crsDataParams = append(crsDataParams, fmt.Sprintf("ha=%s", m.CrsHA.ValueString()))
-	}
-
-	if attribute.IsDefined(m.CrsHARebalanceOnStart) {
-		var haRebalanceOnStart string
-		if m.CrsHARebalanceOnStart.ValueBool() {
-			haRebalanceOnStart = "1"
-		} else {
-			haRebalanceOnStart = "0"
+	addString := func(name string, v types.String) {
+		if attribute.IsDefined(v) {
+			crsDataParams = append(crsDataParams, fmt.Sprintf("%s=%s", name, v.ValueString()))
 		}
+	}
+	addBool := func(name string, v types.Bool) {
+		if attribute.IsDefined(v) {
+			value := "0"
+			if v.ValueBool() {
+				value = "1"
+			}
 
-		crsDataParams = append(crsDataParams, fmt.Sprintf("ha-rebalance-on-start=%s", haRebalanceOnStart))
+			crsDataParams = append(crsDataParams, fmt.Sprintf("%s=%s", name, value))
+		}
+	}
+	addInt64 := func(name string, v types.Int64) {
+		if attribute.IsDefined(v) {
+			crsDataParams = append(crsDataParams, fmt.Sprintf("%s=%d", name, v.ValueInt64()))
+		}
 	}
 
-	if len(crsDataParams) > 0 {
-		return strings.Join(crsDataParams, ",")
-	}
+	addString("ha", m.CrsHA)
+	addBool("ha-auto-rebalance", m.CrsHAAutoRebalance)
+	addInt64("ha-auto-rebalance-hold-duration", m.CrsHAAutoRebalanceHoldDuration)
+	addInt64("ha-auto-rebalance-margin", m.CrsHAAutoRebalanceMargin)
+	addString("ha-auto-rebalance-method", m.CrsHAAutoRebalanceMethod)
+	addInt64("ha-auto-rebalance-threshold", m.CrsHAAutoRebalanceThreshold)
+	addBool("ha-rebalance-on-start", m.CrsHARebalanceOnStart)
 
-	return ""
+	return strings.Join(crsDataParams, ",")
 }
 
 // bandwidthData returns bandwidth limit settings parameter string for API, if any of bandwidth
@@ -411,11 +426,22 @@ func (m *clusterOptionsModel) fromAPI(opts *cluster.OptionsResponseData) error {
 	}
 
 	if opts.ClusterResourceScheduling != nil {
-		m.CrsHARebalanceOnStart = types.BoolPointerValue(opts.ClusterResourceScheduling.HaRebalanceOnStart.PointerBool())
-		m.CrsHA = types.StringPointerValue(opts.ClusterResourceScheduling.HA)
+		crs := opts.ClusterResourceScheduling
+		m.CrsHA = types.StringPointerValue(crs.HA)
+		m.CrsHAAutoRebalance = types.BoolPointerValue(crs.HaAutoRebalance.PointerBool())
+		m.CrsHAAutoRebalanceHoldDuration = types.Int64PointerValue(crs.HaAutoRebalanceHoldDuration.PointerInt64())
+		m.CrsHAAutoRebalanceMargin = types.Int64PointerValue(crs.HaAutoRebalanceMargin.PointerInt64())
+		m.CrsHAAutoRebalanceMethod = types.StringPointerValue(crs.HaAutoRebalanceMethod)
+		m.CrsHAAutoRebalanceThreshold = types.Int64PointerValue(crs.HaAutoRebalanceThreshold.PointerInt64())
+		m.CrsHARebalanceOnStart = types.BoolPointerValue(crs.HaRebalanceOnStart.PointerBool())
 	} else {
-		m.CrsHARebalanceOnStart = types.BoolNull()
 		m.CrsHA = types.StringNull()
+		m.CrsHAAutoRebalance = types.BoolNull()
+		m.CrsHAAutoRebalanceHoldDuration = types.Int64Null()
+		m.CrsHAAutoRebalanceMargin = types.Int64Null()
+		m.CrsHAAutoRebalanceMethod = types.StringNull()
+		m.CrsHAAutoRebalanceThreshold = types.Int64Null()
+		m.CrsHARebalanceOnStart = types.BoolNull()
 	}
 
 	return nil

--- a/fwprovider/cluster/options/resource_options.go
+++ b/fwprovider/cluster/options/resource_options.go
@@ -257,14 +257,58 @@ func (r *clusterOptionsResource) Schema(
 				Optional:    true,
 			},
 			"crs_ha": schema.StringAttribute{
-				Description:         "Cluster resource scheduling setting for HA.",
-				MarkdownDescription: "Cluster resource scheduling setting for HA. Must be `static` | `basic` (default is `basic`).",
-				Optional:            true,
-				Computed:            true,
+				Description: "Cluster resource scheduling setting for HA.",
+				MarkdownDescription: "Cluster resource scheduling setting for HA. Must be `static` | `basic` | " +
+					"`dynamic` (default is `basic`). `dynamic` requires Proxmox VE 9.2+.",
+				Optional: true,
+				Computed: true,
 				Validators: []validator.String{stringvalidator.OneOf([]string{
 					"static",
 					"basic",
+					"dynamic",
 				}...)},
+			},
+			"crs_ha_auto_rebalance": schema.BoolAttribute{
+				Description: "Whether to use CRS for balancing HA resources automatically depending on" +
+					" the current node imbalance. Requires Proxmox VE 9.2+.",
+				Optional: true,
+			},
+			"crs_ha_auto_rebalance_hold_duration": schema.Int64Attribute{
+				Description: "The number of HA rounds for which the cluster node imbalance threshold must be" +
+					" exceeded before triggering an automatic resource balancing migration (default is `3`)." +
+					" Requires Proxmox VE 9.2+.",
+				Optional: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
+			},
+			"crs_ha_auto_rebalance_margin": schema.Int64Attribute{
+				Description: "The minimum relative improvement in cluster node imbalance, in percent, to commit to" +
+					" a resource balancing migration. Must be between `0` and `100` (default is `10`)." +
+					" Requires Proxmox VE 9.2+.",
+				Optional: true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 100),
+				},
+			},
+			"crs_ha_auto_rebalance_method": schema.StringAttribute{
+				Description: "The method to use for the scoring of balancing migrations.",
+				MarkdownDescription: "The method to use for the scoring of balancing migrations. Must be" +
+					" `bruteforce` | `topsis` (default is `bruteforce`). Requires Proxmox VE 9.2+.",
+				Optional: true,
+				Validators: []validator.String{stringvalidator.OneOf([]string{
+					"bruteforce",
+					"topsis",
+				}...)},
+			},
+			"crs_ha_auto_rebalance_threshold": schema.Int64Attribute{
+				Description: "The cluster node imbalance, in percent, which will trigger the automatic resource" +
+					" balancing system if exceeded. Must be between `0` and `100` (default is `30`)." +
+					" Requires Proxmox VE 9.2+.",
+				Optional: true,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 100),
+				},
 			},
 			"crs_ha_rebalance_on_start": schema.BoolAttribute{
 				Description: "Cluster resource scheduling setting for HA rebalance on start.",

--- a/fwprovider/cluster/options/resource_options_test.go
+++ b/fwprovider/cluster/options/resource_options_test.go
@@ -42,6 +42,17 @@ func TestAccResourceClusterOptions(t *testing.T) {
 					ImportState:       true,
 					ImportStateVerify: true,
 				},
+				// Update to the dynamic CRS scheduler; requires PVE 9.2+ (pve-ha-manager 5.2+)
+				{
+					Config: testAccResourceClusterOptionsCrsDynamicConfig(),
+					Check:  testAccResourceClusterOptionsCrsDynamicCheck(),
+				},
+				// ImportState testing with dynamic CRS options
+				{
+					ResourceName:      accTestClusterOptionsName,
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
 				// Update testing
 				{
 					Config: testAccResourceClusterOptionsUpdatedConfig(),
@@ -124,6 +135,33 @@ func testAccResourceClusterOptionsCreatedCheck() resource.TestCheckFunc {
 	)
 }
 
+func testAccResourceClusterOptionsCrsDynamicConfig() string {
+	return `
+  resource "proxmox_cluster_options" "test_options" {
+    crs_ha                              = "dynamic"
+    crs_ha_rebalance_on_start           = true
+    crs_ha_auto_rebalance               = true
+    crs_ha_auto_rebalance_hold_duration = 5
+    crs_ha_auto_rebalance_margin        = 15
+    crs_ha_auto_rebalance_method        = "topsis"
+    crs_ha_auto_rebalance_threshold     = 40
+  }
+	`
+}
+
+func testAccResourceClusterOptionsCrsDynamicCheck() resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(accTestClusterOptionsName, "id", "cluster"),
+		resource.TestCheckResourceAttr(accTestClusterOptionsName, "crs_ha", "dynamic"),
+		resource.TestCheckResourceAttr(accTestClusterOptionsName, "crs_ha_rebalance_on_start", "true"),
+		resource.TestCheckResourceAttr(accTestClusterOptionsName, "crs_ha_auto_rebalance", "true"),
+		resource.TestCheckResourceAttr(accTestClusterOptionsName, "crs_ha_auto_rebalance_hold_duration", "5"),
+		resource.TestCheckResourceAttr(accTestClusterOptionsName, "crs_ha_auto_rebalance_margin", "15"),
+		resource.TestCheckResourceAttr(accTestClusterOptionsName, "crs_ha_auto_rebalance_method", "topsis"),
+		resource.TestCheckResourceAttr(accTestClusterOptionsName, "crs_ha_auto_rebalance_threshold", "40"),
+	)
+}
+
 func testAccResourceClusterOptionsUpdatedConfig() string {
 	return `
   resource "proxmox_cluster_options" "test_options" {
@@ -172,6 +210,12 @@ func testAccResourceClusterOptionsUpdatedCheck() resource.TestCheckFunc {
 		resource.TestCheckNoResourceAttr(accTestClusterOptionsName, "bandwidth_limit_restore"),
 		resource.TestCheckNoResourceAttr(accTestClusterOptionsName, "console"),
 		resource.TestCheckNoResourceAttr(accTestClusterOptionsName, "crs_ha"),
+		resource.TestCheckNoResourceAttr(accTestClusterOptionsName, "crs_ha_rebalance_on_start"),
+		resource.TestCheckNoResourceAttr(accTestClusterOptionsName, "crs_ha_auto_rebalance"),
+		resource.TestCheckNoResourceAttr(accTestClusterOptionsName, "crs_ha_auto_rebalance_hold_duration"),
+		resource.TestCheckNoResourceAttr(accTestClusterOptionsName, "crs_ha_auto_rebalance_margin"),
+		resource.TestCheckNoResourceAttr(accTestClusterOptionsName, "crs_ha_auto_rebalance_method"),
+		resource.TestCheckNoResourceAttr(accTestClusterOptionsName, "crs_ha_auto_rebalance_threshold"),
 		resource.TestCheckNoResourceAttr(accTestClusterOptionsName, "ha_shutdown_policy"),
 		resource.TestCheckNoResourceAttr(accTestClusterOptionsName, "http_proxy"),
 		resource.TestCheckNoResourceAttr(accTestClusterOptionsName, "keyboard"),

--- a/proxmox/cluster/options_types.go
+++ b/proxmox/cluster/options_types.go
@@ -21,8 +21,13 @@ type tagStyle struct {
 	ColorMap      *string           `json:"color-map,omitempty"`
 }
 type crs struct {
-	HaRebalanceOnStart *types.CustomBool `json:"ha-rebalance-on-start,omitempty"`
-	HA                 *string           `json:"ha,omitempty"`
+	HaRebalanceOnStart          *types.CustomBool  `json:"ha-rebalance-on-start,omitempty"`
+	HA                          *string            `json:"ha,omitempty"`
+	HaAutoRebalance             *types.CustomBool  `json:"ha-auto-rebalance,omitempty"`
+	HaAutoRebalanceHoldDuration *types.CustomInt64 `json:"ha-auto-rebalance-hold-duration,omitempty"`
+	HaAutoRebalanceMargin       *types.CustomInt64 `json:"ha-auto-rebalance-margin,omitempty"`
+	HaAutoRebalanceMethod       *string            `json:"ha-auto-rebalance-method,omitempty"`
+	HaAutoRebalanceThreshold    *types.CustomInt64 `json:"ha-auto-rebalance-threshold,omitempty"`
 }
 type notify struct {
 	HAFencingMode        *string `json:"fencing,omitempty"`


### PR DESCRIPTION
### What does this PR do?

Proxmox VE 9.2 introduced a dynamic load balancer for the cluster resource scheduler (CRS): the `crs` datacenter option now accepts `ha=dynamic` plus five auto-rebalance parameters. The `proxmox_virtual_environment_cluster_options` resource rejected `dynamic` at plan time and had no way to manage the auto-rebalance settings.

This PR allows `dynamic` as a `crs_ha` value and adds five optional attributes (`crs_ha_auto_rebalance`, `crs_ha_auto_rebalance_hold_duration`, `crs_ha_auto_rebalance_margin`, `crs_ha_auto_rebalance_method`, `crs_ha_auto_rebalance_threshold`) mapping to the new CRS sub-parameters, with validators matching the PVE spec (method `bruteforce` | `topsis`, margin/threshold 0–100). The API client `crs` type, the composite `crs` parameter serialization, and the response parsing are extended following the existing patterns; deletion and import paths required no changes.

### Usage Example

```hcl
resource "proxmox_virtual_environment_cluster_options" "options" {
  crs_ha                              = "dynamic"
  crs_ha_rebalance_on_start           = true
  crs_ha_auto_rebalance               = true
  crs_ha_auto_rebalance_hold_duration = 5
  crs_ha_auto_rebalance_margin        = 15
  crs_ha_auto_rebalance_method        = "topsis"
  crs_ha_auto_rebalance_threshold     = 40
}
```

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

Acceptance test (TDD): `TestAccResourceClusterOptions` was extended with a step setting `crs_ha = "dynamic"` plus all five auto-rebalance attributes, an import round-trip verifying the API echo, and a removal step exercising the composite `crs` delete.

Before the fix (test fails schema rejects the new config):

```text
Error: Unsupported argument
  on terraform_plugin_test.tf line 15, in resource "proxmox_cluster_options" "test_options":
  15:     crs_ha_auto_rebalance               = true
An argument named "crs_ha_auto_rebalance" is not expected here.
(... same for the other 4 new attributes ...)
--- FAIL: TestAccResourceClusterOptions (0.99s)
```

After the fix (against a PVE 9.2 cluster):

```text
=== RUN   TestAccResourceClusterOptions
=== PAUSE TestAccResourceClusterOptions
=== CONT  TestAccResourceClusterOptions
--- PASS: TestAccResourceClusterOptions (1.95s)
PASS
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/options   1.958s
```

mitmproxy verification `PUT /api2/json/cluster/options` request body (URL-decoded) and response:

```text
crs=ha=dynamic,ha-auto-rebalance=1,ha-auto-rebalance-hold-duration=5,ha-auto-rebalance-margin=15,ha-auto-rebalance-method=topsis,ha-auto-rebalance-threshold=40,ha-rebalance-on-start=1
Response: 200 OK
```

`GET /cluster/options` echo (note PVE returns the numeric sub-params as JSON strings handled by `types.CustomInt64`):

```json
"crs": {
  "ha": "dynamic",
  "ha-auto-rebalance": 1,
  "ha-auto-rebalance-hold-duration": "5",
  "ha-auto-rebalance-margin": "15",
  "ha-auto-rebalance-method": "topsis",
  "ha-auto-rebalance-threshold": "40",
  "ha-rebalance-on-start": 1
}
```

Removal step sent `delete=crs` → `200 OK`. No 4xx/5xx responses in the capture.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)

Closes #2939