### PR TITLE
fix(vm): persist `boot_order` on first apply when cloning

### DIFF
--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -1663,6 +1663,37 @@ func TestAccResourceVMClone(t *testing.T) {
 				}),
 			),
 		}}},
+		{"clone persists boot_order on first apply", []resource.TestStep{{
+			// Template auto-derives boot order ["scsi0", "net0"]; the clone overrides it to
+			// just ["scsi0"]. Without applying boot_order on the clone create path, state
+			// retains the inherited order, producing a non-empty plan after the first apply.
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "template" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					template  = true
+					disk {
+						datastore_id = "local-lvm"
+						interface    = "scsi0"
+						size         = 8
+					}
+					network_device {
+						bridge = "vmbr0"
+					}
+				}
+				resource "proxmox_virtual_environment_vm" "clone" {
+					node_name  = "{{.NodeName}}"
+					started    = false
+					boot_order = ["scsi0"]
+					clone {
+						vm_id = proxmox_virtual_environment_vm.template.vm_id
+					}
+				}`),
+			Check: ResourceAttributes("proxmox_virtual_environment_vm.clone", map[string]string{
+				"boot_order.#": "1",
+				"boot_order.0": "scsi0",
+			}),
+		}}},
 		{"clone cpu.architecture as root", []resource.TestStep{{
 			Config: te.RenderConfig(`
 				resource "proxmox_virtual_environment_vm" "template" {

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -2775,6 +2775,18 @@ func vmCreateClone(ctx context.Context, d *schema.ResourceData, m any) diag.Diag
 
 	updateBody.StartOnBoot = &onBoot
 
+	// Apply an explicit boot order to the clone; when empty, preserve the source VM's order.
+	if bootOrder := d.Get(mkBootOrder).([]any); len(bootOrder) > 0 {
+		bootOrderConverted := make([]string, len(bootOrder))
+		for i, device := range bootOrder {
+			bootOrderConverted[i] = device.(string)
+		}
+
+		updateBody.Boot = &vms.CustomBoot{
+			Order: &bootOrderConverted,
+		}
+	}
+
 	updateBody.SMBIOS = vmGetSMBIOS(d)
 
 	updateBody.StartupOrder = vmGetStartupOrder(d)


### PR DESCRIPTION
### What does this PR do?

When cloning a VM, a configured `boot_order` was silently dropped on the first apply. The clone
create path (`vmCreateClone`) builds a post-clone update body with dozens of config overrides
but never set the boot order, so the cloned VM kept the source VM's order. The value only
reached Proxmox on the *second* apply via the update path's `HasChange` branch, producing a
spurious in-place diff that converged on the third apply (state read back was already correct —
this was a create-vs-update field asymmetry, not a read gap). This sets `boot_order` from config
in the clone create path when explicitly configured, leaving the source's order intact when
unset.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

New acceptance test `TestAccResourceVMClone/clone_persists_boot_order_on_first_apply` clones a
template whose auto-derived boot order is `["scsi0", "net0"]` and overrides it on the clone to
`["scsi0"]`. The default post-apply empty-plan check plus an explicit state assertion catch the
bug.

**Before the fix (RED)** — clone retained the inherited order:

```text
=== RUN   TestAccResourceVMClone/clone_persists_boot_order_on_first_apply
    resource_vm_test.go:1958: Step 1/1 error: Check failed: proxmox_virtual_environment_vm.clone:
        Attribute "boot_order.#" value: expected '2' to match '1'
--- FAIL: TestAccResourceVMClone/clone_persists_boot_order_on_first_apply (10.63s)
```

**After the fix (GREEN)** — boot order applied on first apply, no pending diff:

```text
$ ./testacc TestAccResourceVMClone
--- PASS: TestAccResourceVMClone (0.00s)
    --- PASS: TestAccResourceVMClone/clone_with_network_device (5.08s)
    --- PASS: TestAccResourceVMClone/clone_persists_boot_order_on_first_apply (10.25s)
    --- PASS: TestAccResourceVMClone/clone_cpu.architecture_as_root (4.86s)
    --- PASS: TestAccResourceVMClone/clone_machine_type (4.05s)
    --- PASS: TestAccResourceVMClone/clone_no_vga_block (3.87s)
    --- PASS: TestAccResourceVMClone/clone_with_network_devices (3.64s)
    --- PASS: TestAccResourceVMClone/clone_initialization_datastore_does_not_exist (3.54s)
    --- PASS: TestAccResourceVMClone/clone_hotplug_inherited (3.83s)
    --- PASS: TestAccResourceVMClone/clone_hotplug_override (3.78s)
    --- PASS: TestAccResourceVMClone/clone_user_account_drift (7.31s)
    --- PASS: TestAccResourceVMClone/clone_with_empty_ip_config_block (5.35s)
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	16.965s
```

Full clone suite (11 subtests) green — no regressions. `make lint` reports `0 issues`.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2966

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Opus 4.8). All changes have been reviewed and verified by a human.*
