### PR TITLE
fix(core): send delete to PVE when write-only attributes are removed

### DIFF
--- a/fwprovider/access/model_realm_openid.go
+++ b/fwprovider/access/model_realm_openid.go
@@ -126,6 +126,12 @@ func (m *realmOpenIDModel) toUpdateRequest(state *realmOpenIDModel, clientKeyWO 
 		req.ClientKey = clientKeyWO.ValueStringPointer()
 	} else {
 		updateStringAttribute(&req.ClientKey, m.ClientKey, state.ClientKey, &toDelete, "client-key")
+
+		// Write-only client_key_wo is never mirrored into state, so the version counter
+		// leaving state is the removal signal.
+		if m.ClientKey.IsNull() && m.ClientKeyWOVersion.IsNull() && !state.ClientKeyWOVersion.IsNull() {
+			toDelete = append(toDelete, "client-key")
+		}
 	}
 
 	// Optional fields: support unsetting using the API's `delete` parameter.
@@ -189,7 +195,9 @@ func (m *realmOpenIDModel) fromAPIResponse(data *access.RealmGetResponseData, di
 	m.IssuerURL = types.StringPointerValue(data.IssuerURL)
 	m.ClientID = types.StringPointerValue(data.ClientID)
 
-	// Note: client_key is never returned by the API, preserve from state
+	// client_key is deliberately not mirrored from the API response (which does return
+	// it): when the key is supplied via the write-only client_key_wo it must stay null
+	// in state, so preserve whatever state already holds.
 
 	// Set optional string fields
 	m.UsernameClaim = types.StringPointerValue(data.UsernameClaim)

--- a/fwprovider/access/resource_realm_openid_test.go
+++ b/fwprovider/access/resource_realm_openid_test.go
@@ -127,6 +127,34 @@ func TestAccRealmOpenIDWriteOnly(t *testing.T) {
 				),
 			},
 		}},
+		{"removing client_key_wo deletes the key from PVE", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_realm_openid" "test_remove" {
+						realm                 = "{{.Realm}}-rm"
+						issuer_url            = "https://accounts.google.com"
+						client_id             = "test-client-id"
+						client_key_wo         = "remove-me"
+						client_key_wo_version = 1
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("proxmox_realm_openid.test_remove", "client_key_wo_version", "1"),
+					testCheckOpenIDRealmClientKey(te, fmt.Sprintf("%s-rm", realm), true),
+				),
+			},
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_realm_openid" "test_remove" {
+						realm      = "{{.Realm}}-rm"
+						issuer_url = "https://accounts.google.com"
+						client_id  = "test-client-id"
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("proxmox_realm_openid.test_remove", "client_key_wo_version"),
+					testCheckOpenIDRealmClientKey(te, fmt.Sprintf("%s-rm", realm), false),
+				),
+			},
+		}},
 		{"migrating from client_key to client_key_wo clears it from state", []resource.TestStep{
 			{
 				Config: te.RenderConfig(`
@@ -198,7 +226,7 @@ func TestAccRealmOpenIDWriteOnly(t *testing.T) {
 // testCheckOpenIDRealmExists verifies, via a direct API read, that the realm exists
 // on the server and is an OpenID realm. Used to prove a realm configured solely with
 // the write-only client_key_wo is actually created, even though the secret never
-// lands in Terraform state (and the API never returns it for read-back).
+// lands in Terraform state.
 func testCheckOpenIDRealmExists(te *test.Environment, realm string) resource.TestCheckFunc {
 	return func(*terraform.State) error {
 		data, err := te.AccessClient().GetRealm(context.Background(), realm)
@@ -208,6 +236,28 @@ func testCheckOpenIDRealmExists(te *test.Environment, realm string) resource.Tes
 
 		if data.Type != "openid" {
 			return fmt.Errorf("realm %q has type %q, want %q", realm, data.Type, "openid")
+		}
+
+		return nil
+	}
+}
+
+// testCheckOpenIDRealmClientKey verifies, via a direct API read, whether the realm has a
+// client-key configured. Used to prove that removing client_key_wo sends delete=client-key.
+func testCheckOpenIDRealmClientKey(te *test.Environment, realm string, want bool) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		data, err := te.AccessClient().GetRealm(context.Background(), realm)
+		if err != nil {
+			return fmt.Errorf("reading OpenID realm %q: %w", realm, err)
+		}
+
+		has := data.ClientKey != nil && *data.ClientKey != ""
+		if has != want {
+			if want {
+				return fmt.Errorf("realm %q has no client-key; write-only client_key_wo was not stored", realm)
+			}
+
+			return fmt.Errorf("client-key still present on PVE after removing client_key_wo")
 		}
 
 		return nil

--- a/fwprovider/cluster/acme/resource_acme_dns_plugin.go
+++ b/fwprovider/cluster/acme/resource_acme_dns_plugin.go
@@ -305,6 +305,10 @@ func (r *acmePluginResource) Update(ctx context.Context, req resource.UpdateRequ
 		updateRequest.Data = &data
 	case !state.Data.IsNull():
 		toDelete = append(toDelete, "data")
+	// Write-only data_wo is never mirrored into state, so the version counter
+	// leaving state is the removal signal.
+	case plan.DataWOVersion.IsNull() && !state.DataWOVersion.IsNull():
+		toDelete = append(toDelete, "data")
 	}
 
 	if resp.Diagnostics.HasError() {

--- a/fwprovider/cluster/acme/resource_acme_dns_plugin_test.go
+++ b/fwprovider/cluster/acme/resource_acme_dns_plugin_test.go
@@ -255,6 +255,36 @@ func TestAccResourceACMEDNSPluginWriteOnly(t *testing.T) {
 				),
 			},
 		}},
+		{"removing data_wo deletes data from PVE", []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_acme_dns_plugin" "test_plugin_remove" {
+						plugin = "{{.PluginName}}-remove"
+						api = "cf"
+						data_wo = {
+							"CF_API_KEY" = "remove-me"
+						}
+						data_wo_version = 1
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("proxmox_acme_dns_plugin.test_plugin_remove", "data_wo_version", "1"),
+					testCheckACMEPluginDataStored(te, fmt.Sprintf("%s-remove", pluginName), map[string]string{
+						"CF_API_KEY": "remove-me",
+					}),
+				),
+			},
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_acme_dns_plugin" "test_plugin_remove" {
+						plugin = "{{.PluginName}}-remove"
+						api = "cf"
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("proxmox_acme_dns_plugin.test_plugin_remove", "data_wo_version"),
+					testCheckACMEPluginDataEmpty(te, fmt.Sprintf("%s-remove", pluginName)),
+				),
+			},
+		}},
 		{"data_wo_version requires data_wo", []resource.TestStep{
 			{
 				Config: te.RenderConfig(`
@@ -316,6 +346,23 @@ func testCheckACMEPluginDataStored(te *test.Environment, pluginID string, want m
 			if got := (*plugin.Data)[k]; got != v {
 				return fmt.Errorf("ACME plugin %q data[%q] = %q, want %q", pluginID, k, got, v)
 			}
+		}
+
+		return nil
+	}
+}
+
+// testCheckACMEPluginDataEmpty verifies, via a direct API read, that the plugin has no
+// DNS data configured. Used to prove that removing data_wo sends delete=data.
+func testCheckACMEPluginDataEmpty(te *test.Environment, pluginID string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		plugin, err := te.ClusterClient().ACME().Plugins().Get(context.Background(), pluginID)
+		if err != nil {
+			return fmt.Errorf("reading ACME plugin %q: %w", pluginID, err)
+		}
+
+		if plugin.Data != nil && len(*plugin.Data) > 0 {
+			return fmt.Errorf("data still present on PVE after removing data_wo: %v", *plugin.Data)
 		}
 
 		return nil


### PR DESCRIPTION
### What does this PR do?

Removing a write-only attribute (`data_wo` on `proxmox_acme_dns_plugin`, `client_key_wo` on
`proxmox_virtual_environment_realm_openid`) together with its `*_wo_version` counter never sent
`delete=<param>` to PVE: write-only values are never mirrored into state, so the existing
null-vs-null removal detection in Update appended nothing to the delete list. The credentials
stayed live on the cluster (`/etc/pve/priv/acme/plugins.cfg`, `/etc/pve/domains.cfg`) while the
Terraform plan showed them as removed.

This PR applies the same removal signal already used by `proxmox_metrics_server` (#2972): the
version counter leaving state (plan `*_wo_version` null, state non-null, plaintext sibling null)
now appends the parameter to the API delete list. Both resources get a new acceptance subtest
that proves removal via a direct API read, plus two factually wrong code comments corrected
(PVE's `GET /access/domains/<realm>` does return `client-key`).

### Usage Example

```hcl
resource "proxmox_acme_dns_plugin" "example" {
  plugin = "example-dns"
  api    = "cf"
  data_wo = {
    "CF_API_KEY" = "secret-key"
  }
  data_wo_version = 1
}

# Removing data_wo + data_wo_version and re-applying now clears the
# credentials from PVE (sends delete=data), same as removing plaintext data:
# resource "proxmox_acme_dns_plugin" "example" {
#   plugin = "example-dns"
#   api    = "cf"
# }
```

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work

TDD — both fixes were written test-first; each new subtest failed on unmodified code with the
exact defect signature and passes with the fix.

**ACME DNS plugin — failing test before the fix (RED):**

```text
resource_acme_dns_plugin_test.go:319: Step 2/2 error: Check failed: Check 2/2 error:
    data still present on PVE after removing data_wo: map[CF_API_KEY:remove-me]
--- FAIL: TestAccResourceACMEDNSPluginWriteOnly/removing_data_wo_deletes_data_from_PVE (3.82s)
```

**After the fix:**

```text
./testacc "TestAccResourceACMEDNSPlugin.*" -- -v

--- PASS: TestAccResourceACMEDNSPlugin (0.00s)                (5 subtests)
--- PASS: TestAccResourceACMEDNSPluginWriteOnly (0.00s)       (5 subtests, incl. new removal subtest)
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/cluster/acme      7.657s
```

**OpenID realm — failing test before the fix (RED):**

```text
resource_realm_openid_test.go:214: Step 2/2 error: Check failed: Check 2/2 error:
    client-key still present on PVE after removing client_key_wo
--- FAIL: TestAccRealmOpenIDWriteOnly/removing_client_key_wo_deletes_the_key_from_PVE (4.46s)
```

**After the fix:**

```text
./testacc "TestAccRealmOpenID.*" -- -v

--- PASS: TestAccRealmOpenIDUsernameClaim (2.94s)
--- PASS: TestAccRealmOpenIDWriteOnly (0.00s)                 (6 subtests, incl. new removal subtest)
--- PASS: TestAccRealmOpenID (7.63s)
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/access    8.142s
```

**API verification:** both new subtests assert behavior via direct API reads rather than
Terraform state — `testCheckACMEPluginDataEmpty` (`GET /cluster/acme/plugins/<id>`) and
`testCheckOpenIDRealmClientKey` (`GET /access/domains/<realm>`) fail if the credential is still
configured on PVE after the removal step, proving the `delete=` parameter reached PVE and took
effect. Additionally verified on a live PVE 9.2 node that `pvesh set /cluster/acme/plugins/<id>
--delete data` and `pvesh set /access/domains/<id> --delete client-key` are valid operations
that clear the respective fields.

Full acme package (`./testacc --resource acme` — account, plugin, and datasource tests) also
passes; `make build`, `make test`, `make lint` (0 issues) all green.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

Closes #2975

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Fable 5). All changes have been reviewed and verified by a human.*
