### PR TITLE
fix(hwmapping): percent-encode comments to survive PVE round-trip

### DIFF
--- a/fwprovider/cluster/hardwaremapping/resource_hardware_mapping_test.go
+++ b/fwprovider/cluster/hardwaremapping/resource_hardware_mapping_test.go
@@ -921,6 +921,175 @@ func TestAccResourceHardwareMappingUSBInvalidInput(t *testing.T) {
 	)
 }
 
+// TestAccResourceHardwareMappingCommentSpecialChars verifies that comments containing non-ASCII or percent
+// characters round-trip intact through the Proxmox VE API for all hardware mapping types.
+func TestAccResourceHardwareMappingCommentSpecialChars(t *testing.T) {
+	data, te := testAccResourceHardwareMappingInit(t)
+
+	commentCreate := "NVIDIA RTX 2000 Ada Generation — MS-A2 discrete GPU"
+	commentUpdate := "reserved for host — 50% shared ✓"
+	mapComment := "café über GPU—passthrough"
+
+	resource.Test(
+		t, resource.TestCase{
+			ProtoV6ProviderFactories: te.AccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(
+						`
+					resource "proxmox_hardware_mapping_pci" "test" {
+						comment = "%s"
+						name    = "test-comment-special-pci"
+						map     = [
+							{
+								comment      = "%s"
+								id           = "%s"
+								iommu_group  = %d
+								node         = "%s"
+								path         = "%s"
+								subsystem_id = "%s"
+							},
+						]
+					}
+					`,
+						commentCreate,
+						mapComment,
+						data.MapDeviceIDs[0],
+						data.MapIOMMUGroups[0],
+						te.NodeName,
+						data.MapPathsPCI[0],
+						data.MapSubsystemIDs[0],
+					),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(accTestHardwareMappingNamePCI, "comment", commentCreate),
+						resource.TestCheckTypeSetElemNestedAttrs(
+							accTestHardwareMappingNamePCI, "map.*", map[string]string{
+								"comment": mapComment,
+							},
+						),
+					),
+				},
+
+				// The "Read" implementation must decode the same way, otherwise import produces a mismatch.
+				{
+					ImportState:       true,
+					ImportStateId:     "test-comment-special-pci",
+					ImportStateVerify: true,
+					ResourceName:      accTestHardwareMappingNamePCI,
+				},
+
+				{
+					Config: fmt.Sprintf(
+						`
+					resource "proxmox_hardware_mapping_pci" "test" {
+						comment = "%s"
+						name    = "test-comment-special-pci"
+						map     = [
+							{
+								comment      = "%s"
+								id           = "%s"
+								iommu_group  = %d
+								node         = "%s"
+								path         = "%s"
+								subsystem_id = "%s"
+							},
+						]
+					}
+					`,
+						commentUpdate,
+						mapComment,
+						data.MapDeviceIDs[0],
+						data.MapIOMMUGroups[0],
+						te.NodeName,
+						data.MapPathsPCI[0],
+						data.MapSubsystemIDs[0],
+					),
+					Check: resource.TestCheckResourceAttr(accTestHardwareMappingNamePCI, "comment", commentUpdate),
+				},
+			},
+		},
+	)
+
+	resource.Test(
+		t, resource.TestCase{
+			ProtoV6ProviderFactories: te.AccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(
+						`
+					resource "proxmox_hardware_mapping_usb" "test" {
+						comment = "%s"
+						name    = "test-comment-special-usb"
+						map     = [
+							{
+								comment = "%s"
+								id      = "%s"
+								node    = "%s"
+								path    = "%s"
+							},
+						]
+					}
+					`,
+						commentCreate,
+						mapComment,
+						data.MapDeviceIDs[0],
+						te.NodeName,
+						data.MapPathsUSB[0],
+					),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(accTestHardwareMappingNameUSB, "comment", commentCreate),
+						resource.TestCheckTypeSetElemNestedAttrs(
+							accTestHardwareMappingNameUSB, "map.*", map[string]string{
+								"comment": mapComment,
+							},
+						),
+					),
+				},
+				{
+					ImportState:       true,
+					ImportStateId:     "test-comment-special-usb",
+					ImportStateVerify: true,
+					ResourceName:      accTestHardwareMappingNameUSB,
+				},
+			},
+		},
+	)
+
+	resource.Test(
+		t, resource.TestCase{
+			ProtoV6ProviderFactories: te.AccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(
+						`
+					resource "proxmox_hardware_mapping_dir" "test" {
+						comment = "%s"
+						name    = "test-comment-special-dir"
+						map     = [
+							{
+								node = "%s"
+								path = "%s"
+							},
+						]
+					}
+					`,
+						commentUpdate,
+						te.NodeName,
+						data.MapPathsDir[0],
+					),
+					Check: resource.TestCheckResourceAttr(accTestHardwareMappingNameDir, "comment", commentUpdate),
+				},
+				{
+					ImportState:       true,
+					ImportStateId:     "test-comment-special-dir",
+					ImportStateVerify: true,
+					ResourceName:      accTestHardwareMappingNameDir,
+				},
+			},
+		},
+	)
+}
+
 // TestAccResourceHardwareMappingDirImportNonExistent verifies that importing a non-existent directory mapping
 // returns an error instead of silently removing it from state.
 func TestAccResourceHardwareMappingDirImportNonExistent(t *testing.T) {

--- a/proxmox/cluster/mapping/mapping.go
+++ b/proxmox/cluster/mapping/mapping.go
@@ -16,9 +16,35 @@ import (
 	proxmoxtypes "github.com/bpg/terraform-provider-proxmox/proxmox/types/hardwaremapping"
 )
 
+// encodedDescription returns a percent-encoded copy of a description so it survives the round-trip through
+// the Proxmox VE API, which double-encodes stored non-ASCII bytes on read.
+func encodedDescription(description *string) *string {
+	if description == nil {
+		return nil
+	}
+
+	encoded := proxmoxtypes.EncodeText(*description)
+
+	return &encoded
+}
+
+// decodeDescription reverses encodedDescription.
+func decodeDescription(description *string) *string {
+	if description == nil {
+		return nil
+	}
+
+	decoded := proxmoxtypes.DecodeText(*description)
+
+	return &decoded
+}
+
 // Create creates a new hardware mapping.
 func (c *Client) Create(ctx context.Context, hmType proxmoxtypes.Type, data *CreateRequestBody) error {
-	err := c.DoRequest(ctx, http.MethodPost, c.ExpandPath(hmType, ""), data, nil)
+	body := *data
+	body.Description = encodedDescription(data.Description)
+
+	err := c.DoRequest(ctx, http.MethodPost, c.ExpandPath(hmType, ""), &body, nil)
 	if err != nil {
 		return fmt.Errorf("creating hardware mapping %q: %w", data.ID, err)
 	}
@@ -49,6 +75,8 @@ func (c *Client) Get(ctx context.Context, hmType proxmoxtypes.Type, name string)
 		return nil, api.ErrNoDataObjectInResponse
 	}
 
+	resBody.Data.Description = decodeDescription(resBody.Data.Description)
+
 	return resBody.Data, nil
 }
 
@@ -71,12 +99,19 @@ func (c *Client) List(ctx context.Context, hmType proxmoxtypes.Type, checkNode s
 		return nil, api.ErrNoDataObjectInResponse
 	}
 
+	for _, item := range resBody.Data {
+		item.Description = decodeDescription(item.Description)
+	}
+
 	return resBody.Data, nil
 }
 
 // Update updates an existing hardware mapping.
 func (c *Client) Update(ctx context.Context, hmType proxmoxtypes.Type, name string, data *UpdateRequestBody) error {
-	err := c.DoRequest(ctx, http.MethodPut, c.ExpandPath(hmType, url.PathEscape(name)), data, nil)
+	body := *data
+	body.Description = encodedDescription(data.Description)
+
+	err := c.DoRequest(ctx, http.MethodPut, c.ExpandPath(hmType, url.PathEscape(name)), &body, nil)
 	if err != nil {
 		return fmt.Errorf("udating hardware mapping %q: %w", name, err)
 	}

--- a/proxmox/types/hardwaremapping/map.go
+++ b/proxmox/types/hardwaremapping/map.go
@@ -130,7 +130,7 @@ func (hm Map) String() string {
 	}
 
 	if hm.Description != nil {
-		attrs = append(attrs, joinKV(AttrNameDescription, *hm.Description))
+		attrs = append(attrs, joinKV(AttrNameDescription, EncodeText(*hm.Description)))
 	}
 
 	if hm.IOMMUGroup != nil {
@@ -198,7 +198,8 @@ func ParseMap(input string) (Map, error) {
 
 		switch attrSplit[0] {
 		case AttrNameDescription:
-			hm.Description = &attrSplit[1]
+			description := DecodeText(attrSplit[1])
+			hm.Description = &description
 
 		case attrNameDeviceID:
 			id, err := ParseDeviceID(attrSplit[1])

--- a/proxmox/types/hardwaremapping/text.go
+++ b/proxmox/types/hardwaremapping/text.go
@@ -1,0 +1,44 @@
+/*
+	This Source Code Form is subject to the terms of the Mozilla Public
+	License, v. 2.0. If a copy of the MPL was not distributed with this
+	file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+
+package hardwaremapping
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"unicode/utf8"
+)
+
+// EncodeText percent-encodes control characters, non-ASCII bytes, and the percent sign in free-form text.
+// The Proxmox VE cluster mapping API stores descriptions raw and returns high-bit bytes double-encoded, so
+// only printable ASCII survives a round-trip. This mirrors the encoding Proxmox VE itself applies to VM
+// descriptions via PVE::Tools::encode_text.
+func EncodeText(text string) string {
+	var b strings.Builder
+
+	for i := range len(text) {
+		c := text[i]
+		if c < 0x20 || c > 0x7e || c == '%' {
+			fmt.Fprintf(&b, "%%%02X", c)
+		} else {
+			b.WriteByte(c)
+		}
+	}
+
+	return b.String()
+}
+
+// DecodeText reverses EncodeText. Values not written by this provider may contain stray percent signs or
+// invalid UTF-8 sequences; those are returned unchanged.
+func DecodeText(text string) string {
+	decoded, err := url.PathUnescape(text)
+	if err != nil || !utf8.ValidString(decoded) {
+		return text
+	}
+
+	return decoded
+}

--- a/proxmox/types/hardwaremapping/text_test.go
+++ b/proxmox/types/hardwaremapping/text_test.go
@@ -1,0 +1,79 @@
+/*
+	This Source Code Form is subject to the terms of the Mozilla Public
+	License, v. 2.0. If a copy of the MPL was not distributed with this
+	file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+
+package hardwaremapping
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		encoded string
+	}{
+		{"plain ASCII unchanged", "NVIDIA RTX 2000, GPU: primary", "NVIDIA RTX 2000, GPU: primary"},
+		{"em dash", "a — b", "a %E2%80%94 b"},
+		{"percent sign", "50% shared", "50%25 shared"},
+		{"multi-byte unicode", "café ✓", "caf%C3%A9 %E2%9C%93"},
+		{"control character", "a\nb", "a%0Ab"},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.encoded, EncodeText(tt.input))
+			require.Equal(t, tt.input, DecodeText(tt.encoded), "decode must reverse encode")
+		})
+	}
+}
+
+func TestDecodeTextInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"stray percent", "100% GPU"},
+		{"invalid escape", "a%ZZb"},
+		{"invalid UTF-8 after decode", "a%FFb"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.input, DecodeText(tt.input), "undecodable values must be returned unchanged")
+		})
+	}
+}
+
+func TestMapStringDescriptionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	description := "café — 50% shared"
+	hm := Map{
+		ID:          "8086:5916",
+		Node:        "pve",
+		Description: &description,
+	}
+
+	encoded := hm.String()
+	require.Contains(t, encoded, "description=caf%C3%A9 %E2%80%94 50%25 shared")
+
+	parsed, err := ParseMap(encoded)
+	require.NoError(t, err)
+	require.NotNil(t, parsed.Description)
+	require.Equal(t, description, *parsed.Description)
+}


### PR DESCRIPTION
### What does this PR do?

<!--- Clearly state the problem and how this PR solves it. -->

Hardware mapping comments containing non-ASCII characters (e.g. an em-dash) came back mangled after apply, causing `Provider produced inconsistent result after apply` on `.comment` (and on map-entry comments).

The root cause is on the PVE side: the `/cluster/mapping/*` API stores the description as raw UTF-8 but reads it back without decoding, so its JSON encoder double-encodes every non-ASCII byte (`—` → `â`). Verified directly on a PVE 9.2.3 host with `pvesh` alone — the config file holds correct bytes (`e2 80 94`) while the API returns `c3 a2 c2 80 c2 94`-style garbage; the provider was only relaying it.

The fix mirrors the convention PVE itself uses for VM descriptions (`PVE::Tools::encode_text`): percent-encode `%`, control characters, and all non-ASCII bytes on write, and decode on read, at the shared mapping client layer. This covers the top-level comment and per-map-entry comments for all three mapping types (PCI, USB, dir) plus their datasources. On read, values that fail to decode (written by the PVE UI or older provider versions) are kept as-is, so existing mappings are unaffected and self-heal on the next apply.

Trade-off: the PVE web UI shows provider-written non-ASCII comments percent-encoded (e.g. `%E2%80%94`), and a literal `%` is stored as `%25` — unavoidable for a lossless round-trip through the broken PVE read path. Plain-ASCII comments are stored unchanged.

### Contributor's Note

<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work

<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

New acceptance test `TestAccResourceHardwareMappingCommentSpecialChars` exercises em-dash/unicode/percent comments (top-level and map-entry) with create, import round-trip, and update across all three mapping types.

**Before the fix (RED):**

```text
Error: Provider produced inconsistent result after apply

When applying changes to proxmox_hardware_mapping_pci.test, provider
"provider[...]" produced an unexpected new value: .comment: was
cty.StringVal("NVIDIA RTX 2000 Ada Generation — MS-A2 discrete GPU"), but now
cty.StringVal("NVIDIA RTX 2000 Ada Generation â MS-A2 discrete GPU").
```

**After the fix:**

```text
./testacc TestAccResourceHardwareMappingCommentSpecialChars -- -v
=== RUN   TestAccResourceHardwareMappingCommentSpecialChars
--- PASS: TestAccResourceHardwareMappingCommentSpecialChars (4.60s)
PASS
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/hardwaremapping   5.241s
```

**Full regression** (`./testacc --resource hardwaremapping`): all 13 hardware mapping tests + `TestAccDataSourceHardwarePCI` pass. `make test` and `make lint` clean; new unit tests cover encode/decode round-trips and fallback behavior for undecodable values.

**mitmproxy verification** — the provider now sends pure-ASCII on the wire and PVE returns it byte-identical:

```text
POST /api2/json/cluster/mapping/pci
    description: NVIDIA RTX 2000 Ada Generation %E2%80%94 MS-A2 discrete GPU
    map: id=...,node=pve,path=...,description=caf%C3%A9 %C3%BCber GPU%E2%80%94passthrough,...

GET /api2/json/cluster/mapping/pci/test-comment-special-pci
    "description": "NVIDIA RTX 2000 Ada Generation %E2%80%94 MS-A2 discrete GPU"   <- byte-identical

PUT /api2/json/cluster/mapping/pci/test-comment-special-pci
    description: reserved for host %E2%80%94 50%25 shared %E2%9C%93
```

**PVE-side root-cause evidence** (no provider involved, PVE 9.2.3):

```text
# pvesh create /cluster/mapping/pci --id claudetest --description "NVIDIA RTX — em-dash test" ...
Wide character in print at /usr/share/perl5/PVE/File.pm line 75

# hexdump /etc/pve/mapping/pci.cfg   -> ... 20 e2 80 94 20 ...   (stored correctly as UTF-8)
# pvesh get /cluster/mapping/pci/claudetest | hexdump
                                    -> ... 20 c3 a2 c2 80 c2 94 20 ...   (double-encoded on read)
```

<!--- Please keep this note for the community --->

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #2974

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->

---

🤖 _This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Fable 5). All changes have been reviewed and verified by a human._
