### PR TITLE
feat(storage): add `options` parameter for proxmox_storage_cifs resource

### DIFF
--- a/docs/resources/storage_cifs.md
+++ b/docs/resources/storage_cifs.md
@@ -54,6 +54,7 @@ resource "proxmox_storage_cifs" "example" {
 - `disable` (Boolean) Whether the storage is disabled.
 - `domain` (String) The SMB/CIFS domain.
 - `nodes` (Set of String) A list of nodes where this storage is available.
+- `options` (String) The mount options for the SMB/CIFS share (see 'man mount.cifs').
 - `preallocation` (String) The preallocation mode for raw and qcow2 images.
 - `snapshot_as_volume_chain` (Boolean) Enable support for creating snapshots through volume backing-chains.
 - `subdirectory` (String) A subdirectory to mount within the share.

--- a/docs/resources/virtual_environment_storage_cifs.md
+++ b/docs/resources/virtual_environment_storage_cifs.md
@@ -56,6 +56,7 @@ resource "proxmox_virtual_environment_storage_cifs" "example" {
 - `disable` (Boolean) Whether the storage is disabled.
 - `domain` (String) The SMB/CIFS domain.
 - `nodes` (Set of String) A list of nodes where this storage is available.
+- `options` (String) The mount options for the SMB/CIFS share (see 'man mount.cifs').
 - `preallocation` (String) The preallocation mode for raw and qcow2 images.
 - `snapshot_as_volume_chain` (Boolean) Enable support for creating snapshots through volume backing-chains.
 - `subdirectory` (String) A subdirectory to mount within the share.

--- a/fwprovider/storage/model_cifs.go
+++ b/fwprovider/storage/model_cifs.go
@@ -25,6 +25,7 @@ type CIFSStorageModel struct {
 	Share                  types.String `tfsdk:"share"`
 	Domain                 types.String `tfsdk:"domain"`
 	SubDirectory           types.String `tfsdk:"subdirectory"`
+	Options                types.String `tfsdk:"options"`
 	Preallocation          types.String `tfsdk:"preallocation"`
 	SnapshotsAsVolumeChain types.Bool   `tfsdk:"snapshot_as_volume_chain"`
 	Backups                *BackupModel `tfsdk:"backups"`
@@ -48,6 +49,7 @@ func (m *CIFSStorageModel) toCreateAPIRequest(ctx context.Context) (any, error) 
 	request.Share = m.Share.ValueStringPointer()
 	request.Domain = m.Domain.ValueStringPointer()
 	request.Subdirectory = m.SubDirectory.ValueStringPointer()
+	request.Options = m.Options.ValueStringPointer()
 	request.Preallocation = m.Preallocation.ValueStringPointer()
 	request.SnapshotsAsVolumeChain = proxmoxtypes.CustomBool(m.SnapshotsAsVolumeChain.ValueBool())
 
@@ -70,6 +72,7 @@ func (m *CIFSStorageModel) toUpdateAPIRequest(ctx context.Context) (any, error) 
 		return nil, err
 	}
 
+	request.Options = m.Options.ValueStringPointer()
 	request.Preallocation = m.Preallocation.ValueStringPointer()
 
 	if m.Backups != nil {
@@ -103,6 +106,10 @@ func (m *CIFSStorageModel) fromAPI(ctx context.Context, datastore *storage.Datas
 
 	if datastore.Domain != nil {
 		m.Domain = types.StringValue(*datastore.Domain)
+	}
+
+	if datastore.Options != nil {
+		m.Options = types.StringValue(*datastore.Options)
 	}
 
 	if datastore.SubDirectory != nil {

--- a/fwprovider/storage/resource_cifs.go
+++ b/fwprovider/storage/resource_cifs.go
@@ -90,6 +90,10 @@ func (r *cifsStorageResource) Schema(_ context.Context, _ resource.SchemaRequest
 				stringplanmodifier.RequiresReplace(),
 			},
 		},
+		"options": schema.StringAttribute{
+			Description: "The mount options for the SMB/CIFS share (see 'man mount.cifs').",
+			Optional:    true,
+		},
 		"preallocation": schema.StringAttribute{
 			Description: "The preallocation mode for raw and qcow2 images.",
 			Optional:    true,

--- a/proxmox/storage/cifs_types.go
+++ b/proxmox/storage/cifs_types.go
@@ -8,6 +8,7 @@ type CIFSStorageMutableFields struct {
 
 	Backups DataStoreWithBackups `json:"-" url:"backups,omitempty"`
 
+	Options       *string `json:"options,omitempty"       url:"options,omitempty"`
 	Preallocation *string `json:"preallocation,omitempty" url:"preallocation,omitempty"`
 }
 


### PR DESCRIPTION
### What does this PR do?
<!--- Clearly state the problem and how this PR solves it. -->
 Add the `options` parameter to `proxmox_storage_cifs`, the same way it's already implemented for nfs storage resources.

### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [x] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

Creating a new resource
<img width="1098" height="193" alt="Capture d’écran du 2026-06-15 17-22-36" src="https://github.com/user-attachments/assets/d8eeb948-cd75-4a11-b457-67b49b633b42" />

<img width="1092" height="580" alt="Capture d’écran du 2026-06-15 17-20-04" src="https://github.com/user-attachments/assets/5756dc13-2517-453f-97e4-16d89a4ef9b1" />

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2946 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
