### PR TITLE
chore(docs): close convention gaps in ADRs 002/004/005/006/008

### DIFF
--- a/docs/adr/002-api-client-structure.md
+++ b/docs/adr/002-api-client-structure.md
@@ -152,6 +152,28 @@ func (c *Client) VNets(zoneID string) *vnets.Client {
 4. **Path expansion** handles URL construction, callers pass relative paths
 5. **Response types** defined in same package as client
 
+### Request/Response Body Conventions
+
+PVE endpoints are form-encoded on write and JSON on read, and both directions have wire quirks that the struct tags must encode.
+
+**Field deletion.** Request bodies that support clearing fields carry:
+
+```go
+Delete []string `url:"delete,omitempty,comma"`
+```
+
+Use `[]string` (not `*string` with manual `strings.Join`). The `comma` modifier makes `go-querystring` serialize as a single `delete=field1,field2` parameter, which is what PVE expects — without it, `[]string` serializes as repeated `delete=field1&delete=field2` parameters, which is wrong for most PVE endpoints.
+
+**Booleans.** Use `*proxmoxtypes.CustomBool` with the `,int` modifier on the `url:` tag:
+
+```go
+Disable *types.CustomBool `json:"disable,omitempty" url:"disable,omitempty,int"`
+```
+
+`CustomBool` marshals JSON as `"0"`/`"1"`; the `,int` modifier makes the URL form encoding emit `0`/`1`. Without it, form encoding emits `true`/`false`, which PVE rejects for bool-as-int fields.
+
+**Integers PVE serializes as strings.** The API viewer documents many fields as `integer`, but the Perl backend returns some of them as JSON **strings** when explicitly set (e.g. `"15"` instead of `15`), which crashes a plain `*int` decode. Type the **GET response** field `*proxmoxtypes.CustomInt` (or `*CustomInt64`) — its `UnmarshalJSON` accepts both quoted and bare forms. The **request** field can stay `*int`: it is only marshaled, never decoded, so the asymmetric narrow fix is correct. Verify which fields are affected with `pvesh get` or mitmproxy before widening the change.
+
 ## Example: Adding a New API Endpoint
 
 To add support for a new Proxmox API at `/api2/json/cluster/foo/bar`:
@@ -202,6 +224,9 @@ func (c *Client) Foo() *foo.Client {
 - Calling the base HTTP API directly from resource code instead of through domain clients.
 - Hardcoding API paths instead of using `ExpandPath()`.
 - Forgetting to wrap errors with `%w` — breaks `errors.Is()` checks in the resource layer.
+- Omitting the `comma` modifier on a `Delete []string` field — serializes as repeated `delete=` parameters instead of one comma-separated value. See [Request/Response Body Conventions](#requestresponse-body-conventions).
+- Omitting the `,int` modifier on a `*CustomBool` `url:` tag — form encoding emits `true`/`false`, which PVE rejects.
+- Using plain `*int` on a GET response field that PVE serializes as a quoted string — decode crashes at runtime; use `*proxmoxtypes.CustomInt`.
 
 ## References
 

--- a/docs/adr/004-schema-design-conventions.md
+++ b/docs/adr/004-schema-design-conventions.md
@@ -92,6 +92,24 @@ This helper returns a `schema.StringAttribute` with `Computed: true`, `UseStateF
 
 For resources where the user provides the ID (e.g., SDN VNet's `id` is user-specified), define the attribute manually with `Required: true` and `RequiresReplace()`.
 
+### Import ID Format
+
+For **node-scoped** resources, the import ID is not the resource `id` — it is `node_name/<resource id>`. The resource `id` stays the bare PVE identifier (a vmid, or a volume ID like `datastore:content/file`) with no node in it; the node is a separate attribute that the importer sets.
+
+The canonical parse splits on the **first** `/` so the remainder can itself contain slashes:
+
+```go
+nodeName, id, found := strings.Cut(importID, "/")
+if !found {
+    return fmt.Errorf("unexpected format of ID (%s), expected node_name/id", importID)
+}
+// importer: keep id verbatim as the resource id, set node_name separately; Read fills the rest
+```
+
+`pve/100` → node `pve`, id `100`. For multi-segment IDs (e.g. `pve/local:iso/image.iso`), chain `strings.Cut` on each delimiter and validate `found` plus non-empty parts at every step. When Read cannot re-derive all lookup keys from the bare id, the importer must set them explicitly (not rely on Read alone) — verify with `ImportStateCheck`; `ImportStateVerify` is often impractical because config-only attributes (URLs, timeouts) are not recoverable from the API.
+
+Baking the node **into** the id (e.g. `id = "<node>:<iface>"`, used by the Linux bridge/VLAN/bond resources, where import ID == resource id) is acceptable only when designing a **new** id that has no other unique key. Never change an already-released id format to add the node — that is a breaking state change requiring a `StateUpgrader`. Keep the released bare id and add the node as an import-time prefix instead.
+
 ### Validators
 
 Use validators from the `terraform-plugin-framework-validators` module for standard rules. Use project-specific validators from `fwprovider/validators/` for reusable domain rules (e.g., `validators.SDNID()`).
@@ -148,6 +166,17 @@ func (r *myResource) ConfigValidators(_ context.Context) []resource.ConfigValida
 ```
 
 For more complex validation that requires parsing attribute values, implement `ResourceWithValidateConfig` and add logic in the `ValidateConfig` method.
+
+**Null and unknown need different treatment in `ValidateConfig`.** Config values that come from unresolved references (e.g. `vlan_aware = other_resource.attr`) are **unknown** at validate time, and `ValueBool()` returns `false` for unknown — so a naive check false-positives. But skipping the check for null _and_ unknown alike is the symmetric mistake: for a field whose omission lets a known default apply, **null still represents a real misconfiguration** worth flagging. When one field triggers the rule and another gates it, treat each side differently — require the trigger to be defined, and skip only when the gating field is unknown:
+
+```go
+// Trigger field: attribute.IsDefined (must have a real value).
+// Gating field: !IsUnknown (null = omitted, default applies — still checked;
+//               unknown = unresolvable yet — skip, PVE validates at apply).
+if attribute.IsDefined(data.VIDs) && !data.VLANAware.IsUnknown() && !data.VLANAware.ValueBool() {
+    resp.Diagnostics.AddAttributeError(...)
+}
+```
 
 **When to add a validator vs document the constraint.** Cross-attribute constraints are documented in `MarkdownDescription` by default — let PVE reject invalid combinations at apply time. Promote to a plan-time validator only when (a) the constraint is hit _frequently_ in support issues, or (b) PVE's apply-time error is unhelpful (cryptic, mislocated, or only surfaces after partial side-effects). Every plan-time validator is a maintenance liability: it duplicates PVE's logic, drifts as PVE evolves, and adds a failure point distinct from the API's own. Keep the bar high.
 
@@ -362,6 +391,8 @@ The project provides custom attribute types in `fwprovider/types/`:
 - Using non-standard model method names (`importFromAPI`, `toAPIRequestBody`, `toCreateRequest`, etc.) instead of the canonical `toAPI()` / `toAPICreate()` / `toAPIUpdate()` / `fromAPI()`. See [Model-API Conversion](#model-api-conversion).
 - Omitting `Description` on schema attributes — every attribute must have a non-empty description.
 - Defining local bool-to-int64 conversion helpers instead of updating the API type to use `*proxmoxtypes.CustomBool`.
+- Treating null and unknown alike in `ValidateConfig` cross-field checks — unknown references false-positive with `ValueBool()`, while skipping null drops real misconfigurations. See [Cross-Field Validation](#cross-field-validation).
+- Changing a released resource `id` format (e.g. to embed the node name) when adding import support — breaking state change. Add the node as an import-time prefix instead. See [Import ID Format](#import-id-format).
 
 ## References
 

--- a/docs/adr/005-error-handling.md
+++ b/docs/adr/005-error-handling.md
@@ -30,20 +30,37 @@ Where `[Action]` is a CRUD verb and `[Resource]` identifies the Proxmox object.
 
 Standard summaries for the resource lifecycle:
 
-| Operation                      | Summary Format                               | Example                                          |
-|--------------------------------|----------------------------------------------|--------------------------------------------------|
-| Create                         | `"Unable to Create [Resource]"`              | `"Unable to Create SDN VNet"`                    |
-| Read-back after create         | `"Unable to Read [Resource] After Creation"` | `"Unable to Read SDN VNet After Creation"`       |
-| Read                           | `"Unable to Read [Resource]"`                | `"Unable to Read SDN VNet"`                      |
-| Update                         | `"Unable to Update [Resource]"`              | `"Unable to Update SDN VNet"`                    |
-| Read-back after update         | `"Unable to Read [Resource] After Update"`   | `"Unable to Read SDN VNet After Update"`         |
-| Delete                         | `"Unable to Delete [Resource]"`              | `"Unable to Delete SDN VNet"`                    |
-| Import                         | `"Unable to Import [Resource]"`              | `"Unable to Import SDN VNet"`                    |
-| Not found (import/datasource)  | `"[Resource] Not Found"`                     | `"SDN VNet Not Found"`                           |
+| Operation                     | Summary Format                               | Example                                    |
+| ----------------------------- | -------------------------------------------- | ------------------------------------------ |
+| Create                        | `"Unable to Create [Resource]"`              | `"Unable to Create SDN VNet"`              |
+| Read-back after create        | `"Unable to Read [Resource] After Creation"` | `"Unable to Read SDN VNet After Creation"` |
+| Read                          | `"Unable to Read [Resource]"`                | `"Unable to Read SDN VNet"`                |
+| Update                        | `"Unable to Update [Resource]"`              | `"Unable to Update SDN VNet"`              |
+| Read-back after update        | `"Unable to Read [Resource] After Update"`   | `"Unable to Read SDN VNet After Update"`   |
+| Delete                        | `"Unable to Delete [Resource]"`              | `"Unable to Delete SDN VNet"`              |
+| Import                        | `"Unable to Import [Resource]"`              | `"Unable to Import SDN VNet"`              |
+| Not found (import/datasource) | `"[Resource] Not Found"`                     | `"SDN VNet Not Found"`                     |
 
 When the resource name or ID is available, include it in the summary using `fmt.Sprintf` (e.g., `fmt.Sprintf("Unable to Read SDN VNet %q", id)`). Domain clients do not consistently include the resource identity in their error messages, so the summary is the only reliable place for it.
 
 The detail string (second argument) should be `err.Error()`, which carries the full error chain from the API layer.
+
+### Task Result Diagnostics
+
+`tasks.TaskResult.AddDiags(diags, summary)` and `AddDiagsAsWarnings(diags, summary)` (`proxmox/nodes/tasks/task_result.go`) pass `summary` straight through to `diags.AddError` / `AddWarning`. The `"Unable to [Action] [Resource]"` format therefore applies to those call sites exactly as it does to direct `AddError` calls:
+
+```go
+vmAPI.CreateVM(ctx, body).AddDiags(diags, fmt.Sprintf("Unable to Create VM %d", id))
+vmStop(ctx, vmAPI).AddDiagsAsWarnings(diags, fmt.Sprintf("Unable to Stop VM %d", id))
+```
+
+`AddDiagsAsWarnings` exists for deliberately non-fatal task failures (e.g. a best-effort stop before delete) — the severity is downgraded by the caller's choice, but the operation still failed, so the `"Unable to"` prefix still applies.
+
+A format conformance sweep that greps only `AddError(` misses these call sites — audit all four shapes:
+
+```bash
+grep -nE 'AddError\(|AddWarning\(|AddDiags\(|AddDiagsAsWarnings\(' fwprovider/...
+```
 
 ### Diagnostic Severity
 
@@ -99,6 +116,8 @@ const ErrResourceDoesNotExist Error = "the requested resource does not exist"
 errors.Join(ErrResourceDoesNotExist, &HTTPError{Code: 404, Message: "..."})
 errors.Join(ErrResourceDoesNotExist, &HTTPError{Code: 500, Message: "...does not exist..."})
 ```
+
+**Not-found string matching is deliberately case-sensitive**, matching the exact case of the upstream emitter: PVE Perl plugins emit lowercase (`does not exist`, `no such resource`); libc-derived strings passed through tools like qemu-img, rbd, or lvm are capitalized (`No such file or directory`, i.e. `strerror(ENOENT)`). Do not broaden the matcher to case-insensitive "for robustness" — once an error is classified as `ErrResourceDoesNotExist`, retry loops short-circuit and call sites downgrade to "resource gone" semantics, so a too-broad match silently misclassifies recoverable transient errors. When adding a pattern, identify its emitter (PVE Perl source, or a libc passthrough) and match that exact case. When the not-found signal is domain-specific (Ceph pools, qemu-img output, …), translate it at the domain client's call site instead of widening the central matcher — see `isUnrecognizedPoolErr` in `proxmox/nodes/ceph/pool/` for the reference.
 
 #### Layer 2: Domain Client (`proxmox/{domain}/`)
 
@@ -176,7 +195,7 @@ If `State.Set` fails (e.g., due to a type mismatch between the model struct and 
 Datasources differ from resources in their error handling for not-found scenarios:
 
 | Scenario         | Resource Behavior                                      | Datasource Behavior                                                            |
-|------------------|--------------------------------------------------------|--------------------------------------------------------------------------------|
+| ---------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------ |
 | Target not found | `resp.State.RemoveResource(ctx)` (triggers recreation) | `resp.Diagnostics.AddError("[Resource] Not Found", ...)` (configuration error) |
 | Read source      | `req.State.Get(ctx, &state)`                           | `req.Config.Get(ctx, &config)`                                                 |
 | Configure type   | `config.Resource`                                      | `config.DataSource`                                                            |
@@ -199,21 +218,21 @@ For list datasources that return collections (e.g., `proxmox_backup_jobs`), an e
 
 Use standard Go error inspection:
 
-| Need                 | Method                                                       |
-|----------------------|--------------------------------------------------------------|
-| Check for sentinel   | `errors.Is(err, api.ErrResourceDoesNotExist)`                |
-| Extract HTTP status  | `errors.As(err, &httpError)` then inspect `httpError.Code`   |
-| Add context          | `fmt.Errorf("context: %w", err)`                             |
+| Need                | Method                                                     |
+| ------------------- | ---------------------------------------------------------- |
+| Check for sentinel  | `errors.Is(err, api.ErrResourceDoesNotExist)`              |
+| Extract HTTP status | `errors.As(err, &httpError)` then inspect `httpError.Code` |
+| Add context         | `fmt.Errorf("context: %w", err)`                           |
 
 ### Retry Policies
 
 Retry logic is centralized in the `proxmox/retry/` package, which provides three operation constructors:
 
-| Constructor            | Use Case                                              | Attempts  | Backoff     | Method   |
-|------------------------|-------------------------------------------------------|-----------|-------------|----------|
-| `NewTaskOperation`     | Async UPID-based tasks (create, clone, delete, start) | 3         | Exponential | `DoTask` |
-| `NewAPICallOperation`  | Synchronous blocking API calls (e.g. PUT /config)     | 3         | Exponential | `Do`     |
-| `NewPollOperation`     | Wait-for-condition loops (status, config unlock)      | Unlimited | Fixed (1s)  | `DoPoll` |
+| Constructor           | Use Case                                              | Attempts  | Backoff     | Method   |
+| --------------------- | ----------------------------------------------------- | --------- | ----------- | -------- |
+| `NewTaskOperation`    | Async UPID-based tasks (create, clone, delete, start) | 3         | Exponential | `DoTask` |
+| `NewAPICallOperation` | Synchronous blocking API calls (e.g. PUT /config)     | 3         | Exponential | `Do`     |
+| `NewPollOperation`    | Wait-for-condition loops (status, config unlock)      | Unlimited | Fixed (1s)  | `DoPoll` |
 
 Key behaviors of `DoTask`:
 
@@ -223,10 +242,10 @@ Key behaviors of `DoTask`:
 
 Common retry predicates:
 
-| Predicate                    | Matches                                           |
-|------------------------------|---------------------------------------------------|
-| `IsTransientAPIError`        | HTTP 5xx, "got no worker upid", "got timeout"     |
-| `ErrorContains(substr)`      | Error message contains substring                  |
+| Predicate               | Matches                                       |
+| ----------------------- | --------------------------------------------- |
+| `IsTransientAPIError`   | HTTP 5xx, "got no worker upid", "got timeout" |
+| `ErrorContains(substr)` | Error message contains substring              |
 
 Do not retry on:
 
@@ -267,6 +286,8 @@ Do not retry on:
 - Saving `plan` directly to state after Create (`resp.State.Set(ctx, &plan)`) — always read back from the API. See [Read-Back After Create and Update](#read-back-after-create-and-update).
 - Using bare `resp.State.Set()` without wrapping in `resp.Diagnostics.Append()` — silently discards state serialization errors. See [State Set Error Propagation](#state-set-error-propagation).
 - Calling `resp.State.RemoveResource(ctx)` in a datasource Read — datasources must error on not-found, not remove state. See [Datasource Error Handling](#datasource-error-handling).
+- Auditing summary format by grepping `AddError(` only — `TaskResult.AddDiags` / `AddDiagsAsWarnings` carry summaries too. See [Task Result Diagnostics](#task-result-diagnostics).
+- Making the not-found string matching case-insensitive, or adding a pattern without checking which case the emitter produces. See [Layer 1](#layer-1-http-client-proxmoxapi).
 
 ## References
 

--- a/docs/adr/006-testing-requirements.md
+++ b/docs/adr/006-testing-requirements.md
@@ -17,7 +17,7 @@ Contributions need clear testing expectations. Without documented requirements, 
 ### Test Coverage Requirements
 
 | Test Type              | Requirement                                      | Purpose                                             |
-|------------------------|--------------------------------------------------|-----------------------------------------------------|
+| ---------------------- | ------------------------------------------------ | --------------------------------------------------- |
 | Acceptance tests       | **Required** for all new resources and bug fixes | Verify real API behavior end-to-end                 |
 | Unit tests             | **Recommended** for complex logic                | Test parsing, validation, model conversion          |
 | Example configurations | **Optional**                                     | Legacy tests and user-facing examples in `example/` |
@@ -102,7 +102,7 @@ for _, tt := range tests {
 The `fwprovider/test/` package provides shared utilities:
 
 | Helper                                      | Purpose                                         |
-|---------------------------------------------|-------------------------------------------------|
+| ------------------------------------------- | ----------------------------------------------- |
 | `test.InitEnvironment(t)`                   | Provider factories, config rendering, node name |
 | `test.ResourceAttributes(addr, map)`        | Bulk attribute assertions                       |
 | `test.NoResourceAttributesSet(addr, attrs)` | Assert attributes are null/unset                |
@@ -168,6 +168,19 @@ func TestAccMyResource_Validators(t *testing.T) {
 ### API Verification
 
 Tests passing does not guarantee correct API calls. After tests pass, verify API calls with mitmproxy using the "debug API" workflow. See [DEBUGGING.md](../../.dev/DEBUGGING.md).
+
+**Proving the absence of an API call needs a positive control.** When a change's effect is that a call is _no longer made_ (a skip flag, a removed redundant request), "grepped the flow log, found 0 matches" is weak evidence — 0 also results from a wrong endpoint string or a test that never reached the code path. Make it conclusive: confirm the exact endpoint string from the client code first, assert that the _other_ expected calls are present in the same capture (proving the capture worked), and run a control scenario where the call _should_ fire, confirming a non-zero count. The 0-vs-N contrast across two near-identical runs is the proof; a bare 0 is not.
+
+**Write-only and secret values need out-of-band assertions.** Write-only attribute values are never in state, and PVE redacts many secrets from GET responses — state checks and direct API reads both come back empty whether or not the secret arrived. Many such secrets are observable as root-only files under `/etc/pve/priv/` on the PVE host (e.g. `metricserver/<id>.pw`); assert via root SSH:
+
+```go
+out := te.ExecuteNodeCommands([]string{
+    fmt.Sprintf("cat /etc/pve/priv/metricserver/%s.pw 2>/dev/null || echo MISSING", name),
+})
+exists := !strings.Contains(out, "MISSING")
+```
+
+Assert the file exists after create-with-secret and is gone after the secret's removal — this catches delete-path gaps that state-only checks cannot. Before reaching for mitmproxy, probe `ls -R /etc/pve/priv/` on the test host for a per-resource credentials file.
 
 ## Consequences
 

--- a/docs/adr/008-sub-block-contract.md
+++ b/docs/adr/008-sub-block-contract.md
@@ -107,6 +107,51 @@ The body-taking form coexists with the universal `(plan, state, *[]string, "api-
 
 Hand-rolled `ShouldBeRemoved` + `IsDefined` cascades that branch on `plan.Field.Equal(state.Field)` are not used in either form — `attribute.StringPtrFromValue` already returns nil for null/unknown, so the explicit `IsDefined` guard is redundant in `FillCreateBody` _and_ `FillUpdateBody`. A reflection-based `body.ToDelete(GoFieldName)` helper on `vms.UpdateRequestBody` exists for legacy callers, but new sub-package code must not use it — the canonical pattern is `attribute.CheckDeleteBody` with the API name. See [Common Mistakes](#common-mistakes).
 
+### Guard Ordering in `FillUpdateBody`
+
+When a single-nested sub-package normalizes null/unknown plan Objects into an all-null `Model` for per-field diffing (an `unpackOrEmpty`-style helper), the top-of-function guards must come in a specific order:
+
+```go
+// FIRST: skip when the plan is unknown or identical to state.
+if planValue.IsUnknown() || planValue.Equal(stateValue) {
+    return
+}
+
+plan := unpackOrEmpty(ctx, planValue, diags)
+state := unpackOrEmpty(ctx, stateValue, diags)
+if diags.HasError() {
+    return
+}
+
+// Per-field CheckDeleteBody calls, then compound/atomic field deletion.
+// Gate compound deletion on plan.Type.IsNull() (not !IsDefined) so an
+// inner-field plan that is unknown is not mis-read as a removal.
+
+// THEN: skip population on full block removal.
+if planValue.IsNull() {
+    return
+}
+
+plan.toAPI(ctx, body, diags)
+```
+
+Two failure modes make the ordering load-bearing. First, the unpack helper collapses a block-level unknown into all-null fields — without the top `IsUnknown()` guard, every `CheckDeleteBody(plan.X, state.X, ...)` fires a spurious `delete=`. Second, `!attribute.IsDefined(plan.Type)` matches both null and unknown, so an inner field set from an unresolved reference (e.g. `cpu.type = other_resource.x.computed_attr`) would mis-trigger a compound `delete=cpu`; gate compound deletion on `plan.Type.IsNull()` so only explicit user removal triggers it.
+
+### Conversion Pitfalls
+
+**Zero is a value.** A user-set `0` on an `Int64` attribute must reach PVE when `0` is a meaningful PVE value (e.g. "no limit"). The pattern `if v.ValueInt64() != 0` silently drops it — use `attribute.Int64PtrFromValue`, which returns a pointer to `0` when the user set 0 and nil when null/unknown. When the API struct field is `*int` rather than `*int64`, cast explicitly:
+
+```go
+if v := attribute.Int64PtrFromValue(m.MaxBytes); v != nil {
+    n := int(*v)
+    dev.MaxBytes = &n
+}
+```
+
+Verify with mitmproxy that PVE accepts `0` as meaningful for the specific field; if PVE rejects it, raise the validator's lower bound instead of silently dropping the value.
+
+**Empty string vs null on non-pointer subfields.** Some PVE wire types have `string` (not `*string`) subfields (e.g. `CustomRNGDevice.Source`). In `NewValue`, map an empty string from the API to `types.StringNull()` — otherwise plan=null vs state=`""` produces a permanent diff.
+
 ### Map-keyed Update Diff
 
 Map-keyed sub-packages diff plan against state with `utils.MapDiff`, which returns three maps (`toCreate`, `toUpdate`, `toDelete`):
@@ -120,6 +165,8 @@ for slot := range toDelete      { body.Delete = append(body.Delete, slot) }
 ```
 
 Slot-level deletion appends the slot key (e.g. `"net1"`, `"ide2"`) directly to `body.Delete`. This is the same `body.Delete []string` (`url:"delete,omitempty,comma"`) that scalar field deletion populates via `attribute.CheckDeleteBody` — slot keys and scalar API names share one comma-separated `delete=…` parameter on the wire. The per-device add helper (`AddCustomStorageDevice`, `AddNetworkDevice`, etc.) is sub-package-specific; cdrom is the reference, calling `body.AddCustomStorageDevice(iface, dev.toAPI())` — the `toAPI()` / `fromAPI()` names mandated by [ADR-004 §Model-API Conversion](004-schema-design-conventions.md#model-api-conversion).
+
+Do not add an `if planValue.IsNull() { return }` early-return ahead of the diff. When the user removes the whole block after having slots, the plan is null and the slot deletes come precisely from `MapDiff(nil, state)`'s `toDelete` — Go ranges over nil maps as no-ops, so the null plan needs no special-casing, and an early return silently leaks every slot on block removal.
 
 ### File Layout
 
@@ -151,6 +198,30 @@ Sub-block names normally correspond to one PVE concept (`cpu` → CPU emulation,
 
 The `cpu` block is the historical exception: `cpu.numa` (PVE: `numa=1` — a top-level VM toggle) and `cpu.hotplugged` (PVE: `vcpus=N` — a top-level vCPU count) are SDK-inherited misnomers scheduled for relocation — `numa.enabled` under a dedicated top-level `numa` block, `vcpus` as a top-level scalar — tracked under [#1231](https://github.com/bpg/terraform-provider-proxmox/issues/1231). Future sub-packages should not repeat the pattern.
 
+### Per-Commit Verification Gate
+
+Each sub-package port commit passes all of:
+
+1. `make lint` — 0 issues.
+2. `go build ./...` — clean.
+3. `./testacc TestAccResourceVM2<Sub>` — all scenarios pass.
+4. `./testacc TestAccResourceClonedVM` — the joint-ownership gate: sub-packages consumed by `proxmox_cloned_vm` break it silently otherwise.
+5. Mitmproxy trace reviewed — Create and Update send the expected wire parameters; block removal emits `delete=<key>` (compound) or `delete=<slot>` per removed slot (map-keyed), not silence; field removal emits per-field `delete=<api-name>` for multi-key sub-blocks.
+6. `make docs` — regenerate when the schema shape changed visibly (`Computed` flag, description text).
+
+Skipping step 3 masks schema-shape bugs; skipping step 4 breaks `proxmox_cloned_vm` silently; skipping step 5 misses behavioral regressions that state assertions cannot catch (a leaked block-removal delete leaves state clean while PVE still has the device).
+
+### Mandatory Acceptance Scenarios
+
+Per [ADR-006 §Functional Coverage](006-testing-requirements.md#functional-coverage-requirement), every sub-package covers:
+
+- No block in HCL → state has no block attributes set (verifies the `NullValue` guard).
+- Block set with a subset of fields → set fields in state, others null (plan stability).
+- Update changes the block → state matches the new config (compound replacement / map update).
+- Block removed entirely after being set → state has no block attributes (verifies block-level delete).
+- Map-keyed only: add slot, update slot, remove slot — the three `MapDiff` paths; plus apply → empty re-plan (reorder immunity).
+- Fields where zero is meaningful: set to `0` → state has `0` (see [Conversion Pitfalls](#conversion-pitfalls)).
+
 ## Consequences
 
 ### Positive
@@ -176,6 +247,10 @@ The `cpu` block is the historical exception: `cpu.numa` (PVE: `numa=1` — a top
 - Importing a sub-package's `Model` from the parent resource or another sub-package. Even though `Model` is Go-visible (capital `M`), it is sub-package-internal by contract — the parent resource composes via `Value` / `NewValue` / `Fill…Body` only.
 - Exposing the block as `proxmox_vm.attribute_name` when the block contains attributes from unrelated PVE concepts — split into separate blocks instead. The cpu→numa→vcpus relocation is the cautionary tale.
 - Map-keyed slot regex too loose (`^[a-z]+[0-9]+$`) or too tight (only the slots used in tests). Bound it from the PVE Perl source's `MAX_*` constants.
+- An `if planValue.IsNull() { return }` early-return before the map diff — leaks every slot delete on whole-block removal. See [Map-keyed Update Diff](#map-keyed-update-diff).
+- Running per-field `CheckDeleteBody` calls before the block-level `IsUnknown()` guard — a block-unknown plan collapses to all-null fields and fires spurious deletes. See [Guard Ordering in `FillUpdateBody`](#guard-ordering-in-fillupdatebody).
+- Using `!= 0` as an unset check on integer fields where `0` is a valid PVE value — use `attribute.Int64PtrFromValue`. See [Conversion Pitfalls](#conversion-pitfalls).
+- Guarding body assignment with `reflect.DeepEqual(dev, &vms.Custom<X>{})` zero-checks — assign `body.<Device> = plan.toAPI()` directly; the compound serializer already skips zero fields via `omitempty`.
 
 ## References
 


### PR DESCRIPTION
### What does this PR do?

Closes the documentation gaps identified in #2981: a set of conventions and pitfalls that are applied consistently during reviews but were never recorded in the ADRs, so they kept resurfacing as repeated review comments and bot false-positive debates. This PR upstreams them into the existing ADRs:

- **ADR-002** — new *Request/Response Body Conventions* section: `Delete []string` with `url:"delete,omitempty,comma"`, `*CustomBool` + `,int` URL modifier, and `*CustomInt` for GET-response fields that PVE serializes as strings despite being documented as integers.
- **ADR-004** — new *Import ID Format* section (node-scoped resources import as `node_name/<id>` via `strings.Cut`; never retrofit a released id format), plus the null-vs-unknown asymmetric gating pattern for `ValidateConfig` cross-field checks.
- **ADR-005** — new *Task Result Diagnostics* section (`TaskResult.AddDiags` / `AddDiagsAsWarnings` pass the summary straight to `AddError`/`AddWarning`, so the `"Unable to …"` format and conformance sweeps must cover both call shapes), plus the deliberate case-sensitivity of not-found string matching in the HTTP layer and the domain-client escape hatch (`isUnrecognizedPoolErr`).
- **ADR-006** — *API Verification* extended with the 0-vs-N positive-control rule for proving the *absence* of an API call, and the `/etc/pve/priv/` root-SSH assertion pattern for write-only secrets that state checks and GET responses cannot observe.
- **ADR-008** — new *Guard Ordering in `FillUpdateBody`* and *Conversion Pitfalls* sections (unknown-guard-at-top, `IsNull`-gated compound deletes, int-zero handling including the `*int` cast, empty-string vs null on non-pointer subfields), the map-diff early-return delete-leak warning, a *Per-Commit Verification Gate*, and *Mandatory Acceptance Scenarios* per sub-package.

Each ADR's *Common Mistakes* list was extended to match. Documentation-only — no code changes.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

Documentation-only change — no runtime surface. Verification performed instead of acceptance tests:

**Checks** (`/bpg:ready`, 2026-07-03): `make build` clean, `make lint` 0 issues, `make test` all packages ok, prettier + markdownlint-cli2 0 errors on all five edited ADRs.

**Anchor integrity** — every intra-doc `#anchor` link in the edited files was checked against script-derived GitHub-style anchors for all ADR headings, including the new sections (`#guard-ordering-in-fillupdatebody`, `#conversion-pitfalls`, `#task-result-diagnostics`, `#import-id-format`, `#requestresponse-body-conventions`): all resolve.

**Factual claims verified against current code:**

- `TaskResult.AddDiags` / `AddDiagsAsWarnings` summary pass-through — `proxmox/nodes/tasks/task_result.go:65,79`
- `isUnrecognizedPoolErr` call-site escape hatch — `proxmox/nodes/ceph/pool/ceph_pool.go:62`
- Case-split not-found patterns (lowercase PVE Perl vs capitalized libc) — `proxmox/api/client.go:368-372`
- `MapDiff` three-map return — `utils/maps.go:138`
- `parseImportIDWithNodeName` + `strings.Cut` convention — `proxmoxtf/resource/vm/vm.go`
- `te.ExecuteNodeCommands` root-SSH helper — `fwprovider/test/test_environment.go`

**Reference hygiene** — no issue/PR numbers added to the ADRs (only pre-existing #1231 tracking references remain), per the no-PR-refs-in-static-docs rule these ADRs themselves document.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

Closes #2981

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Fable 5). All changes have been reviewed and verified by a human.*
