### PR TITLE
feat(acme): add write-only data_wo argument to proxmox_acme_dns_plugin

### DIFF
--- a/docs/resources/acme_dns_plugin.md
+++ b/docs/resources/acme_dns_plugin.md
@@ -34,7 +34,10 @@ resource "proxmox_acme_dns_plugin" "example" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `data` (Map of String) DNS plugin data.
+- `data_wo` (Map of String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) DNS plugin data, supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) so credentials are never stored in Terraform state. Requires Terraform 1.11+. Mutually exclusive with `data`.
 - `digest` (String) SHA1 digest of the current configuration. Prevent changes if current configuration file has a different digest. This can be used to prevent concurrent modifications.
 - `disable` (Boolean) Flag to disable the config.
 - `validation_delay` (Number) Extra delay in seconds to wait before requesting validation. Allows to cope with a long TTL of DNS records (0 - 172800).

--- a/docs/resources/acme_dns_plugin.md
+++ b/docs/resources/acme_dns_plugin.md
@@ -37,7 +37,8 @@ resource "proxmox_acme_dns_plugin" "example" {
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
 - `data` (Map of String) DNS plugin data.
-- `data_wo` (Map of String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) DNS plugin data, supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) so credentials are never stored in Terraform state. Requires Terraform 1.11+. Mutually exclusive with `data`.
+- `data_wo` (Map of String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) DNS plugin data, supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) so credentials are never stored in Terraform state. Requires Terraform 1.11+. Mutually exclusive with `data`. Pair with `data_wo_version` to push rotated values.
+- `data_wo_version` (Number) Version counter for `data_wo`. Because write-only values are not stored in state, Terraform cannot detect when `data_wo` changes; increment this value to signal a rotation and force the new `data_wo` to be sent.
 - `digest` (String) SHA1 digest of the current configuration. Prevent changes if current configuration file has a different digest. This can be used to prevent concurrent modifications.
 - `disable` (Boolean) Flag to disable the config.
 - `validation_delay` (Number) Extra delay in seconds to wait before requesting validation. Allows to cope with a long TTL of DNS records (0 - 172800).

--- a/docs/resources/virtual_environment_acme_dns_plugin.md
+++ b/docs/resources/virtual_environment_acme_dns_plugin.md
@@ -39,7 +39,8 @@ resource "proxmox_virtual_environment_acme_dns_plugin" "example" {
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
 - `data` (Map of String) DNS plugin data.
-- `data_wo` (Map of String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) DNS plugin data, supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) so credentials are never stored in Terraform state. Requires Terraform 1.11+. Mutually exclusive with `data`.
+- `data_wo` (Map of String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) DNS plugin data, supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) so credentials are never stored in Terraform state. Requires Terraform 1.11+. Mutually exclusive with `data`. Pair with `data_wo_version` to push rotated values.
+- `data_wo_version` (Number) Version counter for `data_wo`. Because write-only values are not stored in state, Terraform cannot detect when `data_wo` changes; increment this value to signal a rotation and force the new `data_wo` to be sent.
 - `digest` (String) SHA1 digest of the current configuration. Prevent changes if current configuration file has a different digest. This can be used to prevent concurrent modifications.
 - `disable` (Boolean) Flag to disable the config.
 - `validation_delay` (Number) Extra delay in seconds to wait before requesting validation. Allows to cope with a long TTL of DNS records (0 - 172800).

--- a/docs/resources/virtual_environment_acme_dns_plugin.md
+++ b/docs/resources/virtual_environment_acme_dns_plugin.md
@@ -36,7 +36,10 @@ resource "proxmox_virtual_environment_acme_dns_plugin" "example" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `data` (Map of String) DNS plugin data.
+- `data_wo` (Map of String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) DNS plugin data, supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) so credentials are never stored in Terraform state. Requires Terraform 1.11+. Mutually exclusive with `data`.
 - `digest` (String) SHA1 digest of the current configuration. Prevent changes if current configuration file has a different digest. This can be used to prevent concurrent modifications.
 - `disable` (Boolean) Flag to disable the config.
 - `validation_delay` (Number) Extra delay in seconds to wait before requesting validation. Allows to cope with a long TTL of DNS records (0 - 172800).

--- a/fwprovider/cluster/acme/model_plugin.go
+++ b/fwprovider/cluster/acme/model_plugin.go
@@ -40,6 +40,8 @@ type acmePluginModel struct {
 type acmePluginCreateModel struct {
 	baseACMEPluginModel
 
+	// Write-only DNS plugin data; never persisted to state. Read via req.Config.
+	DataWO types.Map `tfsdk:"data_wo"`
 	// Flag to disable the config
 	Disable types.Bool `tfsdk:"disable"`
 }

--- a/fwprovider/cluster/acme/model_plugin.go
+++ b/fwprovider/cluster/acme/model_plugin.go
@@ -42,6 +42,8 @@ type acmePluginCreateModel struct {
 
 	// Write-only DNS plugin data; never persisted to state. Read via req.Config.
 	DataWO types.Map `tfsdk:"data_wo"`
+	// Change-detection trigger for the write-only DataWO; bump to force a resend.
+	DataWOVersion types.Int64 `tfsdk:"data_wo_version"`
 	// Flag to disable the config
 	Disable types.Bool `tfsdk:"disable"`
 }

--- a/fwprovider/cluster/acme/resource_acme_dns_plugin.go
+++ b/fwprovider/cluster/acme/resource_acme_dns_plugin.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -25,9 +26,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = &acmePluginResource{}
-	_ resource.ResourceWithConfigure   = &acmePluginResource{}
-	_ resource.ResourceWithImportState = &acmePluginResource{}
+	_ resource.Resource                     = &acmePluginResource{}
+	_ resource.ResourceWithConfigure        = &acmePluginResource{}
+	_ resource.ResourceWithImportState      = &acmePluginResource{}
+	_ resource.ResourceWithConfigValidators = &acmePluginResource{}
 )
 
 // NewACMEPluginResource creates a new resource for managing ACME plugins.
@@ -67,6 +69,14 @@ func (r *acmePluginResource) Schema(
 			"data": schema.MapAttribute{
 				Description: "DNS plugin data.",
 				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"data_wo": schema.MapAttribute{
+				Description: "DNS plugin data (write-only).",
+				MarkdownDescription: "DNS plugin data, supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) " +
+					"so credentials are never stored in Terraform state. Requires Terraform 1.11+. Mutually exclusive with `data`.",
+				Optional:    true,
+				WriteOnly:   true,
 				ElementType: types.StringType,
 			},
 			"digest": schema.StringAttribute{
@@ -123,11 +133,30 @@ func (r *acmePluginResource) Configure(
 	r.client = cfg.Client.Cluster().ACME().Plugins()
 }
 
+// ConfigValidators enforces mutual exclusion between data and its write-only sibling.
+func (r *acmePluginResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.Conflicting(
+			path.MatchRoot("data"),
+			path.MatchRoot("data_wo"),
+		),
+	}
+}
+
 // Create creates a new ACME plugin on the Proxmox cluster.
 func (r *acmePluginResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan acmePluginCreateModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Write-only data_wo is only present in config, never in plan.
+	var dataWO types.Map
+
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("data_wo"), &dataWO)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -139,7 +168,11 @@ func (r *acmePluginResource) Create(ctx context.Context, req resource.CreateRequ
 	createRequest.API = plan.API.ValueString()
 	data := make(plugins.DNSPluginData)
 
-	plan.Data.ElementsAs(ctx, &data, false)
+	if !dataWO.IsNull() {
+		dataWO.ElementsAs(ctx, &data, false)
+	} else {
+		plan.Data.ElementsAs(ctx, &data, false)
+	}
 
 	createRequest.Data = &data
 	createRequest.Disable = plan.Disable.ValueBool()
@@ -199,14 +232,25 @@ func (r *acmePluginResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
+	// A freshly imported resource has only `plugin` set; `digest` is always populated
+	// by Create/Update, so a null digest means "imported, not yet reconciled" and we
+	// must hydrate the `data` attribute from the API for import to work.
+	imported := state.Digest.IsNull()
+
 	state.API = types.StringValue(plugin.API)
 	state.Digest = types.StringValue(plugin.Digest)
 	state.ValidationDelay = types.Int64Value(plugin.ValidationDelay)
 
-	mapValue, diags := types.MapValueFrom(ctx, types.StringType, plugin.Data)
-	resp.Diagnostics.Append(diags...)
+	// Mirror the API data back into the `data` attribute only when it is the source of
+	// truth (the `data` path, or import). When credentials were supplied via the
+	// write-only `data_wo`, `data` is null in state and must stay null; otherwise GET
+	// (which returns the stored data) would create a perpetual diff against null config.
+	if imported || !state.Data.IsNull() {
+		mapValue, diags := types.MapValueFrom(ctx, types.StringType, plugin.Data)
+		resp.Diagnostics.Append(diags...)
 
-	state.Data = mapValue
+		state.Data = mapValue
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -224,17 +268,29 @@ func (r *acmePluginResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	// Write-only data_wo is only present in config, never in plan/state.
+	var dataWO types.Map
+
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("data_wo"), &dataWO)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	updateRequest := &plugins.ACMEPluginsUpdateRequestBody{}
 	updateRequest.API = plan.API.ValueString()
 
 	data := make(plugins.DNSPluginData)
 
-	plan.Data.ElementsAs(ctx, &data, false)
-
-	if plan.Data.IsNull() && !state.Data.IsNull() {
-		toDelete = append(toDelete, "data")
-	} else {
+	switch {
+	case !dataWO.IsNull():
+		dataWO.ElementsAs(ctx, &data, false)
 		updateRequest.Data = &data
+	case !plan.Data.IsNull():
+		plan.Data.ElementsAs(ctx, &data, false)
+		updateRequest.Data = &data
+	case !state.Data.IsNull():
+		toDelete = append(toDelete, "data")
 	}
 
 	updateRequest.Digest = plan.Digest.ValueString()

--- a/fwprovider/cluster/acme/resource_acme_dns_plugin.go
+++ b/fwprovider/cluster/acme/resource_acme_dns_plugin.go
@@ -179,9 +179,13 @@ func (r *acmePluginResource) Create(ctx context.Context, req resource.CreateRequ
 	data := make(plugins.DNSPluginData)
 
 	if !dataWO.IsNull() {
-		dataWO.ElementsAs(ctx, &data, false)
+		resp.Diagnostics.Append(dataWO.ElementsAs(ctx, &data, false)...)
 	} else {
-		plan.Data.ElementsAs(ctx, &data, false)
+		resp.Diagnostics.Append(plan.Data.ElementsAs(ctx, &data, false)...)
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	createRequest.Data = &data
@@ -294,13 +298,17 @@ func (r *acmePluginResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	switch {
 	case !dataWO.IsNull():
-		dataWO.ElementsAs(ctx, &data, false)
+		resp.Diagnostics.Append(dataWO.ElementsAs(ctx, &data, false)...)
 		updateRequest.Data = &data
 	case !plan.Data.IsNull():
-		plan.Data.ElementsAs(ctx, &data, false)
+		resp.Diagnostics.Append(plan.Data.ElementsAs(ctx, &data, false)...)
 		updateRequest.Data = &data
 	case !state.Data.IsNull():
 		toDelete = append(toDelete, "data")
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	updateRequest.Digest = plan.Digest.ValueString()

--- a/fwprovider/cluster/acme/resource_acme_dns_plugin.go
+++ b/fwprovider/cluster/acme/resource_acme_dns_plugin.go
@@ -74,10 +74,20 @@ func (r *acmePluginResource) Schema(
 			"data_wo": schema.MapAttribute{
 				Description: "DNS plugin data (write-only).",
 				MarkdownDescription: "DNS plugin data, supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) " +
-					"so credentials are never stored in Terraform state. Requires Terraform 1.11+. Mutually exclusive with `data`.",
+					"so credentials are never stored in Terraform state. Requires Terraform 1.11+. Mutually exclusive with `data`. " +
+					"Pair with `data_wo_version` to push rotated values.",
 				Optional:    true,
 				WriteOnly:   true,
 				ElementType: types.StringType,
+			},
+			"data_wo_version": schema.Int64Attribute{
+				Description: "Version counter for data_wo.",
+				MarkdownDescription: "Version counter for `data_wo`. Because write-only values are not stored in state, Terraform cannot " +
+					"detect when `data_wo` changes; increment this value to signal a rotation and force the new `data_wo` to be sent.",
+				Optional: true,
+				Validators: []validator.Int64{
+					int64validator.AlsoRequires(path.MatchRoot("data_wo")),
+				},
 			},
 			"digest": schema.StringAttribute{
 				Description: "SHA1 digest of the current configuration.",

--- a/fwprovider/cluster/acme/resource_acme_dns_plugin_test.go
+++ b/fwprovider/cluster/acme/resource_acme_dns_plugin_test.go
@@ -205,7 +205,7 @@ func TestAccResourceACMEDNSPluginWriteOnly(t *testing.T) {
 						"digest",
 					}),
 					// Write-only data_wo must never be persisted to state, and the
-					// deprecated data mirror must stay empty when data_wo is used.
+					// data mirror must stay empty when data_wo is used.
 					resource.TestCheckNoResourceAttr("proxmox_acme_dns_plugin.test_plugin_wo", "data_wo.%"),
 					resource.TestCheckNoResourceAttr("proxmox_acme_dns_plugin.test_plugin_wo", "data.%"),
 					// Behavioral proof: the write-only value actually reached the API
@@ -215,6 +215,55 @@ func TestAccResourceACMEDNSPluginWriteOnly(t *testing.T) {
 						"CF_API_KEY":   "test-api-key",
 					}),
 				),
+			},
+		}},
+		{"data_wo_version triggers rotation", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_acme_dns_plugin" "test_plugin_rotate" {
+						plugin = "{{.PluginName}}-rotate"
+						api = "cf"
+						data_wo = {
+							"CF_API_KEY" = "old-key"
+						}
+						data_wo_version = 1
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("proxmox_acme_dns_plugin.test_plugin_rotate", "data_wo_version", "1"),
+					testCheckACMEPluginDataStored(te, fmt.Sprintf("%s-rotate", pluginName), map[string]string{
+						"CF_API_KEY": "old-key",
+					}),
+				),
+			},
+			{
+				// Rotate the secret: new data_wo value + bumped version. The version
+				// bump is what produces a diff (write-only values are invisible to TF).
+				Config: te.RenderConfig(`
+					resource "proxmox_acme_dns_plugin" "test_plugin_rotate" {
+						plugin = "{{.PluginName}}-rotate"
+						api = "cf"
+						data_wo = {
+							"CF_API_KEY" = "new-key"
+						}
+						data_wo_version = 2
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("proxmox_acme_dns_plugin.test_plugin_rotate", "data_wo_version", "2"),
+					testCheckACMEPluginDataStored(te, fmt.Sprintf("%s-rotate", pluginName), map[string]string{
+						"CF_API_KEY": "new-key",
+					}),
+				),
+			},
+		}},
+		{"data_wo_version requires data_wo", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_acme_dns_plugin" "test_plugin_noversion" {
+						plugin = "{{.PluginName}}-noversion"
+						api = "cf"
+						data_wo_version = 1
+					}`),
+				ExpectError: regexp.MustCompile(`Attribute "data_wo" must be specified when "data_wo_version" is specified`),
 			},
 		}},
 		{"data and data_wo are mutually exclusive", []resource.TestStep{

--- a/fwprovider/cluster/acme/resource_acme_dns_plugin_test.go
+++ b/fwprovider/cluster/acme/resource_acme_dns_plugin_test.go
@@ -12,11 +12,14 @@
 package acme_test
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/test"
 )
@@ -166,5 +169,106 @@ func TestAccResourceACMEDNSPlugin(t *testing.T) {
 				Steps:                    tt.step,
 			})
 		})
+	}
+}
+
+func TestAccResourceACMEDNSPluginWriteOnly(t *testing.T) {
+	t.Parallel()
+
+	te := test.InitEnvironment(t)
+	pluginName := test.SafeResourceName("test-plugin-wo")
+	te.AddTemplateVars(map[string]interface{}{
+		"PluginName": pluginName,
+	})
+
+	tests := []struct {
+		name string
+		step []resource.TestStep
+	}{
+		{"data_wo keeps secrets out of state", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_acme_dns_plugin" "test_plugin_wo" {
+						plugin = "{{.PluginName}}"
+						api = "cf"
+						data_wo = {
+							"CF_API_EMAIL" = "test@example.com"
+							"CF_API_KEY"   = "test-api-key"
+						}
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_acme_dns_plugin.test_plugin_wo", map[string]string{
+						"plugin": pluginName,
+						"api":    "cf",
+					}),
+					test.ResourceAttributesSet("proxmox_acme_dns_plugin.test_plugin_wo", []string{
+						"digest",
+					}),
+					// Write-only data_wo must never be persisted to state, and the
+					// deprecated data mirror must stay empty when data_wo is used.
+					resource.TestCheckNoResourceAttr("proxmox_acme_dns_plugin.test_plugin_wo", "data_wo.%"),
+					resource.TestCheckNoResourceAttr("proxmox_acme_dns_plugin.test_plugin_wo", "data.%"),
+					// Behavioral proof: the write-only value actually reached the API
+					// and was stored, even though it never lands in state.
+					testCheckACMEPluginDataStored(te, pluginName, map[string]string{
+						"CF_API_EMAIL": "test@example.com",
+						"CF_API_KEY":   "test-api-key",
+					}),
+				),
+			},
+		}},
+		{"data and data_wo are mutually exclusive", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_acme_dns_plugin" "test_plugin_conflict" {
+						plugin = "{{.PluginName}}-conflict"
+						api = "cf"
+						data = {
+							"CF_API_KEY" = "test-api-key"
+						}
+						data_wo = {
+							"CF_API_KEY" = "test-api-key"
+						}
+					}`),
+				ExpectError: regexp.MustCompile(`These attributes cannot be configured together: \[data,data_wo\]`),
+			},
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource.ParallelTest(t, resource.TestCase{
+				// Write-only attributes require Terraform 1.11+.
+				TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+					tfversion.SkipBelow(tfversion.Version1_11_0),
+				},
+				ProtoV6ProviderFactories: te.AccProviders,
+				Steps:                    tt.step,
+			})
+		})
+	}
+}
+
+// testCheckACMEPluginDataStored verifies, via a direct API read, that the plugin's
+// DNS data matches want. Used to prove write-only data_wo reaches the API even
+// though it is absent from Terraform state.
+func testCheckACMEPluginDataStored(te *test.Environment, pluginID string, want map[string]string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		plugin, err := te.ClusterClient().ACME().Plugins().Get(context.Background(), pluginID)
+		if err != nil {
+			return fmt.Errorf("reading ACME plugin %q: %w", pluginID, err)
+		}
+
+		if plugin.Data == nil {
+			return fmt.Errorf("ACME plugin %q has no data; write-only data_wo was not stored", pluginID)
+		}
+
+		for k, v := range want {
+			if got := (*plugin.Data)[k]; got != v {
+				return fmt.Errorf("ACME plugin %q data[%q] = %q, want %q", pluginID, k, got, v)
+			}
+		}
+
+		return nil
 	}
 }


### PR DESCRIPTION
### What does this PR do?

The `proxmox_acme_dns_plugin` resource exposes DNS provider credentials (API keys/tokens) through the `data` map attribute, which Terraform persists to state in plaintext (#2961). This PR adds a write-only companion argument `data_wo` (`WriteOnly: true`) so credentials can be supplied via configuration and kept out of plan and state. Because write-only values are invisible to Terraform's diff, a paired `data_wo_version` counter lets users signal a secret rotation and force the new value to be sent. The existing `data` attribute is retained unchanged as a first-class option (no deprecation), and a config validator makes `data` and `data_wo` mutually exclusive. Write-only attributes require Terraform 1.11+ / OpenTofu 1.10+.

### Usage Example

```hcl
resource "proxmox_acme_dns_plugin" "cloudflare" {
  plugin = "cloudflare"
  api    = "cf"

  # Write-only: never stored in Terraform state. Requires Terraform 1.11+.
  data_wo = {
    "CF_API_EMAIL" = "user@example.com"
    "CF_API_KEY"   = var.cf_api_key
  }

  # Bump this when rotating a secret so Terraform pushes the new data_wo value.
  data_wo_version = 1
}
```

`data` and `data_wo` cannot be set together. `data` continues to work exactly as before for users who do not need write-only semantics. `data_wo_version` is optional and only valid alongside `data_wo`.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes - see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

**Acceptance tests** (run against a live Proxmox VE host, through mitmproxy):

```text
$ ./testacc TestAccResourceACMEDNSPlugin -- -v
--- PASS: TestAccResourceACMEDNSPlugin (0.00s)
    --- PASS: TestAccResourceACMEDNSPlugin/invalid_validation_delay (0.17s)
    --- PASS: TestAccResourceACMEDNSPlugin/plugin_with_disable_flag (0.65s)
    --- PASS: TestAccResourceACMEDNSPlugin/plugin_with_validation_delay (0.64s)
    --- PASS: TestAccResourceACMEDNSPlugin/basic_plugin_creation (0.84s)
    --- PASS: TestAccResourceACMEDNSPlugin/update_plugin (2.13s)
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/acme       2.135s

$ ./testacc TestAccResourceACMEDNSPluginWriteOnly -- -v
--- PASS: TestAccResourceACMEDNSPluginWriteOnly (0.00s)
    --- PASS: TestAccResourceACMEDNSPluginWriteOnly/data_and_data_wo_are_mutually_exclusive (0.16s)
    --- PASS: TestAccResourceACMEDNSPluginWriteOnly/data_wo_version_requires_data_wo (0.16s)
    --- PASS: TestAccResourceACMEDNSPluginWriteOnly/data_wo_keeps_secrets_out_of_state (0.67s)
    --- PASS: TestAccResourceACMEDNSPluginWriteOnly/data_wo_version_triggers_rotation (2.17s)
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/acme       2.174s
```

The write-only test does more than assert state: it reads the plugin back through the API to prove the credentials supplied via `data_wo` actually reached and persisted in Proxmox even though they never appear in state. The existing `TestAccResourceACMEDNSPlugin` (including the import round-trip) still passes, confirming the legacy `data` path is unaffected.

**End-to-end verification with real `.tf` config** (locally built provider, live host):

Applying the `data_wo` example above:

- `terraform plan` renders the value as `data_wo = (write-only attribute)`.
- After apply, `terraform.tfstate` contains `"data": null, "data_wo": null` - the secret value does **not** appear anywhere in state.
- `GET /cluster/acme/plugins/<id>` confirms Proxmox stored the credentials:
  `data: "CF_API_KEY=...\nCF_API_EMAIL=..."`.
- A second `terraform plan` reports `No changes. Your infrastructure matches the configuration.` (no perpetual diff).
- Updating `validation_delay` re-sends `data_wo`, so the stored secret survives the update.
- Setting both `data` and `data_wo` fails at plan time:
  `Error: Invalid Attribute Combination - These attributes cannot be configured together: [data,data_wo]`.
- `data_wo_version` without `data_wo` fails at plan time:
  `Error: Attribute "data_wo" must be specified when "data_wo_version" is specified`.

**Secret rotation via `data_wo_version`** (real `.tf`, live host):

- Changing only the `data_wo` value (no version bump) → `No changes` (write-only values are invisible to Terraform's diff, as expected).
- Bumping `data_wo_version` (`1` -> `2`) → `1 to change`; apply pushes the new value, and `GET /cluster/acme/plugins/<id>` confirms the rotated secret (`key-v1` -> `key-v2`) is stored.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2961