### PR TITLE
fix(node): accept string-typed startall-onboot-delay in node config

### DIFF
--- a/fwprovider/nodes/config/resource_node_config_test.go
+++ b/fwprovider/nodes/config/resource_node_config_test.go
@@ -12,12 +12,15 @@
 package config_test
 
 import (
+	"context"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
 
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/test"
+	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes"
 )
 
 func TestAccResourceNodeConfig(t *testing.T) {
@@ -104,6 +107,58 @@ func TestAccResourceNodeConfig(t *testing.T) {
 				ResourceName:      "proxmox_node_config.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceNodeConfigStartAllOnbootDelay verifies the resource can be read on a node that
+// has startall-onboot-delay explicitly set. PVE serializes that field as a string, which crashed
+// the GET response decode before the fix.
+func TestAccResourceNodeConfigStartAllOnbootDelay(t *testing.T) {
+	t.Parallel()
+
+	te := test.InitEnvironment(t)
+
+	ctx := context.Background()
+
+	// Set startall-onboot-delay out-of-band so PVE returns it as a string on the next GET.
+	err := te.NodeClient().UpdateConfig(ctx, &nodes.ConfigUpdateRequestBody{
+		StartAllOnbootDelay: new(15),
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := te.NodeClient().UpdateConfig(ctx, &nodes.ConfigUpdateRequestBody{
+			Delete: []string{"startall-onboot-delay"},
+		})
+		if err != nil {
+			t.Logf("cleanup: failed to delete startall-onboot-delay: %v", err)
+		}
+	})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_node_config" "test" {
+						node_name   = "{{.NodeName}}"
+						description = "test notes"
+					}
+
+					data "proxmox_node_config" "test" {
+						node_name = proxmox_node_config.test.node_name
+					}
+				`),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_node_config.test", map[string]string{
+						"description": "test notes",
+					}),
+					test.ResourceAttributes("data.proxmox_node_config.test", map[string]string{
+						"description": "test notes",
+					}),
+				),
 			},
 		},
 	})

--- a/proxmox/nodes/config_types.go
+++ b/proxmox/nodes/config_types.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/types"
 )
 
 // ConfigGetResponseBody contains the body from a config get response.
@@ -39,7 +41,8 @@ type ConfigGetResponseData struct {
 	// Prevent changes if current configuration file has different SHA1 digest. This can be used to prevent concurrent modifications.
 	Digest *string `json:"digest,omitempty"`
 	// Initial delay in seconds, before starting all the Virtual Guests with on-boot enabled.
-	StartAllOnbootDelay *int `json:"startall-onboot-delay,omitempty"`
+	// PVE serializes this as a string when explicitly set, so use CustomInt to accept both forms.
+	StartAllOnbootDelay *types.CustomInt `json:"startall-onboot-delay,omitempty"`
 	// Node specific wake on LAN settings.
 	WakeOnLan *WakeOnLandConfig `json:"wakeonlan,omitempty"`
 }

--- a/proxmox/nodes/config_types_test.go
+++ b/proxmox/nodes/config_types_test.go
@@ -7,9 +7,69 @@
 package nodes
 
 import (
+	"encoding/json"
 	"net/url"
 	"testing"
 )
+
+func TestConfigGetResponseData_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		json    string
+		wantNil bool
+		want    int
+	}{
+		{
+			// PVE serializes startall-onboot-delay as a string when explicitly set.
+			name: "startall-onboot-delay as string",
+			json: `{"startall-onboot-delay":"0"}`,
+			want: 0,
+		},
+		{
+			name: "startall-onboot-delay as non-zero string",
+			json: `{"startall-onboot-delay":"15"}`,
+			want: 15,
+		},
+		{
+			name: "startall-onboot-delay as bare integer",
+			json: `{"startall-onboot-delay":15}`,
+			want: 15,
+		},
+		{
+			name:    "startall-onboot-delay absent",
+			json:    `{}`,
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var data ConfigGetResponseData
+			if err := json.Unmarshal([]byte(tt.json), &data); err != nil {
+				t.Fatalf("UnmarshalJSON() unexpected error = %v", err)
+			}
+
+			if tt.wantNil {
+				if data.StartAllOnbootDelay != nil {
+					t.Fatalf("StartAllOnbootDelay = %v, want nil", *data.StartAllOnbootDelay)
+				}
+
+				return
+			}
+
+			if data.StartAllOnbootDelay == nil {
+				t.Fatal("StartAllOnbootDelay = nil, want non-nil")
+			}
+
+			if got := int(*data.StartAllOnbootDelay); got != tt.want {
+				t.Errorf("StartAllOnbootDelay = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestACMEConfig_UnmarshalJSON(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
### What does this PR do?

`proxmox_node_config` crashed during the Read phase on any node that had `startall-onboot-delay`
explicitly set. Proxmox documents that field as an integer but its API serializes the value as a
JSON string (e.g. `"0"`, `"15"`), so decoding the node config GET response into a Go `*int`
failed with `json: cannot unmarshal string into Go struct field
ConfigGetResponseData.data.startall-onboot-delay of type int`. This PR changes the field type in
the GET response struct to the provider's existing `types.CustomInt`, whose unmarshaler already
accepts both the string and bare-integer forms. The crash affected both the resource and the
data source, which share the same GET path; one change fixes both.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

Root cause: `proxmox/nodes/config_types.go` declared `StartAllOnbootDelay *int` in the GET
response; PVE returns it as a string. Fix: `*int` → `*types.CustomInt` (request-body field left
as `*int` — it is sent to the API, never decoded from it).

**Unit test** (`proxmox/nodes/config_types_test.go`):

```
$ go test ./proxmox/nodes/ -run TestConfigGetResponseData_UnmarshalJSON -v
--- PASS: TestConfigGetResponseData_UnmarshalJSON (0.00s)
    --- PASS: .../startall-onboot-delay_as_string
    --- PASS: .../startall-onboot-delay_as_non-zero_string
    --- PASS: .../startall-onboot-delay_as_bare_integer
    --- PASS: .../startall-onboot-delay_absent
```

**Acceptance test** (`fwprovider/nodes/config/resource_node_config_test.go`) — sets
`startall-onboot-delay` out-of-band via the real PVE API, then applies the resource + data
source:

```
$ ./testacc "TestAccResourceNodeConfig.*" -- -v
--- PASS: TestAccResourceNodeConfigEmptyDescription (0.25s)
--- PASS: TestAccResourceNodeConfigStartAllOnbootDelay (1.03s)
--- PASS: TestAccResourceNodeConfig (3.24s)
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/nodes/config	3.742s
```

**Positive control** — temporarily reverting the fix (field back to `*int`) makes the new
acceptance test reproduce the exact issue error, confirming the test exercises the changed path:

```
--- FAIL: TestAccResourceNodeConfigStartAllOnbootDelay (0.55s)
    Error: Unable to Read Node Config "pve"
    error retrieving node config: failed to decode HTTP GET response (path:
    nodes/pve/config) - Reason: json: cannot unmarshal string into Go struct
    field ConfigGetResponseData.data.startall-onboot-delay of type int
```

Before: `terraform plan`/`apply` against such a node failed during Read. After: Read decodes the
string value via `CustomInt` and succeeds.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2945

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.8). All changes have been reviewed and verified by a human.*
