### PR TITLE
fix(cluster): handle `influx_token` write-only status in `metrics_server`

### DIFF
--- a/docs/resources/metrics_server.md
+++ b/docs/resources/metrics_server.md
@@ -50,6 +50,8 @@ resource "proxmox_metrics_server" "opentelemetry_server" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `disable` (Boolean) Set this to `true` to disable this metric server. Defaults to `false`.
 - `graphite_path` (String) Root graphite path (ex: `proxmox.mycluster.mykey`).
 - `graphite_proto` (String) Protocol to send graphite data. Choice is between `udp` | `tcp`. If not set, PVE default is `udp`.
@@ -58,7 +60,9 @@ resource "proxmox_metrics_server" "opentelemetry_server" {
 - `influx_db_proto` (String) Protocol for InfluxDB. Choice is between `udp` | `http` | `https`. If not set, PVE default is `udp`.
 - `influx_max_body_size` (Number) InfluxDB max-body-size in bytes. Requests are batched up to this size. If not set, PVE default is `25000000`.
 - `influx_organization` (String) The InfluxDB organization. Only necessary when using the http v2 api. Has no meaning when using v2 compatibility api.
-- `influx_token` (String, Sensitive) The InfluxDB access token. Only necessary when using the http v2 api. If the v2 compatibility api is used, use `user:password` instead.
+- `influx_token` (String, Sensitive) The InfluxDB access token. Only necessary when using the http v2 api. If the v2 compatibility api is used, use `user:password` instead. Cannot be used together with `influx_token_wo`.
+- `influx_token_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The InfluxDB access token (write-only). Prefer this over `influx_token` to avoid storing the secret in Terraform state. Cannot be used together with `influx_token`.
+- `influx_token_wo_version` (Number) Increment this counter to rotate `influx_token_wo` without changing other fields.
 - `influx_verify` (Boolean) Set to `false` to disable certificate verification for https endpoints. If not set, PVE default is `true`.
 - `mtu` (Number) MTU (maximum transmission unit) for metrics transmission over UDP. If not set, PVE default is `1500` (allowed `512` - `65536`).
 - `opentelemetry_compression` (String) OpenTelemetry compression algorithm for requests. Choice is between `none` | `gzip`. If not set, PVE default is `gzip`.

--- a/docs/resources/virtual_environment_metrics_server.md
+++ b/docs/resources/virtual_environment_metrics_server.md
@@ -52,6 +52,8 @@ resource "proxmox_virtual_environment_metrics_server" "opentelemetry_server" {
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `disable` (Boolean) Set this to `true` to disable this metric server. Defaults to `false`.
 - `graphite_path` (String) Root graphite path (ex: `proxmox.mycluster.mykey`).
 - `graphite_proto` (String) Protocol to send graphite data. Choice is between `udp` | `tcp`. If not set, PVE default is `udp`.
@@ -60,7 +62,9 @@ resource "proxmox_virtual_environment_metrics_server" "opentelemetry_server" {
 - `influx_db_proto` (String) Protocol for InfluxDB. Choice is between `udp` | `http` | `https`. If not set, PVE default is `udp`.
 - `influx_max_body_size` (Number) InfluxDB max-body-size in bytes. Requests are batched up to this size. If not set, PVE default is `25000000`.
 - `influx_organization` (String) The InfluxDB organization. Only necessary when using the http v2 api. Has no meaning when using v2 compatibility api.
-- `influx_token` (String, Sensitive) The InfluxDB access token. Only necessary when using the http v2 api. If the v2 compatibility api is used, use `user:password` instead.
+- `influx_token` (String, Sensitive) The InfluxDB access token. Only necessary when using the http v2 api. If the v2 compatibility api is used, use `user:password` instead. Cannot be used together with `influx_token_wo`.
+- `influx_token_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The InfluxDB access token (write-only). Prefer this over `influx_token` to avoid storing the secret in Terraform state. Cannot be used together with `influx_token`.
+- `influx_token_wo_version` (Number) Increment this counter to rotate `influx_token_wo` without changing other fields.
 - `influx_verify` (Boolean) Set to `false` to disable certificate verification for https endpoints. If not set, PVE default is `true`.
 - `mtu` (Number) MTU (maximum transmission unit) for metrics transmission over UDP. If not set, PVE default is `1500` (allowed `512` - `65536`).
 - `opentelemetry_compression` (String) OpenTelemetry compression algorithm for requests. Choice is between `none` | `gzip`. If not set, PVE default is `gzip`.

--- a/fwprovider/cluster/metrics/model_metrics_server.go
+++ b/fwprovider/cluster/metrics/model_metrics_server.go
@@ -29,6 +29,8 @@ type metricsServerModel struct {
 	InfluxMaxBodySize      types.Int64  `tfsdk:"influx_max_body_size"`
 	InfluxOrganization     types.String `tfsdk:"influx_organization"`
 	InfluxToken            types.String `tfsdk:"influx_token"`
+	InfluxTokenWO          types.String `tfsdk:"influx_token_wo"`
+	InfluxTokenWOVersion   types.Int64  `tfsdk:"influx_token_wo_version"`
 	InfluxVerify           types.Bool   `tfsdk:"influx_verify"`
 	GraphitePath           types.String `tfsdk:"graphite_path"`
 	GraphiteProto          types.String `tfsdk:"graphite_proto"`
@@ -66,7 +68,8 @@ func (m *metricsServerModel) fromAPI(name string, data *metrics.ServerData) {
 	m.InfluxDBProto = types.StringPointerValue(data.InfluxDBProto)
 	m.InfluxMaxBodySize = types.Int64PointerValue(data.MaxBodySize)
 	m.InfluxOrganization = types.StringPointerValue(data.Organization)
-	m.InfluxToken = types.StringPointerValue(data.Token)
+	// InfluxToken is not set here — PVE never returns the token in GET responses.
+	// The caller preserves it from the plan (Create/Update) or prior state (Read) via preserveSensitiveFields.
 	m.GraphitePath = types.StringPointerValue(data.Path)
 	m.GraphiteProto = types.StringPointerValue(data.Proto)
 	m.OTelProto = types.StringPointerValue(data.OTelProto)
@@ -86,6 +89,15 @@ func boolOrDefault(b *proxmoxtypes.CustomBool, def bool) types.Bool {
 	}
 
 	return types.BoolValue(def)
+}
+
+// preserveSensitiveFields copies InfluxToken from src onto dst when dst has a null value.
+// PVE never returns the token in GET responses; the plan (Create/Update) or prior state (Read)
+// is the authoritative source.
+func preserveSensitiveFields(dst, src *metricsServerModel) {
+	if dst.InfluxToken.IsNull() {
+		dst.InfluxToken = src.InfluxToken
+	}
 }
 
 // preserveTypeSpecificBools copies InfluxVerify and OTelVerifySSL from src onto dst

--- a/fwprovider/cluster/metrics/model_metrics_server.go
+++ b/fwprovider/cluster/metrics/model_metrics_server.go
@@ -91,12 +91,16 @@ func boolOrDefault(b *proxmoxtypes.CustomBool, def bool) types.Bool {
 	return types.BoolValue(def)
 }
 
-// preserveSensitiveFields copies InfluxToken from src onto dst when dst has a null value.
+// preserveSensitiveFields copies InfluxToken and InfluxTokenWOVersion from src onto dst when dst has a null value.
 // PVE never returns the token in GET responses; the plan (Create/Update) or prior state (Read)
 // is the authoritative source.
 func preserveSensitiveFields(dst, src *metricsServerModel) {
 	if dst.InfluxToken.IsNull() {
 		dst.InfluxToken = src.InfluxToken
+	}
+
+	if dst.InfluxTokenWOVersion.IsNull() {
+		dst.InfluxTokenWOVersion = src.InfluxTokenWOVersion
 	}
 }
 

--- a/fwprovider/cluster/metrics/resource_metrics_server.go
+++ b/fwprovider/cluster/metrics/resource_metrics_server.go
@@ -12,13 +12,16 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/attribute"
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/config"
@@ -28,9 +31,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = &metricsServerResource{}
-	_ resource.ResourceWithConfigure   = &metricsServerResource{}
-	_ resource.ResourceWithImportState = &metricsServerResource{}
+	_ resource.Resource                     = &metricsServerResource{}
+	_ resource.ResourceWithConfigure        = &metricsServerResource{}
+	_ resource.ResourceWithImportState      = &metricsServerResource{}
+	_ resource.ResourceWithConfigValidators = &metricsServerResource{}
 )
 
 type metricsServerResource struct {
@@ -157,10 +161,26 @@ func (r *metricsServerResource) Schema(
 			},
 			"influx_token": schema.StringAttribute{
 				Description: "The InfluxDB access token. Only necessary when using the http v2 " +
-					"api. If the v2 compatibility api is used, use `user:password` instead.",
+					"api. If the v2 compatibility api is used, use `user:password` instead. " +
+					"Cannot be used together with `influx_token_wo`.",
 				Optional:  true,
 				Default:   nil,
 				Sensitive: true,
+			},
+			"influx_token_wo": schema.StringAttribute{
+				Description: "The InfluxDB access token (write-only). Prefer this over " +
+					"`influx_token` to avoid storing the secret in Terraform state. " +
+					"Cannot be used together with `influx_token`.",
+				Optional:  true,
+				WriteOnly: true,
+				Sensitive: true,
+			},
+			"influx_token_wo_version": schema.Int64Attribute{
+				Description: "Increment this counter to rotate `influx_token_wo` without changing other fields.",
+				Optional:    true,
+				Validators: []validator.Int64{
+					int64validator.AlsoRequires(path.MatchRoot("influx_token_wo")),
+				},
 			},
 			"influx_verify": schema.BoolAttribute{
 				Description: "Set to `false` to disable certificate verification for https " +
@@ -234,6 +254,15 @@ func (r *metricsServerResource) Schema(
 	}
 }
 
+func (r *metricsServerResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.Conflicting(
+			path.MatchRoot("influx_token"),
+			path.MatchRoot("influx_token_wo"),
+		),
+	}
+}
+
 func (r *metricsServerResource) Read(
 	ctx context.Context,
 	req resource.ReadRequest,
@@ -265,6 +294,7 @@ func (r *metricsServerResource) Read(
 	// PVE omits verify-certificate / otel-verify-ssl from GET responses when they equal
 	// the server default; preserve the prior state so we don't churn them to null.
 	preserveTypeSpecificBools(readModel, &state)
+	preserveSensitiveFields(readModel, &state)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, readModel)...)
 }
@@ -282,7 +312,20 @@ func (r *metricsServerResource) Create(
 		return
 	}
 
-	err := r.client.CreateServer(ctx, plan.toAPI())
+	reqData := plan.toAPI()
+
+	var tokenWO types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("influx_token_wo"), &tokenWO)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !tokenWO.IsNull() {
+		reqData.Token = tokenWO.ValueStringPointer()
+	}
+
+	err := r.client.CreateServer(ctx, reqData)
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to Create Metrics Server", err.Error())
 		return
@@ -299,6 +342,7 @@ func (r *metricsServerResource) Create(
 	// PVE omits verify-certificate / otel-verify-ssl from GET responses when they equal
 	// the server default; preserve the plan so explicit values survive the round-trip.
 	preserveTypeSpecificBools(readModel, &plan)
+	preserveSensitiveFields(readModel, &plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, readModel)...)
 }
@@ -319,6 +363,13 @@ func (r *metricsServerResource) Update(
 		return
 	}
 
+	var tokenWO types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("influx_token_wo"), &tokenWO)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	var toDelete []string
 
 	attribute.CheckDelete(plan.Disable, state.Disable, &toDelete, "disable")
@@ -329,7 +380,11 @@ func (r *metricsServerResource) Update(
 	attribute.CheckDelete(plan.InfluxDBProto, state.InfluxDBProto, &toDelete, "influxdbproto")
 	attribute.CheckDelete(plan.InfluxMaxBodySize, state.InfluxMaxBodySize, &toDelete, "max-body-size")
 	attribute.CheckDelete(plan.InfluxOrganization, state.InfluxOrganization, &toDelete, "organization")
-	attribute.CheckDelete(plan.InfluxToken, state.InfluxToken, &toDelete, "token")
+	// Skip the token delete when the write-only path is active — the new value replaces it.
+	if tokenWO.IsNull() {
+		attribute.CheckDelete(plan.InfluxToken, state.InfluxToken, &toDelete, "token")
+	}
+
 	attribute.CheckDelete(plan.InfluxVerify, state.InfluxVerify, &toDelete, "verify-certificate")
 	attribute.CheckDelete(plan.GraphitePath, state.GraphitePath, &toDelete, "path")
 	attribute.CheckDelete(plan.GraphiteProto, state.GraphiteProto, &toDelete, "proto")
@@ -344,6 +399,10 @@ func (r *metricsServerResource) Update(
 
 	reqData := plan.toAPI()
 	reqData.Delete = toDelete
+
+	if !tokenWO.IsNull() {
+		reqData.Token = tokenWO.ValueStringPointer()
+	}
 
 	err := r.client.UpdateServer(ctx, reqData)
 	if err != nil {
@@ -362,6 +421,7 @@ func (r *metricsServerResource) Update(
 	// PVE omits verify-certificate / otel-verify-ssl from GET responses when they equal
 	// the server default; preserve the plan so explicit values survive the round-trip.
 	preserveTypeSpecificBools(readModel, &plan)
+	preserveSensitiveFields(readModel, &plan)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, readModel)...)
 }

--- a/fwprovider/cluster/metrics/resource_metrics_server.go
+++ b/fwprovider/cluster/metrics/resource_metrics_server.go
@@ -383,6 +383,12 @@ func (r *metricsServerResource) Update(
 	// Skip the token delete when the write-only path is active — the new value replaces it.
 	if tokenWO.IsNull() {
 		attribute.CheckDelete(plan.InfluxToken, state.InfluxToken, &toDelete, "token")
+
+		// The write-only token is never mirrored into state, so CheckDelete can't see it;
+		// the version counter leaving state is the removal signal.
+		if plan.InfluxToken.IsNull() && plan.InfluxTokenWOVersion.IsNull() && !state.InfluxTokenWOVersion.IsNull() {
+			toDelete = append(toDelete, "token")
+		}
 	}
 
 	attribute.CheckDelete(plan.InfluxVerify, state.InfluxVerify, &toDelete, "verify-certificate")

--- a/fwprovider/cluster/metrics/resource_metrics_server.go
+++ b/fwprovider/cluster/metrics/resource_metrics_server.go
@@ -321,8 +321,8 @@ func (r *metricsServerResource) Create(
 		return
 	}
 
-	if !tokenWO.IsNull() {
-		reqData.Token = tokenWO.ValueStringPointer()
+	if token := attribute.StringPtrFromValue(tokenWO); token != nil {
+		reqData.Token = token
 	}
 
 	err := r.client.CreateServer(ctx, reqData)
@@ -400,8 +400,8 @@ func (r *metricsServerResource) Update(
 	reqData := plan.toAPI()
 	reqData.Delete = toDelete
 
-	if !tokenWO.IsNull() {
-		reqData.Token = tokenWO.ValueStringPointer()
+	if token := attribute.StringPtrFromValue(tokenWO); token != nil {
+		reqData.Token = token
 	}
 
 	err := r.client.UpdateServer(ctx, reqData)

--- a/fwprovider/cluster/metrics/resource_metrics_server_test.go
+++ b/fwprovider/cluster/metrics/resource_metrics_server_test.go
@@ -12,9 +12,11 @@
 package metrics_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/test"
 )
@@ -245,6 +247,36 @@ func TestAccResourceMetricsServer(t *testing.T) {
 				ImportStateVerify: true,
 			},
 		}},
+		{"influx_token survives create and refresh (regression)", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_metrics_server" "acc_influxdb_token" {
+					name         = "acc_influxdb_token"
+					server       = "192.168.3.2"
+					port         = 18091
+					type         = "influxdb"
+					influx_token = "supersecrettoken"
+				  }`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("proxmox_metrics_server.acc_influxdb_token", "id", "acc_influxdb_token"),
+					resource.TestCheckResourceAttrSet("proxmox_metrics_server.acc_influxdb_token", "influx_token"),
+				),
+			},
+			// No-op refresh: influx_token must survive the round-trip through Read.
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_metrics_server" "acc_influxdb_token" {
+					name         = "acc_influxdb_token"
+					server       = "192.168.3.2"
+					port         = 18091
+					type         = "influxdb"
+					influx_token = "supersecrettoken"
+				  }`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("proxmox_metrics_server.acc_influxdb_token", "influx_token"),
+				),
+			},
+		}},
 		{"create opentelemetry metrics server & test datasource", []resource.TestStep{
 			{
 				// Skip this test until we have a way to test opentelemetry servers (i.e. setting up local otel collector)
@@ -282,6 +314,108 @@ func TestAccResourceMetricsServer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resource.ParallelTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: te.AccProviders,
+				Steps:                    tt.steps,
+			})
+		})
+	}
+}
+
+func TestAccResourceMetricsServerWriteOnly(t *testing.T) {
+	t.Parallel()
+
+	te := test.InitEnvironment(t)
+
+	tests := []struct {
+		name  string
+		steps []resource.TestStep
+	}{
+		{"influx_token_wo keeps the secret out of state", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_metrics_server" "acc_influxdb_token_wo" {
+					name                    = "acc_influxdb_token_wo"
+					server                  = "192.168.3.2"
+					port                    = 18092
+					type                    = "influxdb"
+					influx_token_wo         = "supersecrettoken"
+					influx_token_wo_version = 1
+				  }`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("proxmox_metrics_server.acc_influxdb_token_wo", "id", "acc_influxdb_token_wo"),
+					resource.TestCheckResourceAttr("proxmox_metrics_server.acc_influxdb_token_wo", "influx_token_wo_version", "1"),
+					// The write-only secret must never be persisted, and the legacy
+					// influx_token mirror must stay unset when influx_token_wo is used.
+					resource.TestCheckNoResourceAttr("proxmox_metrics_server.acc_influxdb_token_wo", "influx_token_wo"),
+					resource.TestCheckNoResourceAttr("proxmox_metrics_server.acc_influxdb_token_wo", "influx_token"),
+				),
+			},
+		}},
+		{"influx_token_wo_version triggers rotation", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_metrics_server" "acc_influxdb_token_wo_rotate" {
+					name                    = "acc_influxdb_token_wo_rotate"
+					server                  = "192.168.3.2"
+					port                    = 18093
+					type                    = "influxdb"
+					influx_token_wo         = "supersecrettoken"
+					influx_token_wo_version = 1
+				  }`),
+				Check: resource.TestCheckResourceAttr("proxmox_metrics_server.acc_influxdb_token_wo_rotate", "influx_token_wo_version", "1"),
+			},
+			// Rotate the token by bumping the version counter.
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_metrics_server" "acc_influxdb_token_wo_rotate" {
+					name                    = "acc_influxdb_token_wo_rotate"
+					server                  = "192.168.3.2"
+					port                    = 18093
+					type                    = "influxdb"
+					influx_token_wo         = "rotatedsecrettoken"
+					influx_token_wo_version = 2
+				  }`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("proxmox_metrics_server.acc_influxdb_token_wo_rotate", "influx_token_wo_version", "2"),
+					resource.TestCheckNoResourceAttr("proxmox_metrics_server.acc_influxdb_token_wo_rotate", "influx_token"),
+				),
+			},
+		}},
+		{"influx_token_wo_version requires influx_token_wo", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_metrics_server" "acc_influxdb_token_wo_novalue" {
+					name                    = "acc_influxdb_token_wo_novalue"
+					server                  = "192.168.3.2"
+					port                    = 18094
+					type                    = "influxdb"
+					influx_token_wo_version = 1
+				  }`),
+				ExpectError: regexp.MustCompile(`Attribute "influx_token_wo" must be specified`),
+			},
+		}},
+		{"influx_token and influx_token_wo are mutually exclusive", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_metrics_server" "acc_influxdb_token_conflict" {
+					name            = "acc_influxdb_token_conflict"
+					server          = "192.168.3.2"
+					port            = 18095
+					type            = "influxdb"
+					influx_token    = "plaintext-token"
+					influx_token_wo = "writeonly-token"
+				  }`),
+				ExpectError: regexp.MustCompile(`These attributes cannot be configured together`),
+			},
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource.ParallelTest(t, resource.TestCase{
+				TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+					tfversion.SkipBelow(tfversion.Version1_11_0),
+				},
 				ProtoV6ProviderFactories: te.AccProviders,
 				Steps:                    tt.steps,
 			})

--- a/fwprovider/cluster/metrics/resource_metrics_server_test.go
+++ b/fwprovider/cluster/metrics/resource_metrics_server_test.go
@@ -12,10 +12,13 @@
 package metrics_test
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/bpg/terraform-provider-proxmox/fwprovider/test"
@@ -321,6 +324,23 @@ func TestAccResourceMetricsServer(t *testing.T) {
 	}
 }
 
+// checkMetricsTokenFile asserts presence (or absence) of the metrics server token file
+// in /etc/pve/priv/metricserver/ on the PVE node.
+func checkMetricsTokenFile(te *test.Environment, name string, wantExists bool) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		out := te.ExecuteNodeCommands([]string{
+			fmt.Sprintf("cat /etc/pve/priv/metricserver/%s.pw 2>/dev/null || echo MISSING", name),
+		})
+
+		exists := !strings.Contains(out, "MISSING")
+		if exists != wantExists {
+			return fmt.Errorf("token file for %q: exists=%t, want %t", name, exists, wantExists)
+		}
+
+		return nil
+	}
+}
+
 func TestAccResourceMetricsServerWriteOnly(t *testing.T) {
 	t.Parallel()
 
@@ -378,6 +398,34 @@ func TestAccResourceMetricsServerWriteOnly(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("proxmox_metrics_server.acc_influxdb_token_wo_rotate", "influx_token_wo_version", "2"),
 					resource.TestCheckNoResourceAttr("proxmox_metrics_server.acc_influxdb_token_wo_rotate", "influx_token"),
+				),
+			},
+		}},
+		{"removing influx_token_wo deletes the token from PVE", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_metrics_server" "acc_influxdb_token_wo_remove" {
+					name                    = "acc_influxdb_token_wo_remove"
+					server                  = "192.168.3.2"
+					port                    = 18096
+					type                    = "influxdb"
+					influx_token_wo         = "supersecrettoken"
+					influx_token_wo_version = 1
+				  }`),
+				// GET never returns the token; the root-only priv file is the only observable.
+				Check: checkMetricsTokenFile(te, "acc_influxdb_token_wo_remove", true),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_metrics_server" "acc_influxdb_token_wo_remove" {
+					name   = "acc_influxdb_token_wo_remove"
+					server = "192.168.3.2"
+					port   = 18096
+					type   = "influxdb"
+				  }`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("proxmox_metrics_server.acc_influxdb_token_wo_remove", "influx_token_wo_version"),
+					checkMetricsTokenFile(te, "acc_influxdb_token_wo_remove", false),
 				),
 			},
 		}},


### PR DESCRIPTION
### What does this PR do?
<!--- Clearly state the problem and how this PR solves it. -->

Fixes inconsistent applies when creating a metrics_server resource that has an influx_token attribute defined. The `influx_token` attribute is a write-only attribute in proxmox api and is never returned after.

The write-only value is implemented the same way as other resources already in the provider code base.

### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [x] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->
```
Running single test: TestAccResourceMetricsServer

Found test in: ./fwprovider/cluster/metrics/resource_metrics_server_test.go
Package: github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/metrics
Packages: 1, Parallel: 4
=== RUN   TestAccResourceMetricsServer
=== RUN   TestAccResourceMetricsServer/create_influxdb_udp_server_&_update_it_&_again_to_default_mtu
=== PAUSE TestAccResourceMetricsServer/create_influxdb_udp_server_&_update_it_&_again_to_default_mtu
=== RUN   TestAccResourceMetricsServer/create_disabled_influxdb_server_with_verify_toggle_&_round-trip_bools
=== PAUSE TestAccResourceMetricsServer/create_disabled_influxdb_server_with_verify_toggle_&_round-trip_bools
=== RUN   TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_import_it
=== PAUSE TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_import_it
=== RUN   TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_test_datasource
=== PAUSE TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_test_datasource
=== RUN   TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_import_it
=== PAUSE TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_import_it
=== RUN   TestAccResourceMetricsServer/influx_token_survives_create_and_refresh_(regression)
=== PAUSE TestAccResourceMetricsServer/influx_token_survives_create_and_refresh_(regression)
=== RUN   TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_test_datasource
=== PAUSE TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_test_datasource
=== CONT  TestAccResourceMetricsServer/create_influxdb_udp_server_&_update_it_&_again_to_default_mtu
=== CONT  TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_import_it
=== CONT  TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_test_datasource
=== CONT  TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_import_it
=== NAME  TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_test_datasource
    resource_metrics_server_test.go:316: Skipping step 1/1 due to SkipFunc
=== NAME  TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_import_it
    resource_metrics_server_test.go:316: Skipping step 1/2 due to SkipFunc
    resource_metrics_server_test.go:316: Skipping step 2/2 due to SkipFunc
=== CONT  TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_test_datasource
=== CONT  TestAccResourceMetricsServer/create_disabled_influxdb_server_with_verify_toggle_&_round-trip_bools
=== CONT  TestAccResourceMetricsServer/influx_token_survives_create_and_refresh_(regression)
--- PASS: TestAccResourceMetricsServer (0.00s)
    --- PASS: TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_test_datasource (0.22s)
    --- PASS: TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_import_it (0.22s)
    --- PASS: TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_test_datasource (1.49s)
    --- PASS: TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_import_it (2.82s)
    --- PASS: TestAccResourceMetricsServer/create_disabled_influxdb_server_with_verify_toggle_&_round-trip_bools (2.93s)
    --- PASS: TestAccResourceMetricsServer/create_influxdb_udp_server_&_update_it_&_again_to_default_mtu (3.41s)
    --- PASS: TestAccResourceMetricsServer/influx_token_survives_create_and_refresh_(regression) (2.07s)
PASS
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/metrics    3.798s
```

## Maintainer verification (2026-07-03)

Full metrics acceptance suite run against live PVE on the PR branch including the review fix (write-only token removal now sends `delete=token`; verified behaviorally via the root-only `/etc/pve/priv/metricserver/<name>.pw` credentials file):

```text
--- PASS: TestAccResourceMetricsServer (0.00s)
    --- PASS: TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_import_it (0.45s)
    --- PASS: TestAccResourceMetricsServer/create_opentelemetry_metrics_server_&_test_datasource (0.24s)
    --- PASS: TestAccResourceMetricsServer/influx_token_survives_create_and_refresh_(regression) (1.53s)
    --- PASS: TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_import_it (2.62s)
    --- PASS: TestAccResourceMetricsServer/create_influxdb_udp_server_&_update_it_&_again_to_default_mtu (2.71s)
    --- PASS: TestAccResourceMetricsServer/create_graphite_udp_metrics_server_&_test_datasource (3.30s)
    --- PASS: TestAccResourceMetricsServer/create_disabled_influxdb_server_with_verify_toggle_&_round-trip_bools (1.89s)
--- PASS: TestAccResourceMetricsServerWriteOnly (0.00s)
    --- PASS: TestAccResourceMetricsServerWriteOnly/influx_token_wo_version_requires_influx_token_wo (0.29s)
    --- PASS: TestAccResourceMetricsServerWriteOnly/influx_token_and_influx_token_wo_are_mutually_exclusive (0.29s)
    --- PASS: TestAccResourceMetricsServerWriteOnly/influx_token_wo_keeps_the_secret_out_of_state (1.00s)
    --- PASS: TestAccResourceMetricsServerWriteOnly/influx_token_wo_version_triggers_rotation (1.59s)
    --- PASS: TestAccResourceMetricsServerWriteOnly/removing_influx_token_wo_deletes_the_token_from_PVE (3.02s)
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/metrics   7.582s
```

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2971 

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
