### PR TITLE
feat(openid): add write-only client_key_wo to proxmox_realm_openid

### DIFF
--- a/docs/resources/realm_openid.md
+++ b/docs/resources/realm_openid.md
@@ -59,10 +59,14 @@ resource "proxmox_realm_openid" "example" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `acr_values` (String) Authentication Context Class Reference values for the OpenID provider.
 - `audiences` (String) Audiences that the OpenID Issuer may include that are accepted for the client (comma-separated).
 - `autocreate` (Boolean) Automatically create users on the Proxmox cluster if they do not exist.
 - `client_key` (String, Sensitive) OpenID Connect Client Key (secret). Note: stored in Proxmox but not returned by API.
+- `client_key_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) OpenID Connect Client Key (secret), supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) so it is never stored in Terraform state or plan. Requires Terraform 1.11+. Mutually exclusive with `client_key`. Pair with `client_key_wo_version` to push a rotated secret.
+- `client_key_wo_version` (Number) Version counter for `client_key_wo`. Because write-only values are not stored in state, Terraform cannot detect when `client_key_wo` changes; increment this value to signal a rotation and force the new secret to be sent.
 - `comment` (String) Description of the realm.
 - `default` (Boolean) Use this realm as the default for login.
 - `groups_autocreate` (Boolean) Automatically create groups from claims rather than using existing Proxmox VE groups.
@@ -98,6 +102,30 @@ The `client_key` is sent to Proxmox and stored securely, but it's never returned
 - Terraform cannot detect if the client key was changed outside of Terraform
 - You must maintain the client key in your Terraform configuration or use a variable
 - The client key will be marked as sensitive in Terraform state
+
+#### Write-Only Client Key
+
+Because the client key is never read back, persisting it in state serves no drift-detection purpose. To keep the
+secret out of state entirely, use the write-only `client_key_wo` attribute instead of `client_key`. It requires
+Terraform 1.11+ (or OpenTofu 1.10+) and is mutually exclusive with `client_key`.
+
+Since write-only values are invisible to Terraform's diff, changing `client_key_wo` alone has no effect. Pair it
+with `client_key_wo_version` and increment that counter to push a rotated secret to Proxmox.
+
+```hcl
+ephemeral "vault_kv_secret_v2" "sso" {
+  mount = "example"
+  name  = "proxmox/sso"
+}
+
+resource "proxmox_realm_openid" "entra" {
+  realm                 = "sso"
+  issuer_url            = "https://login.microsoftonline.com/<tenant>/v2.0"
+  client_id             = var.oidc_client_id
+  client_key_wo         = ephemeral.vault_kv_secret_v2.sso.data["client_secret"]
+  client_key_wo_version = 1
+}
+```
 
 ### Username Claim
 

--- a/docs/resources/realm_openid.md
+++ b/docs/resources/realm_openid.md
@@ -65,7 +65,7 @@ resource "proxmox_realm_openid" "example" {
 - `audiences` (String) Audiences that the OpenID Issuer may include that are accepted for the client (comma-separated).
 - `autocreate` (Boolean) Automatically create users on the Proxmox cluster if they do not exist.
 - `client_key` (String, Sensitive) OpenID Connect Client Key (secret). Note: stored in Proxmox but not returned by API.
-- `client_key_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) OpenID Connect Client Key (secret), supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) so it is never stored in Terraform state or plan. Requires Terraform 1.11+. Mutually exclusive with `client_key`. Pair with `client_key_wo_version` to push a rotated secret.
+- `client_key_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) OpenID Connect Client Key (secret), supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) so it is never stored in Terraform state or plan. Requires Terraform 1.11+. Mutually exclusive with `client_key`. Pair with `client_key_wo_version` to push a rotated secret.
 - `client_key_wo_version` (Number) Version counter for `client_key_wo`. Because write-only values are not stored in state, Terraform cannot detect when `client_key_wo` changes; increment this value to signal a rotation and force the new secret to be sent.
 - `comment` (String) Description of the realm.
 - `default` (Boolean) Use this realm as the default for login.

--- a/docs/resources/virtual_environment_realm_openid.md
+++ b/docs/resources/virtual_environment_realm_openid.md
@@ -61,10 +61,14 @@ resource "proxmox_virtual_environment_realm_openid" "example" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `acr_values` (String) Authentication Context Class Reference values for the OpenID provider.
 - `audiences` (String) Audiences that the OpenID Issuer may include that are accepted for the client (comma-separated).
 - `autocreate` (Boolean) Automatically create users on the Proxmox cluster if they do not exist.
 - `client_key` (String, Sensitive) OpenID Connect Client Key (secret). Note: stored in Proxmox but not returned by API.
+- `client_key_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) OpenID Connect Client Key (secret), supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) so it is never stored in Terraform state or plan. Requires Terraform 1.11+. Mutually exclusive with `client_key`. Pair with `client_key_wo_version` to push a rotated secret.
+- `client_key_wo_version` (Number) Version counter for `client_key_wo`. Because write-only values are not stored in state, Terraform cannot detect when `client_key_wo` changes; increment this value to signal a rotation and force the new secret to be sent.
 - `comment` (String) Description of the realm.
 - `default` (Boolean) Use this realm as the default for login.
 - `groups_autocreate` (Boolean) Automatically create groups from claims rather than using existing Proxmox VE groups.
@@ -100,6 +104,30 @@ The `client_key` is sent to Proxmox and stored securely, but it's never returned
 - Terraform cannot detect if the client key was changed outside of Terraform
 - You must maintain the client key in your Terraform configuration or use a variable
 - The client key will be marked as sensitive in Terraform state
+
+#### Write-Only Client Key
+
+Because the client key is never read back, persisting it in state serves no drift-detection purpose. To keep the
+secret out of state entirely, use the write-only `client_key_wo` attribute instead of `client_key`. It requires
+Terraform 1.11+ (or OpenTofu 1.10+) and is mutually exclusive with `client_key`.
+
+Since write-only values are invisible to Terraform's diff, changing `client_key_wo` alone has no effect. Pair it
+with `client_key_wo_version` and increment that counter to push a rotated secret to Proxmox.
+
+```hcl
+ephemeral "vault_kv_secret_v2" "sso" {
+  mount = "example"
+  name  = "proxmox/sso"
+}
+
+resource "proxmox_virtual_environment_realm_openid" "entra" {
+  realm                 = "sso"
+  issuer_url            = "https://login.microsoftonline.com/<tenant>/v2.0"
+  client_id             = var.oidc_client_id
+  client_key_wo         = ephemeral.vault_kv_secret_v2.sso.data["client_secret"]
+  client_key_wo_version = 1
+}
+```
 
 ### Username Claim
 

--- a/docs/resources/virtual_environment_realm_openid.md
+++ b/docs/resources/virtual_environment_realm_openid.md
@@ -67,7 +67,7 @@ resource "proxmox_virtual_environment_realm_openid" "example" {
 - `audiences` (String) Audiences that the OpenID Issuer may include that are accepted for the client (comma-separated).
 - `autocreate` (Boolean) Automatically create users on the Proxmox cluster if they do not exist.
 - `client_key` (String, Sensitive) OpenID Connect Client Key (secret). Note: stored in Proxmox but not returned by API.
-- `client_key_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) OpenID Connect Client Key (secret), supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) so it is never stored in Terraform state or plan. Requires Terraform 1.11+. Mutually exclusive with `client_key`. Pair with `client_key_wo_version` to push a rotated secret.
+- `client_key_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) OpenID Connect Client Key (secret), supplied as a [write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) so it is never stored in Terraform state or plan. Requires Terraform 1.11+. Mutually exclusive with `client_key`. Pair with `client_key_wo_version` to push a rotated secret.
 - `client_key_wo_version` (Number) Version counter for `client_key_wo`. Because write-only values are not stored in state, Terraform cannot detect when `client_key_wo` changes; increment this value to signal a rotation and force the new secret to be sent.
 - `comment` (String) Description of the realm.
 - `default` (Boolean) Use this realm as the default for login.

--- a/fwprovider/access/model_realm_openid.go
+++ b/fwprovider/access/model_realm_openid.go
@@ -15,26 +15,30 @@ import (
 )
 
 type realmOpenIDModel struct {
-	ID               types.String `tfsdk:"id"`
-	Realm            types.String `tfsdk:"realm"`
-	IssuerURL        types.String `tfsdk:"issuer_url"`
-	ClientID         types.String `tfsdk:"client_id"`
-	ClientKey        types.String `tfsdk:"client_key"`
-	AutoCreate       types.Bool   `tfsdk:"autocreate"`
-	UsernameClaim    types.String `tfsdk:"username_claim"`
-	GroupsClaim      types.String `tfsdk:"groups_claim"`
-	GroupsAutocreate types.Bool   `tfsdk:"groups_autocreate"`
-	GroupsOverwrite  types.Bool   `tfsdk:"groups_overwrite"`
-	Scopes           types.String `tfsdk:"scopes"`
-	Prompt           types.String `tfsdk:"prompt"`
-	ACRValues        types.String `tfsdk:"acr_values"`
-	Audiences        types.String `tfsdk:"audiences"`
-	QueryUserinfo    types.Bool   `tfsdk:"query_userinfo"`
-	Comment          types.String `tfsdk:"comment"`
-	Default          types.Bool   `tfsdk:"default"`
+	ID        types.String `tfsdk:"id"`
+	Realm     types.String `tfsdk:"realm"`
+	IssuerURL types.String `tfsdk:"issuer_url"`
+	ClientID  types.String `tfsdk:"client_id"`
+	ClientKey types.String `tfsdk:"client_key"`
+	// Write-only client secret; never persisted to state. Read via req.Config.
+	ClientKeyWO types.String `tfsdk:"client_key_wo"`
+	// Change-detection trigger for the write-only ClientKeyWO; bump to force a resend.
+	ClientKeyWOVersion types.Int64  `tfsdk:"client_key_wo_version"`
+	AutoCreate         types.Bool   `tfsdk:"autocreate"`
+	UsernameClaim      types.String `tfsdk:"username_claim"`
+	GroupsClaim        types.String `tfsdk:"groups_claim"`
+	GroupsAutocreate   types.Bool   `tfsdk:"groups_autocreate"`
+	GroupsOverwrite    types.Bool   `tfsdk:"groups_overwrite"`
+	Scopes             types.String `tfsdk:"scopes"`
+	Prompt             types.String `tfsdk:"prompt"`
+	ACRValues          types.String `tfsdk:"acr_values"`
+	Audiences          types.String `tfsdk:"audiences"`
+	QueryUserinfo      types.Bool   `tfsdk:"query_userinfo"`
+	Comment            types.String `tfsdk:"comment"`
+	Default            types.Bool   `tfsdk:"default"`
 }
 
-func (m *realmOpenIDModel) toCreateRequest() *access.RealmCreateRequestBody {
+func (m *realmOpenIDModel) toCreateRequest(clientKeyWO types.String) *access.RealmCreateRequestBody {
 	req := &access.RealmCreateRequestBody{
 		Realm:     m.Realm.ValueString(),
 		Type:      "openid",
@@ -42,7 +46,12 @@ func (m *realmOpenIDModel) toCreateRequest() *access.RealmCreateRequestBody {
 		ClientID:  m.ClientID.ValueStringPointer(),
 	}
 
-	if !m.ClientKey.IsNull() {
+	// client_key (state-persisted) and client_key_wo (write-only) are mutually
+	// exclusive (enforced by ConfigValidators); prefer the write-only value.
+	switch {
+	case !clientKeyWO.IsNull():
+		req.ClientKey = clientKeyWO.ValueStringPointer()
+	case !m.ClientKey.IsNull():
 		req.ClientKey = m.ClientKey.ValueStringPointer()
 	}
 
@@ -97,7 +106,7 @@ func (m *realmOpenIDModel) toCreateRequest() *access.RealmCreateRequestBody {
 	return req
 }
 
-func (m *realmOpenIDModel) toUpdateRequest(state *realmOpenIDModel) *access.RealmUpdateRequestBody {
+func (m *realmOpenIDModel) toUpdateRequest(state *realmOpenIDModel, clientKeyWO types.String) *access.RealmUpdateRequestBody {
 	req := &access.RealmUpdateRequestBody{}
 	var toDelete []string
 
@@ -110,8 +119,16 @@ func (m *realmOpenIDModel) toUpdateRequest(state *realmOpenIDModel) *access.Real
 		req.ClientID = m.ClientID.ValueStringPointer()
 	}
 
+	// Client key: when supplied via the write-only client_key_wo, resend it on every
+	// update (write-only values are invisible to diffs, so rotation is driven by the
+	// client_key_wo_version bump). Otherwise diff the state-tracked client_key.
+	if !clientKeyWO.IsNull() {
+		req.ClientKey = clientKeyWO.ValueStringPointer()
+	} else {
+		updateStringAttribute(&req.ClientKey, m.ClientKey, state.ClientKey, &toDelete, "client-key")
+	}
+
 	// Optional fields: support unsetting using the API's `delete` parameter.
-	updateStringAttribute(&req.ClientKey, m.ClientKey, state.ClientKey, &toDelete, "client-key")
 	updateStringAttribute(&req.Scopes, m.Scopes, state.Scopes, &toDelete, "scopes")
 	updateStringAttribute(&req.Prompt, m.Prompt, state.Prompt, &toDelete, "prompt")
 	updateStringAttribute(&req.ACRValues, m.ACRValues, state.ACRValues, &toDelete, "acr-values")

--- a/fwprovider/access/resource_realm_ldap.go
+++ b/fwprovider/access/resource_realm_ldap.go
@@ -334,7 +334,6 @@ func (r *realmLDAPResource) read(
 	return nil
 }
 
-//nolint:dupl
 func (r *realmLDAPResource) Update(
 	ctx context.Context,
 	req resource.UpdateRequest,

--- a/fwprovider/access/resource_realm_openid.go
+++ b/fwprovider/access/resource_realm_openid.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -20,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/attribute"
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/config"
@@ -29,9 +32,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = (*realmOpenIDResource)(nil)
-	_ resource.ResourceWithConfigure   = (*realmOpenIDResource)(nil)
-	_ resource.ResourceWithImportState = (*realmOpenIDResource)(nil)
+	_ resource.Resource                     = (*realmOpenIDResource)(nil)
+	_ resource.ResourceWithConfigure        = (*realmOpenIDResource)(nil)
+	_ resource.ResourceWithImportState      = (*realmOpenIDResource)(nil)
+	_ resource.ResourceWithConfigValidators = (*realmOpenIDResource)(nil)
 )
 
 type realmOpenIDResource struct {
@@ -91,6 +95,25 @@ func (r *realmOpenIDResource) Schema(
 				Sensitive:   true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"client_key_wo": schema.StringAttribute{
+				Description: "OpenID Connect Client Key (secret), supplied as a write-only argument.",
+				MarkdownDescription: "OpenID Connect Client Key (secret), supplied as a " +
+					"[write-only argument](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only) " +
+					"so it is never stored in Terraform state or plan. Requires Terraform 1.11+. " +
+					"Mutually exclusive with `client_key`. Pair with `client_key_wo_version` to push a rotated secret.",
+				Optional:  true,
+				WriteOnly: true,
+			},
+			"client_key_wo_version": schema.Int64Attribute{
+				Description: "Version counter for client_key_wo.",
+				MarkdownDescription: "Version counter for `client_key_wo`. Because write-only values are not stored in " +
+					"state, Terraform cannot detect when `client_key_wo` changes; increment this value to signal a rotation " +
+					"and force the new secret to be sent.",
+				Optional: true,
+				Validators: []validator.Int64{
+					int64validator.AlsoRequires(path.MatchRoot("client_key_wo")),
 				},
 			},
 			"autocreate": schema.BoolAttribute{
@@ -179,6 +202,16 @@ func (r *realmOpenIDResource) Configure(
 	r.client = cfg.Client
 }
 
+// ConfigValidators enforces mutual exclusion between client_key and its write-only sibling.
+func (r *realmOpenIDResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.Conflicting(
+			path.MatchRoot("client_key"),
+			path.MatchRoot("client_key_wo"),
+		),
+	}
+}
+
 func (r *realmOpenIDResource) Create(
 	ctx context.Context,
 	req resource.CreateRequest,
@@ -192,7 +225,16 @@ func (r *realmOpenIDResource) Create(
 		return
 	}
 
-	createReq := plan.toCreateRequest()
+	// Write-only client_key_wo is present only in config, never in plan or state.
+	var clientKeyWO types.String
+
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("client_key_wo"), &clientKeyWO)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createReq := plan.toCreateRequest(clientKeyWO)
 
 	err := r.client.Access().CreateRealm(ctx, createReq)
 	if err != nil {
@@ -265,7 +307,6 @@ func (r *realmOpenIDResource) readOpenID(
 	return nil
 }
 
-//nolint:dupl
 func (r *realmOpenIDResource) Update(
 	ctx context.Context,
 	req resource.UpdateRequest,
@@ -281,7 +322,16 @@ func (r *realmOpenIDResource) Update(
 		return
 	}
 
-	updateReq := plan.toUpdateRequest(&state)
+	// Write-only client_key_wo is present only in config, never in plan or state.
+	var clientKeyWO types.String
+
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("client_key_wo"), &clientKeyWO)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	updateReq := plan.toUpdateRequest(&state, clientKeyWO)
 
 	err := r.client.Access().UpdateRealm(ctx, plan.Realm.ValueString(), updateReq)
 	if err != nil {

--- a/fwprovider/access/resource_realm_openid.go
+++ b/fwprovider/access/resource_realm_openid.go
@@ -104,6 +104,7 @@ func (r *realmOpenIDResource) Schema(
 					"so it is never stored in Terraform state or plan. Requires Terraform 1.11+. " +
 					"Mutually exclusive with `client_key`. Pair with `client_key_wo_version` to push a rotated secret.",
 				Optional:  true,
+				Sensitive: true,
 				WriteOnly: true,
 			},
 			"client_key_wo_version": schema.Int64Attribute{

--- a/fwprovider/access/resource_realm_openid_test.go
+++ b/fwprovider/access/resource_realm_openid_test.go
@@ -12,9 +12,14 @@
 package access_test
 
 import (
+	"context"
+	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/test"
 )
@@ -49,6 +54,164 @@ func TestAccRealmOpenIDUsernameClaim(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccRealmOpenIDWriteOnly(t *testing.T) {
+	t.Parallel()
+
+	te := test.InitEnvironment(t)
+	realm := test.SafeResourceName("oidc-wo")
+	te.AddTemplateVars(map[string]interface{}{
+		"Realm": realm,
+	})
+
+	tests := []struct {
+		name string
+		step []resource.TestStep
+	}{
+		{"client_key_wo keeps the secret out of state", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_realm_openid" "test_wo" {
+						realm                 = "{{.Realm}}"
+						issuer_url            = "https://accounts.google.com"
+						client_id             = "test-client-id"
+						client_key_wo         = "super-secret-value"
+						client_key_wo_version = 1
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					test.ResourceAttributes("proxmox_realm_openid.test_wo", map[string]string{
+						"realm":                 realm,
+						"client_id":             "test-client-id",
+						"client_key_wo_version": "1",
+					}),
+					// The write-only secret must never be persisted, and the legacy
+					// client_key mirror must stay unset when client_key_wo is used.
+					resource.TestCheckNoResourceAttr("proxmox_realm_openid.test_wo", "client_key_wo"),
+					resource.TestCheckNoResourceAttr("proxmox_realm_openid.test_wo", "client_key"),
+					// Behavioral proof: the realm was actually created on the server.
+					testCheckOpenIDRealmExists(te, realm),
+				),
+			},
+		}},
+		{"client_key_wo_version triggers rotation", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_realm_openid" "test_rotate" {
+						realm                 = "{{.Realm}}-rot"
+						issuer_url            = "https://accounts.google.com"
+						client_id             = "test-client-id"
+						client_key_wo         = "old-secret"
+						client_key_wo_version = 1
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("proxmox_realm_openid.test_rotate", "client_key_wo_version", "1"),
+					resource.TestCheckNoResourceAttr("proxmox_realm_openid.test_rotate", "client_key_wo"),
+				),
+			},
+			{
+				// Rotate the secret: a new client_key_wo with a bumped version. The
+				// version bump is what produces a diff, since write-only values are
+				// invisible to Terraform. Apply must succeed and re-send the secret.
+				Config: te.RenderConfig(`
+					resource "proxmox_realm_openid" "test_rotate" {
+						realm                 = "{{.Realm}}-rot"
+						issuer_url            = "https://accounts.google.com"
+						client_id             = "test-client-id"
+						client_key_wo         = "new-secret"
+						client_key_wo_version = 2
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("proxmox_realm_openid.test_rotate", "client_key_wo_version", "2"),
+					resource.TestCheckNoResourceAttr("proxmox_realm_openid.test_rotate", "client_key_wo"),
+				),
+			},
+		}},
+		{"migrating from client_key to client_key_wo clears it from state", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_realm_openid" "test_migrate" {
+						realm      = "{{.Realm}}-mig"
+						issuer_url = "https://accounts.google.com"
+						client_id  = "test-client-id"
+						client_key = "legacy-secret"
+					}`),
+				Check: resource.TestCheckResourceAttr("proxmox_realm_openid.test_migrate", "client_key", "legacy-secret"),
+			},
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_realm_openid" "test_migrate" {
+						realm                 = "{{.Realm}}-mig"
+						issuer_url            = "https://accounts.google.com"
+						client_id             = "test-client-id"
+						client_key_wo         = "migrated-secret"
+						client_key_wo_version = 1
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("proxmox_realm_openid.test_migrate", "client_key_wo_version", "1"),
+					resource.TestCheckNoResourceAttr("proxmox_realm_openid.test_migrate", "client_key"),
+					resource.TestCheckNoResourceAttr("proxmox_realm_openid.test_migrate", "client_key_wo"),
+				),
+			},
+		}},
+		{"client_key_wo_version requires client_key_wo", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_realm_openid" "test_noversion" {
+						realm                 = "{{.Realm}}-nov"
+						issuer_url            = "https://accounts.google.com"
+						client_id             = "test-client-id"
+						client_key_wo_version = 1
+					}`),
+				ExpectError: regexp.MustCompile(`Attribute "client_key_wo" must be specified when "client_key_wo_version" is\s+specified`),
+			},
+		}},
+		{"client_key and client_key_wo are mutually exclusive", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_realm_openid" "test_conflict" {
+						realm         = "{{.Realm}}-cnf"
+						issuer_url    = "https://accounts.google.com"
+						client_id     = "test-client-id"
+						client_key    = "secret-a"
+						client_key_wo = "secret-b"
+					}`),
+				ExpectError: regexp.MustCompile(`These attributes cannot be configured together: \[client_key,client_key_wo\]`),
+			},
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource.ParallelTest(t, resource.TestCase{
+				// Write-only attributes require Terraform 1.11+.
+				TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+					tfversion.SkipBelow(tfversion.Version1_11_0),
+				},
+				ProtoV6ProviderFactories: te.AccProviders,
+				Steps:                    tt.step,
+			})
+		})
+	}
+}
+
+// testCheckOpenIDRealmExists verifies, via a direct API read, that the realm exists
+// on the server and is an OpenID realm. Used to prove a realm configured solely with
+// the write-only client_key_wo is actually created, even though the secret never
+// lands in Terraform state (and the API never returns it for read-back).
+func testCheckOpenIDRealmExists(te *test.Environment, realm string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		data, err := te.AccessClient().GetRealm(context.Background(), realm)
+		if err != nil {
+			return fmt.Errorf("reading OpenID realm %q: %w", realm, err)
+		}
+
+		if data.Type != "openid" {
+			return fmt.Errorf("realm %q has type %q, want %q", realm, data.Type, "openid")
+		}
+
+		return nil
+	}
 }
 
 func TestAccRealmOpenID(t *testing.T) {

--- a/templates/resources/realm_openid.md.tmpl
+++ b/templates/resources/realm_openid.md.tmpl
@@ -46,6 +46,30 @@ The `client_key` is sent to Proxmox and stored securely, but it's never returned
 - You must maintain the client key in your Terraform configuration or use a variable
 - The client key will be marked as sensitive in Terraform state
 
+#### Write-Only Client Key
+
+Because the client key is never read back, persisting it in state serves no drift-detection purpose. To keep the
+secret out of state entirely, use the write-only `client_key_wo` attribute instead of `client_key`. It requires
+Terraform 1.11+ (or OpenTofu 1.10+) and is mutually exclusive with `client_key`.
+
+Since write-only values are invisible to Terraform's diff, changing `client_key_wo` alone has no effect. Pair it
+with `client_key_wo_version` and increment that counter to push a rotated secret to Proxmox.
+
+```hcl
+ephemeral "vault_kv_secret_v2" "sso" {
+  mount = "example"
+  name  = "proxmox/sso"
+}
+
+resource "proxmox_realm_openid" "entra" {
+  realm                 = "sso"
+  issuer_url            = "https://login.microsoftonline.com/<tenant>/v2.0"
+  client_id             = var.oidc_client_id
+  client_key_wo         = ephemeral.vault_kv_secret_v2.sso.data["client_secret"]
+  client_key_wo_version = 1
+}
+```
+
 ### Username Claim
 
 The `username_claim` attribute is **fixed after creation** — it cannot be changed once the realm is created. Changing it requires destroying and recreating the realm. Common values:

--- a/templates/resources/virtual_environment_realm_openid.md.tmpl
+++ b/templates/resources/virtual_environment_realm_openid.md.tmpl
@@ -48,6 +48,30 @@ The `client_key` is sent to Proxmox and stored securely, but it's never returned
 - You must maintain the client key in your Terraform configuration or use a variable
 - The client key will be marked as sensitive in Terraform state
 
+#### Write-Only Client Key
+
+Because the client key is never read back, persisting it in state serves no drift-detection purpose. To keep the
+secret out of state entirely, use the write-only `client_key_wo` attribute instead of `client_key`. It requires
+Terraform 1.11+ (or OpenTofu 1.10+) and is mutually exclusive with `client_key`.
+
+Since write-only values are invisible to Terraform's diff, changing `client_key_wo` alone has no effect. Pair it
+with `client_key_wo_version` and increment that counter to push a rotated secret to Proxmox.
+
+```hcl
+ephemeral "vault_kv_secret_v2" "sso" {
+  mount = "example"
+  name  = "proxmox/sso"
+}
+
+resource "proxmox_virtual_environment_realm_openid" "entra" {
+  realm                 = "sso"
+  issuer_url            = "https://login.microsoftonline.com/<tenant>/v2.0"
+  client_id             = var.oidc_client_id
+  client_key_wo         = ephemeral.vault_kv_secret_v2.sso.data["client_secret"]
+  client_key_wo_version = 1
+}
+```
+
 ### Username Claim
 
 The `username_claim` attribute is **fixed after creation** — it cannot be changed once the realm is created. Changing it requires destroying and recreating the realm. Common values:


### PR DESCRIPTION
### What does this PR do?

`proxmox_realm_openid.client_key` holds the OIDC client secret, which Terraform persists to state. This PR adds a write-only companion argument `client_key_wo` (`WriteOnly: true`) so the secret can be supplied via configuration and kept out of plan and state including being fed directly from an ephemeral `vault_kv_secret_v2` read. Write-only attributes require Terraform 1.11+ / OpenTofu 1.10+.

This mirrors the `data_wo` convention established for `proxmox_acme_dns_plugin` (#2961).

### Usage Example

```hcl
ephemeral "vault_kv_secret_v2" "sso" {
  mount = "example"
  name  = "proxmox/sso"
}

resource "proxmox_realm_openid" "entra" {
  realm      = "sso"
  issuer_url = "https://login.microsoftonline.com/<tenant>/v2.0"
  client_id  = var.oidc_client_id

  # Write-only: never stored in Terraform state. Requires Terraform 1.11+.
  client_key_wo = ephemeral.vault_kv_secret_v2.sso.data["client_secret"]

  # Bump this when rotating the secret so Terraform pushes the new client_key_wo value.
  client_key_wo_version = 1
}
```

`client_key` and `client_key_wo` cannot be set together. `client_key` continues to work exactly as before for users who do not need write-only semantics. `client_key_wo_version` is optional and only valid alongside `client_key_wo`.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`).
- [x] I have added / updated acceptance tests (**required** see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes; `client_key` unchanged).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

**Acceptance tests** (run against a live Proxmox VE host):

```text
$ ./testacc TestAccRealmOpenIDWriteOnly -- -v
--- PASS: TestAccRealmOpenIDWriteOnly (0.00s)
    --- PASS: TestAccRealmOpenIDWriteOnly/client_key_and_client_key_wo_are_mutually_exclusive (0.15s)
    --- PASS: TestAccRealmOpenIDWriteOnly/client_key_wo_version_requires_client_key_wo (0.13s)
    --- PASS: TestAccRealmOpenIDWriteOnly/client_key_wo_version_triggers_rotation (1.10s)
    --- PASS: TestAccRealmOpenIDWriteOnly/migrating_from_client_key_to_client_key_wo_clears_it_from_state (2.06s)
    --- PASS: TestAccRealmOpenIDWriteOnly/client_key_wo_keeps_the_secret_out_of_state (2.71s)
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/access

$ ./testacc TestAccRealmOpenID -- -v          # backward-compat, legacy client_key path
--- PASS: TestAccRealmOpenID (2.71s)
$ ./testacc TestAccRealmOpenIDUsernameClaim -- -v
--- PASS: TestAccRealmOpenIDUsernameClaim (0.84s)
```

The test suite covers: write-only create (secret absent from state, realm confirmed via direct API read), secret rotation via `client_key_wo_version`, migration from `client_key` to `client_key_wo` (legacy value cleared from state), the `client_key`/`client_key_wo` mutual-exclusivity error, and the `client_key_wo_version` requires `client_key_wo` error. The pre-existing tests still pass, confirming the legacy `client_key` path is unaffected.

**End-to-end verification with a real `.tf` config** (locally built provider, live host Proxmox VE 9.2.2):

Applying a realm configured with `client_key_wo`:

- `terraform plan` renders the value as `client_key_wo = (write-only attribute)` the literal secret is not shown.
- After apply, `terraform.tfstate` contains `"client_key": null, "client_key_wo": null` the secret does **not** appear anywhere in state (a `grep` for the literal value in the state file returns nothing).
- A second `terraform plan` reports `No changes. Your infrastructure matches the configuration.` (no perpetual diff).
- Setting both `client_key` and `client_key_wo` fails at plan time:
  `Error: Invalid Attribute Combination - These attributes cannot be configured together: [client_key,client_key_wo]`.
- `client_key_wo_version` without `client_key_wo` fails at plan time:
  `Error: Attribute "client_key_wo" must be specified when "client_key_wo_version" is specified`.

**Secret rotation via `client_key_wo_version`** (real `.tf`, live host):

- Bumping `client_key_wo_version` (`1` → `2`) with a new value → plan shows `~ client_key_wo_version = 1 -> 2` (`1 to change`); apply pushes the new secret.
- `GET /api2/json/access/domains/<realm>` confirms the rotated secret is stored server-side (`initial-super-secret` → `rotated-new-secret`).
- `terraform destroy` removes the realm; the API confirms it is gone.

**Wire-level verification with mitmproxy** also captured the create `POST` (`client-key=<secret>`) and rotation `PUT` (`client-key=<new-secret>`) request bodies, confirming the write-only value reaches the API on both paths.

### Note on API behavior (`client_key` is returned by PVE)

While verifying this on a live host I found that contrary to the long-standing note in the docs and the `fromAPIResponse` comment (*"client_key is never returned by the API"*)  `GET /access/domains/{realm}` **does** return the OpenID `client-key` value verbatim. This is not a recent regression.

This does not diminish the value of write-only support, nor does it change behavior in this PR:

- Write-only attributes are the only way to consume an ephemeral value such as `vault_kv_secret_v2` version-independent and the primary motivation here.
- `client_key_wo` keeps the secret out of Terraform **state** regardless of what the API returns.
- The provider still does not read `client-key` back into the model, so `client_key` behavior is unchanged.

Correcting the stale "never returned by the API" doc note and adding real drift detection for the plain `client_key` are follow-ups outside this PR's scope.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2963