### PR TITLE
feat(provider): add Cloudflare Access service token support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,20 @@ provider "proxmox" {
 }
 ```
 
+If the Proxmox API endpoint is protected by Cloudflare Access, add a service-token block or provide the matching environment variables:
+
+```hcl
+provider "proxmox" {
+  endpoint  = var.virtual_environment_endpoint
+  api_token = var.virtual_environment_api_token
+
+  cloudflare_access {
+    client_id     = var.cloudflare_access_client_id
+    client_secret = var.cloudflare_access_client_secret
+  }
+}
+```
+
 The variable values can be provided via a separate `.tfvars` file (add it to `.gitignore`).
 See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/values/variables#input-variables) for more information.
 
@@ -525,6 +539,13 @@ All provider arguments can be configured via environment variables. This is the 
 | `PROXMOX_VE_AUTH_TICKET`           | Pre-authenticated session ticket       |
 | `PROXMOX_VE_CSRF_PREVENTION_TOKEN` | CSRF token (used with auth ticket)     |
 
+**Cloudflare Access (optional):**
+
+| Environment Variable                 | Description                                   |
+| ------------------------------------ | --------------------------------------------- |
+| `PROXMOX_VE_CF_ACCESS_CLIENT_ID`     | Cloudflare Access service-token client ID     |
+| `PROXMOX_VE_CF_ACCESS_CLIENT_SECRET` | Cloudflare Access service-token client secret |
+
 **API Options (optional):**
 
 | Environment Variable  | Description                                      |
@@ -559,6 +580,10 @@ In addition to [generic provider arguments](https://developer.hashicorp.com/terr
 - `csrf_prevention_token` - (Optional) The CSRF Prevention Token from an external auth call (can also be sourced from `PROXMOX_VE_CSRF_PREVENTION_TOKEN`). For example, `12345678:some_blob`.
 
 - `api_token` - (Optional) The API Token for the Proxmox Virtual Environment API (can also be sourced from `PROXMOX_VE_API_TOKEN`). Takes precedence over `username` with `password`. For example, `username@realm!for-terraform-provider=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
+
+- `cloudflare_access` - (Optional) Cloudflare Access service-token authentication for the Proxmox VE API endpoint. Can also be sourced from `PROXMOX_VE_CF_ACCESS_CLIENT_ID` and `PROXMOX_VE_CF_ACCESS_CLIENT_SECRET`.
+  - `client_id` - (Optional) The Cloudflare Access service-token client ID.
+  - `client_secret` - (Optional) The Cloudflare Access service-token client secret.
 
 - `otp` - (Optional, Deprecated) The one-time password for the Proxmox Virtual Environment API (can also be sourced from `PROXMOX_VE_OTP`).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,20 +124,6 @@ provider "proxmox" {
 }
 ```
 
-If the Proxmox API endpoint is protected by Cloudflare Access, add a service-token block or provide the matching environment variables:
-
-```hcl
-provider "proxmox" {
-  endpoint  = var.virtual_environment_endpoint
-  api_token = var.virtual_environment_api_token
-
-  cloudflare_access {
-    client_id     = var.cloudflare_access_client_id
-    client_secret = var.cloudflare_access_client_secret
-  }
-}
-```
-
 The variable values can be provided via a separate `.tfvars` file (add it to `.gitignore`).
 See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/values/variables#input-variables) for more information.
 
@@ -278,6 +264,26 @@ export PROXMOX_VE_CSRF_PREVENTION_TOKEN="${resp_csrf}"
 
 terraform plan
 ```
+
+### Cloudflare Access
+
+If the Proxmox VE API endpoint is published behind [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/identity/service-tokens/), the provider can authenticate to Cloudflare with a service token. Add a `cloudflare_access` block, or set the `PROXMOX_VE_CF_ACCESS_CLIENT_ID` and `PROXMOX_VE_CF_ACCESS_CLIENT_SECRET` environment variables:
+
+```hcl
+provider "proxmox" {
+  endpoint  = "https://pve.example.com/"
+  api_token = var.virtual_environment_api_token
+
+  cloudflare_access {
+    client_id     = var.cloudflare_access_client_id
+    client_secret = var.cloudflare_access_client_secret
+  }
+}
+```
+
+The `CF-Access-Client-Id` and `CF-Access-Client-Secret` headers are added only to requests sent to the configured `endpoint` host. Both `client_id` and `client_secret` must be provided together.
+
+~> Cloudflare Access protects the API endpoint only. Features that require an [SSH connection](#ssh-connection) to the Proxmox nodes still need direct network access to them.
 
 ## SSH Connection
 
@@ -581,9 +587,9 @@ In addition to [generic provider arguments](https://developer.hashicorp.com/terr
 
 - `api_token` - (Optional) The API Token for the Proxmox Virtual Environment API (can also be sourced from `PROXMOX_VE_API_TOKEN`). Takes precedence over `username` with `password`. For example, `username@realm!for-terraform-provider=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
 
-- `cloudflare_access` - (Optional) Cloudflare Access service-token authentication for the Proxmox VE API endpoint. Can also be sourced from `PROXMOX_VE_CF_ACCESS_CLIENT_ID` and `PROXMOX_VE_CF_ACCESS_CLIENT_SECRET`.
-  - `client_id` - (Optional) The Cloudflare Access service-token client ID.
-  - `client_secret` - (Optional) The Cloudflare Access service-token client secret.
+- `cloudflare_access` - (Optional) Cloudflare Access service-token authentication for the Proxmox VE API endpoint. See [Cloudflare Access](#cloudflare-access).
+  - `client_id` - (Optional) The Cloudflare Access service-token client ID. Must be set together with `client_secret` (can also be sourced from `PROXMOX_VE_CF_ACCESS_CLIENT_ID`).
+  - `client_secret` - (Optional) The Cloudflare Access service-token client secret. Must be set together with `client_id` (can also be sourced from `PROXMOX_VE_CF_ACCESS_CLIENT_SECRET`).
 
 - `otp` - (Optional, Deprecated) The one-time password for the Proxmox Virtual Environment API (can also be sourced from `PROXMOX_VE_OTP`).
 

--- a/fwprovider/provider.go
+++ b/fwprovider/provider.go
@@ -113,6 +113,11 @@ type proxmoxProviderModel struct {
 			Port    types.Int64  `tfsdk:"port"`
 		} `tfsdk:"node"`
 	} `tfsdk:"ssh"`
+
+	CloudflareAccess []struct {
+		ClientID     types.String `tfsdk:"client_id"`
+		ClientSecret types.String `tfsdk:"client_secret"`
+	} `tfsdk:"cloudflare_access"`
 	TmpDir         types.String `tfsdk:"tmp_dir"`
 	RandomVMIDs    types.Bool   `tfsdk:"random_vm_ids"`
 	RandomVMIDStat types.Int64  `tfsdk:"random_vm_id_start"`
@@ -293,6 +298,32 @@ func (p *proxmoxProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 					},
 				},
 			},
+			"cloudflare_access": schema.ListNestedBlock{
+				Description: "Cloudflare Access service-token authentication for the Proxmox VE API endpoint.",
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"client_id": schema.StringAttribute{
+							Description: "The Cloudflare Access service-token client ID.",
+							Optional:    true,
+							Sensitive:   true,
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(1),
+							},
+						},
+						"client_secret": schema.StringAttribute{
+							Description: "The Cloudflare Access service-token client secret.",
+							Optional:    true,
+							Sensitive:   true,
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(1),
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -343,6 +374,8 @@ func (p *proxmoxProvider) Configure(
 	apiToken := utils.GetAnyStringEnv("PROXMOX_VE_API_TOKEN")
 	username := utils.GetAnyStringEnv("PROXMOX_VE_USERNAME")
 	password := utils.GetAnyStringEnv("PROXMOX_VE_PASSWORD")
+	cfClientID := utils.GetAnyStringEnv("PROXMOX_VE_CF_ACCESS_CLIENT_ID", "PM_VE_CF_ACCESS_CLIENT_ID")
+	cfClientSecret := utils.GetAnyStringEnv("PROXMOX_VE_CF_ACCESS_CLIENT_SECRET", "PM_VE_CF_ACCESS_CLIENT_SECRET")
 
 	if !cfg.APIToken.IsNull() {
 		apiToken = cfg.APIToken.ValueString()
@@ -404,10 +437,41 @@ func (p *proxmoxProvider) Configure(
 		)
 	}
 
+	var cfConfig *api.CloudflareAccessConfig
+
+	if len(cfg.CloudflareAccess) > 0 {
+		cf := cfg.CloudflareAccess[0]
+		if !cf.ClientID.IsNull() {
+			cfClientID = cf.ClientID.ValueString()
+		}
+
+		if !cf.ClientSecret.IsNull() {
+			cfClientSecret = cf.ClientSecret.ValueString()
+		}
+	}
+
+	if cfClientID != "" || cfClientSecret != "" {
+		if cfClientID == "" || cfClientSecret == "" {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("cloudflare_access"),
+				"Incomplete Cloudflare Access Configuration",
+				"Cloudflare Access service-token authentication requires both client_id and client_secret. "+
+					"Set both values in the cloudflare_access block or with PROXMOX_VE_CF_ACCESS_CLIENT_ID and "+
+					"PROXMOX_VE_CF_ACCESS_CLIENT_SECRET.",
+			)
+		} else {
+			cfConfig = &api.CloudflareAccessConfig{
+				ClientID:     cfClientID,
+				ClientSecret: cfClientSecret,
+			}
+		}
+	}
+
 	conn, err := api.NewConnection(
 		endpoint,
 		insecure,
 		minTLS,
+		cfConfig,
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/fwprovider/provider.go
+++ b/fwprovider/provider.go
@@ -94,6 +94,11 @@ type proxmoxProviderModel struct {
 	Username            types.String `tfsdk:"username"`
 	Password            types.String `tfsdk:"password"`
 
+	CloudflareAccess []struct {
+		ClientID     types.String `tfsdk:"client_id"`
+		ClientSecret types.String `tfsdk:"client_secret"`
+	} `tfsdk:"cloudflare_access"`
+
 	SSH []struct {
 		Agent           types.Bool   `tfsdk:"agent"`
 		AgentSocket     types.String `tfsdk:"agent_socket"`
@@ -114,10 +119,6 @@ type proxmoxProviderModel struct {
 		} `tfsdk:"node"`
 	} `tfsdk:"ssh"`
 
-	CloudflareAccess []struct {
-		ClientID     types.String `tfsdk:"client_id"`
-		ClientSecret types.String `tfsdk:"client_secret"`
-	} `tfsdk:"cloudflare_access"`
 	TmpDir         types.String `tfsdk:"tmp_dir"`
 	RandomVMIDs    types.Bool   `tfsdk:"random_vm_ids"`
 	RandomVMIDStat types.Int64  `tfsdk:"random_vm_id_start"`
@@ -199,6 +200,36 @@ func (p *proxmoxProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 			},
 		},
 		Blocks: map[string]schema.Block{
+			"cloudflare_access": schema.ListNestedBlock{
+				Description: "Cloudflare Access service-token authentication for the Proxmox VE API endpoint.",
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"client_id": schema.StringAttribute{
+							Description: "The Cloudflare Access service-token client ID. " +
+								"Must be set together with `client_secret`. " +
+								"Defaults to the value of the `PROXMOX_VE_CF_ACCESS_CLIENT_ID` environment variable.",
+							Optional:  true,
+							Sensitive: true,
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(1),
+							},
+						},
+						"client_secret": schema.StringAttribute{
+							Description: "The Cloudflare Access service-token client secret. " +
+								"Must be set together with `client_id`. " +
+								"Defaults to the value of the `PROXMOX_VE_CF_ACCESS_CLIENT_SECRET` environment variable.",
+							Optional:  true,
+							Sensitive: true,
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(1),
+							},
+						},
+					},
+				},
+			},
 			// have to define it as a list due to backwards compatibility
 			"ssh": schema.ListNestedBlock{
 				Description: "The SSH configuration for the Proxmox nodes.",
@@ -298,32 +329,6 @@ func (p *proxmoxProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 					},
 				},
 			},
-			"cloudflare_access": schema.ListNestedBlock{
-				Description: "Cloudflare Access service-token authentication for the Proxmox VE API endpoint.",
-				Validators: []validator.List{
-					listvalidator.SizeAtMost(1),
-				},
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"client_id": schema.StringAttribute{
-							Description: "The Cloudflare Access service-token client ID.",
-							Optional:    true,
-							Sensitive:   true,
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-							},
-						},
-						"client_secret": schema.StringAttribute{
-							Description: "The Cloudflare Access service-token client secret.",
-							Optional:    true,
-							Sensitive:   true,
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-							},
-						},
-					},
-				},
-			},
 		},
 	}
 }
@@ -374,8 +379,8 @@ func (p *proxmoxProvider) Configure(
 	apiToken := utils.GetAnyStringEnv("PROXMOX_VE_API_TOKEN")
 	username := utils.GetAnyStringEnv("PROXMOX_VE_USERNAME")
 	password := utils.GetAnyStringEnv("PROXMOX_VE_PASSWORD")
-	cfClientID := utils.GetAnyStringEnv("PROXMOX_VE_CF_ACCESS_CLIENT_ID", "PM_VE_CF_ACCESS_CLIENT_ID")
-	cfClientSecret := utils.GetAnyStringEnv("PROXMOX_VE_CF_ACCESS_CLIENT_SECRET", "PM_VE_CF_ACCESS_CLIENT_SECRET")
+	cfClientID := utils.GetAnyStringEnv("PROXMOX_VE_CF_ACCESS_CLIENT_ID")
+	cfClientSecret := utils.GetAnyStringEnv("PROXMOX_VE_CF_ACCESS_CLIENT_SECRET")
 
 	if !cfg.APIToken.IsNull() {
 		apiToken = cfg.APIToken.ValueString()

--- a/fwprovider/test/provider_test.go
+++ b/fwprovider/test/provider_test.go
@@ -14,6 +14,7 @@ package test
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -81,4 +82,96 @@ func TestAccProviderSSHNodeAddressSource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccProviderCloudflareAccess(t *testing.T) {
+	te := InitEnvironment(t)
+
+	const versionDataSource = `
+		data "proxmox_virtual_environment_version" "test" {}
+	`
+
+	versionRead := resource.TestCheckResourceAttrSet("data.proxmox_virtual_environment_version.test", "version")
+
+	// The PVE test endpoint ignores the CF-Access-* headers, so every complete configuration must still read the
+	// version data source. Environment variables are set per scenario, hence resource.Test instead of ParallelTest.
+	tests := []struct {
+		name string
+		env  map[string]string
+		step resource.TestStep
+	}{
+		{
+			name: "both set in block",
+			step: resource.TestStep{
+				Config: `
+					provider "proxmox" {
+						cloudflare_access {
+							client_id     = "test-client-id.access"
+							client_secret = "test-client-secret"
+						}
+					}` + versionDataSource,
+				Check: versionRead,
+			},
+		},
+		{
+			name: "empty block disables cloudflare access",
+			step: resource.TestStep{
+				Config: `
+					provider "proxmox" {
+						cloudflare_access {}
+					}` + versionDataSource,
+				Check: versionRead,
+			},
+		},
+		{
+			name: "only client_id in block",
+			step: resource.TestStep{
+				Config: `
+					provider "proxmox" {
+						cloudflare_access {
+							client_id = "test-client-id.access"
+						}
+					}` + versionDataSource,
+				ExpectError: regexp.MustCompile(`(?s)requires both client_id and\s+client_secret`),
+			},
+		},
+		{
+			name: "client_id in block, secret from env",
+			env:  map[string]string{"PROXMOX_VE_CF_ACCESS_CLIENT_SECRET": "test-client-secret"},
+			step: resource.TestStep{
+				Config: `
+					provider "proxmox" {
+						cloudflare_access {
+							client_id = "test-client-id.access"
+						}
+					}` + versionDataSource,
+				Check: versionRead,
+			},
+		},
+		{
+			name: "both from env",
+			env: map[string]string{
+				"PROXMOX_VE_CF_ACCESS_CLIENT_ID":     "test-client-id.access",
+				"PROXMOX_VE_CF_ACCESS_CLIENT_SECRET": "test-client-secret",
+			},
+			step: resource.TestStep{
+				Config: `
+					provider "proxmox" {}` + versionDataSource,
+				Check: versionRead,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			resource.Test(t, resource.TestCase{
+				ProtoV6ProviderFactories: te.AccProviders,
+				Steps:                    []resource.TestStep{tt.step},
+			})
+		})
+	}
 }

--- a/fwprovider/test/test_environment.go
+++ b/fwprovider/test/test_environment.go
@@ -259,7 +259,7 @@ func (e *Environment) Client() api.Client {
 					panic(err)
 				}
 
-				conn, err := api.NewConnection(endpoint, true, "")
+				conn, err := api.NewConnection(endpoint, true, "", nil)
 				if err != nil {
 					panic(err)
 				}

--- a/proxmox/api/client.go
+++ b/proxmox/api/client.go
@@ -66,7 +66,7 @@ type Connection struct {
 }
 
 // NewConnection creates and initializes a Connection instance.
-func NewConnection(endpoint string, insecure bool, minTLS string) (*Connection, error) {
+func NewConnection(endpoint string, insecure bool, minTLS string, cfConfig *CloudflareAccessConfig) (*Connection, error) {
 	u, err := url.ParseRequestURI(endpoint)
 	if err != nil {
 		return nil, errors.New(
@@ -96,6 +96,10 @@ func NewConnection(endpoint string, insecure bool, minTLS string) (*Connection, 
 
 	if logging.IsDebugOrHigher() {
 		transport = logging.NewLoggingHTTPTransport(transport)
+	}
+
+	if cfConfig != nil && cfConfig.ClientID != "" && cfConfig.ClientSecret != "" {
+		transport = NewCloudflareAccessTransport(transport, *cfConfig, endpoint)
 	}
 
 	// make sure the path does not contain "/api2/json"

--- a/proxmox/api/client.go
+++ b/proxmox/api/client.go
@@ -94,12 +94,13 @@ func NewConnection(endpoint string, insecure bool, minTLS string, cfConfig *Clou
 		},
 	}
 
-	if logging.IsDebugOrHigher() {
-		transport = logging.NewLoggingHTTPTransport(transport)
-	}
-
+	// Inject Cloudflare Access headers below the logging transport so the secret never reaches TF_LOG output.
 	if cfConfig != nil && cfConfig.ClientID != "" && cfConfig.ClientSecret != "" {
 		transport = NewCloudflareAccessTransport(transport, *cfConfig, endpoint)
+	}
+
+	if logging.IsDebugOrHigher() {
+		transport = logging.NewLoggingHTTPTransport(transport)
 	}
 
 	// make sure the path does not contain "/api2/json"

--- a/proxmox/api/cloudflare_access.go
+++ b/proxmox/api/cloudflare_access.go
@@ -1,0 +1,96 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// CloudflareAccessConfig holds the Cloudflare Access service-token credentials.
+type CloudflareAccessConfig struct {
+	ClientID     string
+	ClientSecret string
+}
+
+// cloudflareAccessTransport wraps an http.RoundTripper to inject Cloudflare Access
+// service-token headers into requests scoped to the configured endpoint host.
+type cloudflareAccessTransport struct {
+	base         http.RoundTripper
+	config       CloudflareAccessConfig
+	endpointHost string
+}
+
+// NewCloudflareAccessTransport returns a RoundTripper that adds
+// CF-Access-Client-Id and CF-Access-Client-Secret headers to requests
+// whose Host matches the configured endpoint host.
+// Port differences are ignored.
+func NewCloudflareAccessTransport(
+	base http.RoundTripper,
+	config CloudflareAccessConfig,
+	endpointURL string,
+) http.RoundTripper {
+	host := extractHost(endpointURL)
+
+	return &cloudflareAccessTransport{
+		base:         base,
+		config:       config,
+		endpointHost: host,
+	}
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *cloudflareAccessTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	if !matchesEndpointHost(req, t.endpointHost) {
+		resp, err := base.RoundTrip(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to send Cloudflare Access passthrough request: %w", err)
+		}
+
+		return resp, nil
+	}
+
+	cloned := req.Clone(req.Context())
+	cloned.Header = req.Header.Clone()
+
+	cloned.Header.Set("CF-Access-Client-Id", t.config.ClientID)
+	cloned.Header.Set("CF-Access-Client-Secret", t.config.ClientSecret)
+
+	resp, err := base.RoundTrip(cloned)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send Cloudflare Access authenticated request: %w", err)
+	}
+
+	return resp, nil
+}
+
+// extractHost parses the endpoint URL and returns the hostname, stripping any port.
+func extractHost(endpointURL string) string {
+	u, err := url.Parse(endpointURL)
+	if err != nil {
+		return ""
+	}
+
+	return u.Hostname()
+}
+
+// matchesEndpointHost returns true when the request is addressed to the same
+// origin as the Proxmox endpoint. Port differences are ignored so that
+// "pve.example.com" matches "pve.example.com:8006".
+func matchesEndpointHost(req *http.Request, endpointHost string) bool {
+	if endpointHost == "" {
+		return false
+	}
+
+	return req.URL.Hostname() == endpointHost
+}

--- a/proxmox/api/cloudflare_access_test.go
+++ b/proxmox/api/cloudflare_access_test.go
@@ -1,0 +1,476 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package api
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// recordingTransport captures the last request that was sent through it.
+type recordingTransport struct {
+	mu       sync.Mutex
+	lastReq  *http.Request
+	respCode int
+	respBody string
+}
+
+func (t *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.lastReq = req.Clone(req.Context())
+
+	return &http.Response{
+		StatusCode: t.respCode,
+		Body:       io.NopCloser(strings.NewReader(t.respBody)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func (t *recordingTransport) lastRequest() *http.Request {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.lastReq
+}
+
+func TestCloudflareAccessTransport_HeadersAdded(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingTransport{respCode: http.StatusOK, respBody: `{}`}
+
+	config := CloudflareAccessConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+	}
+
+	transport := NewCloudflareAccessTransport(rec, config, "https://pve.example.com:8006/")
+
+	client := &http.Client{Transport: transport}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"https://pve.example.com:8006/api2/json/version",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	lastReq := rec.lastRequest()
+	if lastReq == nil {
+		t.Fatal("no request was recorded")
+	}
+
+	if got := lastReq.Header.Get("CF-Access-Client-Id"); got != "test-client-id" {
+		t.Errorf("CF-Access-Client-Id = %q, want %q", got, "test-client-id")
+	}
+
+	if got := lastReq.Header.Get("CF-Access-Client-Secret"); got != "test-client-secret" {
+		t.Errorf("CF-Access-Client-Secret = %q, want %q", got, "test-client-secret")
+	}
+}
+
+func TestCloudflareAccessTransport_ExistingHeadersPreserved(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingTransport{respCode: http.StatusOK, respBody: `{}`}
+
+	config := CloudflareAccessConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+	}
+
+	transport := NewCloudflareAccessTransport(rec, config, "https://pve.example.com/")
+
+	client := &http.Client{Transport: transport}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"https://pve.example.com/api2/json/version",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	req.Header.Set("X-Custom-Header", "custom-value")
+	req.Header.Set("Authorization", "PVE token=value")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	lastReq := rec.lastRequest()
+	if lastReq == nil {
+		t.Fatal("no request was recorded")
+	}
+
+	if got := lastReq.Header.Get("X-Custom-Header"); got != "custom-value" {
+		t.Errorf("X-Custom-Header = %q, want %q", got, "custom-value")
+	}
+
+	if got := lastReq.Header.Get("Authorization"); got != "PVE token=value" {
+		t.Errorf("Authorization = %q, want %q", got, "PVE token=value")
+	}
+}
+
+func TestCloudflareAccessTransport_OriginalRequestUnchanged(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingTransport{respCode: http.StatusOK, respBody: `{}`}
+
+	config := CloudflareAccessConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+	}
+
+	transport := NewCloudflareAccessTransport(rec, config, "https://pve.example.com/")
+
+	client := &http.Client{Transport: transport}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"https://pve.example.com/api2/json/version",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	originalHeaderCount := len(req.Header)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := req.Header.Get("CF-Access-Client-Id"); got != "" {
+		t.Errorf("original request was mutated: CF-Access-Client-Id = %q", got)
+	}
+
+	if len(req.Header) != originalHeaderCount {
+		t.Errorf("original request header count changed from %d to %d", originalHeaderCount, len(req.Header))
+	}
+}
+
+func TestCloudflareAccessTransport_DuplicateHeadersOverwritten(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingTransport{respCode: http.StatusOK, respBody: `{}`}
+
+	config := CloudflareAccessConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+	}
+
+	transport := NewCloudflareAccessTransport(rec, config, "https://pve.example.com/")
+
+	client := &http.Client{Transport: transport}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"https://pve.example.com/api2/json/version",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	req.Header.Set("CF-Access-Client-Id", "existing-value")
+	req.Header.Set("CF-Access-Client-Secret", "existing-secret")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	lastReq := rec.lastRequest()
+	if lastReq == nil {
+		t.Fatal("no request was recorded")
+	}
+
+	if got := lastReq.Header.Get("CF-Access-Client-Id"); got != "test-client-id" {
+		t.Errorf("CF-Access-Client-Id = %q, want %q (should overwrite)", got, "test-client-id")
+	}
+
+	if got := lastReq.Header[textproto.CanonicalMIMEHeaderKey("CF-Access-Client-Id")]; len(got) != 1 {
+		t.Errorf("CF-Access-Client-Id has %d values, want 1", len(got))
+	}
+}
+
+func TestCloudflareAccessTransport_DifferentHost_NoHeaders(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingTransport{respCode: http.StatusOK, respBody: `{}`}
+
+	config := CloudflareAccessConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+	}
+
+	transport := NewCloudflareAccessTransport(rec, config, "https://pve.example.com/")
+
+	client := &http.Client{Transport: transport}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"https://external-host.example.com/api2/json/version",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	lastReq := rec.lastRequest()
+	if lastReq == nil {
+		t.Fatal("no request was recorded")
+	}
+
+	if got := lastReq.Header.Get("CF-Access-Client-Id"); got != "" {
+		t.Errorf("CF-Access-Client-Id should not be set for different host, got %q", got)
+	}
+
+	if got := lastReq.Header.Get("CF-Access-Client-Secret"); got != "" {
+		t.Errorf("CF-Access-Client-Secret should not be set for different host, got %q", got)
+	}
+}
+
+func TestCloudflareAccessTransport_NilBase(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cid := r.Header.Get("CF-Access-Client-Id")
+		csec := r.Header.Get("CF-Access-Client-Secret")
+
+		if cid != "test-client-id" {
+			t.Errorf("CF-Access-Client-Id = %q, want %q", cid, "test-client-id")
+		}
+
+		if csec != "test-client-secret" {
+			t.Errorf("CF-Access-Client-Secret = %q, want %q", csec, "test-client-secret")
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	config := CloudflareAccessConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+	}
+
+	transport := NewCloudflareAccessTransport(nil, config, server.URL)
+
+	client := &http.Client{Transport: transport}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		server.URL+"/api2/json/version",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+}
+
+func TestCloudflareAccessTransport_TransportError_NoCredentialsInError(t *testing.T) {
+	t.Parallel()
+
+	errTransport := &errorTransport{err: &net.OpError{
+		Op:  "dial",
+		Net: "tcp",
+	}}
+
+	config := CloudflareAccessConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+	}
+
+	transport := NewCloudflareAccessTransport(errTransport, config, "https://pve.example.com/")
+
+	client := &http.Client{Transport: transport}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"https://pve.example.com/api2/json/version",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	errStr := err.Error()
+	if strings.Contains(errStr, "test-client-id") || strings.Contains(errStr, "test-client-secret") {
+		t.Errorf("error contains credentials: %s", errStr)
+	}
+}
+
+func TestCloudflareAccessTransport_Redirect_CrossHost(t *testing.T) {
+	t.Parallel()
+	var redirectHeaders http.Header
+
+	redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectHeaders = r.Header.Clone()
+		w.Header().Set("Location", "http://127.0.0.1:0/target")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer redirectServer.Close()
+
+	config := CloudflareAccessConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+	}
+
+	transport := NewCloudflareAccessTransport(nil, config, "https://pve.example.com/")
+
+	client := &http.Client{
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		redirectServer.URL+"/source",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if redirectHeaders != nil {
+		if got := redirectHeaders.Get("CF-Access-Client-Id"); got != "" {
+			t.Errorf("redirect request should not have CF-Access-Client-Id, got %q", got)
+		}
+	}
+}
+
+func TestExtractHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://pve.example.com:8006/", "pve.example.com"},
+		{"https://pve.example.com/", "pve.example.com"},
+		{"https://10.0.111.15:8006/api2/json", "10.0.111.15"},
+		{"https://10.0.111.15/", "10.0.111.15"},
+		{"invalid", ""},
+	}
+
+	for _, tt := range tests {
+		got := extractHost(tt.input)
+		if got != tt.want {
+			t.Errorf("extractHost(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestMatchesEndpointHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		requestURL   string
+		endpointHost string
+		want         bool
+	}{
+		{"exact match", "https://pve.example.com:8006/api", "pve.example.com", true},
+		{"host only", "https://pve.example.com/api", "pve.example.com", true},
+		{"different host", "https://other.example.com/api", "pve.example.com", false},
+		{"empty host", "https://pve.example.com/api", "", false},
+		{"ip match", "https://10.0.111.15:8006/api", "10.0.111.15", true},
+		{"ip different port", "https://10.0.111.15:9999/api", "10.0.111.15", true},
+		{"same host different port", "https://pve.example.com:9999/api", "pve.example.com", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequestWithContext(
+				context.Background(),
+				http.MethodGet,
+				tt.requestURL,
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+
+			got := matchesEndpointHost(req, tt.endpointHost)
+			if got != tt.want {
+				t.Errorf("matchesEndpointHost(%v, %q) = %v, want %v",
+					req.URL, tt.endpointHost, got, tt.want)
+			}
+		})
+	}
+}
+
+type errorTransport struct {
+	err error
+}
+
+func (t *errorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, t.err
+}

--- a/proxmox/api/cloudflare_access_test.go
+++ b/proxmox/api/cloudflare_access_test.go
@@ -358,33 +358,47 @@ func TestCloudflareAccessTransport_TransportError_NoCredentialsInError(t *testin
 
 func TestCloudflareAccessTransport_Redirect_CrossHost(t *testing.T) {
 	t.Parallel()
-	var redirectHeaders http.Header
 
-	redirectServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		redirectHeaders = r.Header.Clone()
-		w.Header().Set("Location", "http://127.0.0.1:0/target")
-		w.WriteHeader(http.StatusFound)
+	var (
+		mu            sync.Mutex
+		sourceHeaders http.Header
+		targetHeaders http.Header
+	)
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		targetHeaders = r.Header.Clone()
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
 	}))
-	defer redirectServer.Close()
+	defer target.Close()
+
+	// httptest binds to 127.0.0.1; redirecting to "localhost" gives a different hostname on the same machine.
+	targetURL := strings.Replace(target.URL, "127.0.0.1", "localhost", 1) + "/target"
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		sourceHeaders = r.Header.Clone()
+		mu.Unlock()
+
+		http.Redirect(w, r, targetURL, http.StatusFound)
+	}))
+	defer source.Close()
 
 	config := CloudflareAccessConfig{
 		ClientID:     "test-client-id",
 		ClientSecret: "test-client-secret",
 	}
 
-	transport := NewCloudflareAccessTransport(nil, config, "https://pve.example.com/")
+	transport := NewCloudflareAccessTransport(nil, config, source.URL)
 
-	client := &http.Client{
-		Transport: transport,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	client := &http.Client{Transport: transport}
 
 	req, err := http.NewRequestWithContext(
 		context.Background(),
 		http.MethodGet,
-		redirectServer.URL+"/source",
+		source.URL+"/source",
 		nil,
 	)
 	if err != nil {
@@ -397,10 +411,31 @@ func TestCloudflareAccessTransport_Redirect_CrossHost(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if redirectHeaders != nil {
-		if got := redirectHeaders.Get("CF-Access-Client-Id"); got != "" {
-			t.Errorf("redirect request should not have CF-Access-Client-Id, got %q", got)
-		}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected redirect to be followed, got status %d", resp.StatusCode)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if sourceHeaders == nil {
+		t.Fatal("endpoint host was never requested")
+	}
+
+	if got := sourceHeaders.Get("CF-Access-Client-Id"); got != "test-client-id" {
+		t.Errorf("endpoint host request CF-Access-Client-Id = %q, want %q", got, "test-client-id")
+	}
+
+	if targetHeaders == nil {
+		t.Fatal("redirect target was never requested")
+	}
+
+	if got := targetHeaders.Get("CF-Access-Client-Id"); got != "" {
+		t.Errorf("redirect target should not receive CF-Access-Client-Id, got %q", got)
+	}
+
+	if got := targetHeaders.Get("CF-Access-Client-Secret"); got != "" {
+		t.Errorf("redirect target should not receive CF-Access-Client-Secret, got %q", got)
 	}
 }
 
@@ -473,4 +508,71 @@ type errorTransport struct {
 
 func (t *errorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return nil, t.err
+}
+
+func TestNewConnection_CloudflareAccessHeadersSent(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu  sync.Mutex
+		got http.Header
+	)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		got = r.Header.Clone()
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if _, err := w.Write([]byte(`{"data":{"version":"8.4.1","release":"8.4","repoid":"abc"}}`)); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	config := &CloudflareAccessConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+	}
+
+	conn, err := NewConnection(server.URL, true, "", config)
+	if err != nil {
+		t.Fatalf("NewConnection: %v", err)
+	}
+
+	creds, err := NewCredentials("", "", "", "user@pve!token=test", "", "")
+	if err != nil {
+		t.Fatalf("NewCredentials: %v", err)
+	}
+
+	client, err := NewClient(creds, conn)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	var resp map[string]any
+
+	if err := client.DoRequest(context.Background(), http.MethodGet, "version", nil, &resp); err != nil {
+		t.Fatalf("DoRequest: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if got == nil {
+		t.Fatal("server was never called")
+	}
+
+	if v := got.Get("CF-Access-Client-Id"); v != "test-client-id" {
+		t.Errorf("CF-Access-Client-Id = %q, want %q", v, "test-client-id")
+	}
+
+	if v := got.Get("CF-Access-Client-Secret"); v != "test-client-secret" {
+		t.Errorf("CF-Access-Client-Secret = %q, want %q", v, "test-client-secret")
+	}
+
+	if v := got.Get("Authorization"); v == "" {
+		t.Error("Authorization header missing")
+	}
 }

--- a/proxmox/cluster/ha/resources/resources_test.go
+++ b/proxmox/cluster/ha/resources/resources_test.go
@@ -31,7 +31,7 @@ func newTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 func newTestClient(t *testing.T, endpoint string) *Client {
 	t.Helper()
 
-	conn, err := api.NewConnection(endpoint, true, "")
+	conn, err := api.NewConnection(endpoint, true, "", nil)
 	require.NoError(t, err)
 
 	creds, err := api.NewCredentials("", "", "", "user@pve!token=test", "", "")

--- a/proxmox/nodes/containers/containers_test.go
+++ b/proxmox/nodes/containers/containers_test.go
@@ -65,7 +65,7 @@ func newTestServer(t *testing.T, handler http.Handler) *httptest.Server {
 func newTestClient(t *testing.T, endpoint string) *Client {
 	t.Helper()
 
-	conn, err := api.NewConnection(endpoint, true, "")
+	conn, err := api.NewConnection(endpoint, true, "", nil)
 	require.NoError(t, err)
 
 	creds, err := api.NewCredentials("", "", "", "user@pve!token=test", "", "")

--- a/proxmox/nodes/tasks/tasks_test.go
+++ b/proxmox/nodes/tasks/tasks_test.go
@@ -24,7 +24,7 @@ const testUPID = "UPID:pve:00001234:00005678:AABBCCDD:vzcreate:100:root@pam:"
 func newTestClient(t *testing.T, endpoint string) *Client {
 	t.Helper()
 
-	conn, err := api.NewConnection(endpoint, true, "")
+	conn, err := api.NewConnection(endpoint, true, "", nil)
 	require.NoError(t, err)
 
 	creds, err := api.NewCredentials("", "", "", "user@pve!token=test", "", "")

--- a/proxmox/storage/contract_test.go
+++ b/proxmox/storage/contract_test.go
@@ -786,7 +786,7 @@ func newStorageGetContractServer() *httptest.Server {
 func newStorageClientForTest(t *testing.T, endpoint string) *Client {
 	t.Helper()
 
-	conn, err := api.NewConnection(endpoint, true, "1.2")
+	conn, err := api.NewConnection(endpoint, true, "1.2", nil)
 	if err != nil {
 		t.Fatalf("NewConnection returned error: %v", err)
 	}

--- a/proxmoxtf/provider/provider.go
+++ b/proxmoxtf/provider/provider.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -99,7 +100,45 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (any, diag.D
 	creds, err = api.NewCredentials(username, password, otp, apiToken, authTicket, csrfPreventionToken)
 	diags = append(diags, diag.FromErr(err)...)
 
-	conn, err = api.NewConnection(endpoint, insecure, minTLS)
+	cfClientID := os.Getenv(envProviderCloudflareAccessClientID)
+	if cfClientID == "" {
+		cfClientID = os.Getenv(envProviderCloudflareAccessClientIDAlt)
+	}
+
+	cfClientSecret := os.Getenv(envProviderCloudflareAccessClientSecret)
+	if cfClientSecret == "" {
+		cfClientSecret = os.Getenv(envProviderCloudflareAccessClientSecretAlt)
+	}
+
+	if v, ok := d.GetOk(mkProviderCloudflareAccess); ok {
+		cfBlock := v.([]any)
+		if len(cfBlock) > 0 {
+			cf := cfBlock[0].(map[string]any)
+
+			if v, ok := cf[mkProviderCloudflareAccessClientID].(string); ok && v != "" {
+				cfClientID = v
+			}
+
+			if v, ok := cf[mkProviderCloudflareAccessClientSecret].(string); ok && v != "" {
+				cfClientSecret = v
+			}
+		}
+	}
+
+	var cfConfig *api.CloudflareAccessConfig
+
+	if cfClientID != "" || cfClientSecret != "" {
+		if cfClientID == "" || cfClientSecret == "" {
+			diags = append(diags, diag.Errorf("cloudflare_access requires both client_id and client_secret")...)
+		} else {
+			cfConfig = &api.CloudflareAccessConfig{
+				ClientID:     cfClientID,
+				ClientSecret: cfClientSecret,
+			}
+		}
+	}
+
+	conn, err = api.NewConnection(endpoint, insecure, minTLS, cfConfig)
 	diags = append(diags, diag.FromErr(err)...)
 
 	if diags.HasError() {

--- a/proxmoxtf/provider/provider.go
+++ b/proxmoxtf/provider/provider.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -100,43 +99,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (any, diag.D
 	creds, err = api.NewCredentials(username, password, otp, apiToken, authTicket, csrfPreventionToken)
 	diags = append(diags, diag.FromErr(err)...)
 
-	cfClientID := os.Getenv(envProviderCloudflareAccessClientID)
-	if cfClientID == "" {
-		cfClientID = os.Getenv(envProviderCloudflareAccessClientIDAlt)
-	}
-
-	cfClientSecret := os.Getenv(envProviderCloudflareAccessClientSecret)
-	if cfClientSecret == "" {
-		cfClientSecret = os.Getenv(envProviderCloudflareAccessClientSecretAlt)
-	}
-
-	if v, ok := d.GetOk(mkProviderCloudflareAccess); ok {
-		cfBlock := v.([]any)
-		if len(cfBlock) > 0 {
-			cf := cfBlock[0].(map[string]any)
-
-			if v, ok := cf[mkProviderCloudflareAccessClientID].(string); ok && v != "" {
-				cfClientID = v
-			}
-
-			if v, ok := cf[mkProviderCloudflareAccessClientSecret].(string); ok && v != "" {
-				cfClientSecret = v
-			}
-		}
-	}
-
-	var cfConfig *api.CloudflareAccessConfig
-
-	if cfClientID != "" || cfClientSecret != "" {
-		if cfClientID == "" || cfClientSecret == "" {
-			diags = append(diags, diag.Errorf("cloudflare_access requires both client_id and client_secret")...)
-		} else {
-			cfConfig = &api.CloudflareAccessConfig{
-				ClientID:     cfClientID,
-				ClientSecret: cfClientSecret,
-			}
-		}
-	}
+	cfConfig, cfDiags := cloudflareAccessConfig(d)
+	diags = append(diags, cfDiags...)
 
 	conn, err = api.NewConnection(endpoint, insecure, minTLS, cfConfig)
 	diags = append(diags, diag.FromErr(err)...)
@@ -295,6 +259,42 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (any, diag.D
 	}
 
 	return config, nil
+}
+
+// cloudflareAccessConfig resolves the Cloudflare Access service-token credentials from the provider block,
+// falling back to environment variables. It returns nil when neither value is set.
+func cloudflareAccessConfig(d *schema.ResourceData) (*api.CloudflareAccessConfig, diag.Diagnostics) {
+	clientID := utils.GetAnyStringEnv(envProviderCloudflareAccessClientID)
+	clientSecret := utils.GetAnyStringEnv(envProviderCloudflareAccessClientSecret)
+
+	if v, ok := d.GetOk(mkProviderCloudflareAccess); ok {
+		cfBlock := v.([]any)
+		// An empty block, or one whose attributes are all null, is read back as a nil element.
+		if len(cfBlock) > 0 {
+			if cf, ok := cfBlock[0].(map[string]any); ok {
+				if v, ok := cf[mkProviderCloudflareAccessClientID].(string); ok && v != "" {
+					clientID = v
+				}
+
+				if v, ok := cf[mkProviderCloudflareAccessClientSecret].(string); ok && v != "" {
+					clientSecret = v
+				}
+			}
+		}
+	}
+
+	if clientID == "" && clientSecret == "" {
+		return nil, nil
+	}
+
+	if clientID == "" || clientSecret == "" {
+		return nil, diag.Errorf("cloudflare_access requires both client_id and client_secret")
+	}
+
+	return &api.CloudflareAccessConfig{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+	}, nil
 }
 
 type apiResolver struct {

--- a/proxmoxtf/provider/provider_test.go
+++ b/proxmoxtf/provider/provider_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
 
+	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/test"
 )
 
@@ -56,4 +58,97 @@ func TestProviderSchema(t *testing.T) {
 
 	// do not limit number of nodes in the cluster
 	test.AssertListMaxItems(t, providerSSHSchema, mkProviderSSHNode, 0)
+
+	providerCloudflareAccessSchema := test.AssertNestedSchemaExistence(t, s, mkProviderCloudflareAccess)
+
+	test.AssertOptionalArguments(t, providerCloudflareAccessSchema, []string{
+		mkProviderCloudflareAccessClientID,
+		mkProviderCloudflareAccessClientSecret,
+	})
+}
+
+func TestCloudflareAccessConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		envID      string
+		envSecret  string
+		block      []any
+		wantConfig *api.CloudflareAccessConfig
+		wantErr    bool
+	}{
+		{
+			name: "block absent, no env",
+		},
+		{
+			name:  "empty block, no env",
+			block: []any{map[string]any{}},
+		},
+		{
+			name:       "both set in block",
+			block:      []any{map[string]any{"client_id": "block-id", "client_secret": "block-secret"}},
+			wantConfig: &api.CloudflareAccessConfig{ClientID: "block-id", ClientSecret: "block-secret"},
+		},
+		{
+			name:    "only client_id in block",
+			block:   []any{map[string]any{"client_id": "block-id"}},
+			wantErr: true,
+		},
+		{
+			name:      "only client_secret from env",
+			envSecret: "env-secret",
+			wantErr:   true,
+		},
+		{
+			name:       "client_id in block, secret from env",
+			envSecret:  "env-secret",
+			block:      []any{map[string]any{"client_id": "block-id"}},
+			wantConfig: &api.CloudflareAccessConfig{ClientID: "block-id", ClientSecret: "env-secret"},
+		},
+		{
+			name:       "both from env, block absent",
+			envID:      "env-id",
+			envSecret:  "env-secret",
+			wantConfig: &api.CloudflareAccessConfig{ClientID: "env-id", ClientSecret: "env-secret"},
+		},
+		{
+			name:       "both from env, empty block",
+			envID:      "env-id",
+			envSecret:  "env-secret",
+			block:      []any{map[string]any{}},
+			wantConfig: &api.CloudflareAccessConfig{ClientID: "env-id", ClientSecret: "env-secret"},
+		},
+		{
+			name:       "block overrides env",
+			envID:      "env-id",
+			envSecret:  "env-secret",
+			block:      []any{map[string]any{"client_id": "block-id", "client_secret": "block-secret"}},
+			wantConfig: &api.CloudflareAccessConfig{ClientID: "block-id", ClientSecret: "block-secret"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(envProviderCloudflareAccessClientID, tt.envID)
+			t.Setenv(envProviderCloudflareAccessClientSecret, tt.envSecret)
+
+			raw := map[string]any{}
+			if tt.block != nil {
+				raw[mkProviderCloudflareAccess] = tt.block
+			}
+
+			d := schema.TestResourceDataRaw(t, createSchema(), raw)
+
+			got, diags := cloudflareAccessConfig(d)
+
+			if tt.wantErr {
+				require.True(t, diags.HasError())
+				require.Nil(t, got)
+
+				return
+			}
+
+			require.False(t, diags.HasError(), diags)
+			require.Equal(t, tt.wantConfig, got)
+		})
+	}
 }

--- a/proxmoxtf/provider/schema.go
+++ b/proxmoxtf/provider/schema.go
@@ -43,6 +43,15 @@ const (
 	mkProviderSSHNodeName    = "name"
 	mkProviderSSHNodeAddress = "address"
 	mkProviderSSHNodePort    = "port"
+
+	mkProviderCloudflareAccess             = "cloudflare_access"
+	mkProviderCloudflareAccessClientID     = "client_id"
+	mkProviderCloudflareAccessClientSecret = "client_secret"
+
+	envProviderCloudflareAccessClientID        = "PROXMOX_VE_CF_ACCESS_CLIENT_ID"
+	envProviderCloudflareAccessClientSecret    = "PROXMOX_VE_CF_ACCESS_CLIENT_SECRET" //nolint:gosec
+	envProviderCloudflareAccessClientIDAlt     = "PM_VE_CF_ACCESS_CLIENT_ID"
+	envProviderCloudflareAccessClientSecretAlt = "PM_VE_CF_ACCESS_CLIENT_SECRET" //nolint:gosec
 )
 
 func createSchema() map[string]*schema.Schema {
@@ -292,6 +301,38 @@ func createSchema() map[string]*schema.Schema {
 			Optional:     true,
 			Description:  "The ending number for random VM / Container IDs.",
 			ValidateFunc: validation.IntBetween(100, 999999999),
+		},
+		mkProviderCloudflareAccess: {
+			Type:        schema.TypeList,
+			Optional:    true,
+			MaxItems:    1,
+			Description: "Cloudflare Access service-token authentication for the Proxmox VE API endpoint.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					mkProviderCloudflareAccessClientID: {
+						Type:         schema.TypeString,
+						Optional:     true,
+						Sensitive:    true,
+						Description:  "The Cloudflare Access service-token client ID.",
+						ValidateFunc: validation.StringIsNotEmpty,
+						DefaultFunc: schema.MultiEnvDefaultFunc(
+							[]string{envProviderCloudflareAccessClientID, envProviderCloudflareAccessClientIDAlt},
+							nil,
+						),
+					},
+					mkProviderCloudflareAccessClientSecret: {
+						Type:         schema.TypeString,
+						Optional:     true,
+						Sensitive:    true,
+						Description:  "The Cloudflare Access service-token client secret.",
+						ValidateFunc: validation.StringIsNotEmpty,
+						DefaultFunc: schema.MultiEnvDefaultFunc(
+							[]string{envProviderCloudflareAccessClientSecret, envProviderCloudflareAccessClientSecretAlt},
+							nil,
+						),
+					},
+				},
+			},
 		},
 	}
 }

--- a/proxmoxtf/provider/schema.go
+++ b/proxmoxtf/provider/schema.go
@@ -48,10 +48,8 @@ const (
 	mkProviderCloudflareAccessClientID     = "client_id"
 	mkProviderCloudflareAccessClientSecret = "client_secret"
 
-	envProviderCloudflareAccessClientID        = "PROXMOX_VE_CF_ACCESS_CLIENT_ID"
-	envProviderCloudflareAccessClientSecret    = "PROXMOX_VE_CF_ACCESS_CLIENT_SECRET" //nolint:gosec
-	envProviderCloudflareAccessClientIDAlt     = "PM_VE_CF_ACCESS_CLIENT_ID"
-	envProviderCloudflareAccessClientSecretAlt = "PM_VE_CF_ACCESS_CLIENT_SECRET" //nolint:gosec
+	envProviderCloudflareAccessClientID     = "PROXMOX_VE_CF_ACCESS_CLIENT_ID"
+	envProviderCloudflareAccessClientSecret = "PROXMOX_VE_CF_ACCESS_CLIENT_SECRET" //nolint:gosec
 )
 
 func createSchema() map[string]*schema.Schema {
@@ -310,26 +308,24 @@ func createSchema() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					mkProviderCloudflareAccessClientID: {
-						Type:         schema.TypeString,
-						Optional:     true,
-						Sensitive:    true,
-						Description:  "The Cloudflare Access service-token client ID.",
+						Type:      schema.TypeString,
+						Optional:  true,
+						Sensitive: true,
+						Description: "The Cloudflare Access service-token client ID. " +
+							"Must be set together with `client_secret`. " +
+							"Defaults to the value of the `PROXMOX_VE_CF_ACCESS_CLIENT_ID` environment variable.",
 						ValidateFunc: validation.StringIsNotEmpty,
-						DefaultFunc: schema.MultiEnvDefaultFunc(
-							[]string{envProviderCloudflareAccessClientID, envProviderCloudflareAccessClientIDAlt},
-							nil,
-						),
+						DefaultFunc:  schema.EnvDefaultFunc(envProviderCloudflareAccessClientID, nil),
 					},
 					mkProviderCloudflareAccessClientSecret: {
-						Type:         schema.TypeString,
-						Optional:     true,
-						Sensitive:    true,
-						Description:  "The Cloudflare Access service-token client secret.",
+						Type:      schema.TypeString,
+						Optional:  true,
+						Sensitive: true,
+						Description: "The Cloudflare Access service-token client secret. " +
+							"Must be set together with `client_id`. " +
+							"Defaults to the value of the `PROXMOX_VE_CF_ACCESS_CLIENT_SECRET` environment variable.",
 						ValidateFunc: validation.StringIsNotEmpty,
-						DefaultFunc: schema.MultiEnvDefaultFunc(
-							[]string{envProviderCloudflareAccessClientSecret, envProviderCloudflareAccessClientSecretAlt},
-							nil,
-						),
+						DefaultFunc:  schema.EnvDefaultFunc(envProviderCloudflareAccessClientSecret, nil),
 					},
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

Adds provider-level support for Cloudflare Access service-token authentication when the Proxmox VE API endpoint is protected by Cloudflare Access.

The provider can now be configured with:

```hcl
provider "proxmox" {
  endpoint  = var.virtual_environment_endpoint
  api_token = var.virtual_environment_api_token

  cloudflare_access {
    client_id     = var.cloudflare_access_client_id
    client_secret = var.cloudflare_access_client_secret
  }
}
```

The same values can also be supplied with `PROXMOX_VE_CF_ACCESS_CLIENT_ID` and `PROXMOX_VE_CF_ACCESS_CLIENT_SECRET`.

Internally, this adds a scoped HTTP transport wrapper that injects `CF-Access-Client-Id` and `CF-Access-Client-Secret` only for requests addressed to the configured Proxmox endpoint host. Existing request headers are preserved and the original request is not mutated.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

Unit tests:

```text
PATH=/home/srvadmin/.local/go1.26.0/bin:$PATH make test
```

Result: passed.

Lint:

```text
PATH=/home/srvadmin/.local/go1.26.0/bin:/home/srvadmin/go/bin:$PATH make lint
```

Result:

```text
0 issues.
```

Manual Terraform validation with a local development override provider binary and a Cloudflare Access-protected Proxmox endpoint:

```text
TF_CLI_CONFIG_FILE=/home/srvadmin/tf-test/dev.tfrc TF_DISABLE_CHECKPOINT=true terraform validate -no-color
```

Result: passed with the expected provider development override warning.

```text
TF_CLI_CONFIG_FILE=/home/srvadmin/tf-test/dev.tfrc TF_DISABLE_CHECKPOINT=true terraform plan -input=false -no-color
```

Result: passed. The read-only nodes data source completed successfully:

```text
data.proxmox_virtual_environment_nodes.nodes: Read complete after 6s [id=nodes]

Changes to Outputs:
  + node_names = [
      + "Masla",
    ]
```

No Terraform apply was run.

`make example` was not run because the bundled example workflow applies and destroys real resources and is not configured for this Cloudflare Access-protected test environment.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

Relates #3026

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->
* @bpg/maintainers

<!---
BEGIN_COMMIT_OVERRIDE
reverted(provider): add Cloudflare Access service token support (#3014)
END_COMMIT_OVERRIDE
--->