### PR TITLE
fix(vm): delete ipconfigN keys when an ip_config block is removed

### DIFF
--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -6119,6 +6119,35 @@ func vmAppendMissingDeviceDeletes(
 	return del
 }
 
+// vmRemovedIPConfigKeys returns the ipconfigN keys present on the VM that the planned
+// cloud-init configuration no longer covers. Cloud-init IP configuration is sent as a
+// numbered list, so dropping an ip_config block simply omits its key from the payload
+// instead of removing it from the VM; the keys have to be deleted explicitly.
+func vmRemovedIPConfigKeys(vmConfig *vms.GetResponseData, cloudInitConfig *vms.CustomCloudInitConfig) []string {
+	if vmConfig == nil {
+		return nil
+	}
+
+	planned := 0
+	if cloudInitConfig != nil {
+		planned = len(cloudInitConfig.IPConfig)
+	}
+
+	var removed []string
+
+	for key := range vmConfig.IPConfigs {
+		var index int
+
+		if _, err := fmt.Sscanf(key, "ipconfig%d", &index); err == nil && index >= planned {
+			removed = append(removed, key)
+		}
+	}
+
+	sort.Strings(removed)
+
+	return removed
+}
+
 func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	// reset the default timeout for the update operation
 	ctx = context.WithoutCancel(ctx)
@@ -6593,6 +6622,13 @@ func vmUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 		cloudInitConfig := vmGetCloudInitConfig(d)
 
 		updateBody.CloudInitConfig = cloudInitConfig
+
+		// The update payload only carries the ip_config blocks that are still present in
+		// the configuration, so removing one leaves its ipconfigN key on the VM: the plan
+		// keeps showing the same removal forever, and every apply power-cycles the guest
+		// for a change that is never made. Delete the leftover keys explicitly, the same
+		// way network devices are handled below.
+		del = append(del, vmRemovedIPConfigKeys(vmConfig, cloudInitConfig)...)
 
 		initialization := d.Get(mkInitialization).([]any)
 

--- a/proxmoxtf/resource/vm/vm_test.go
+++ b/proxmoxtf/resource/vm/vm_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/vms"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/disk"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/resource/vm/network"
 	"github.com/bpg/terraform-provider-proxmox/proxmoxtf/test"
@@ -613,6 +614,65 @@ func Test_parseImportIDWIthNodeName(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedNodeName, nodeName)
 			require.Equal(t, tt.expectedID, id)
+		})
+	}
+}
+
+// TestVMRemovedIPConfigKeys tests that ipconfigN keys no longer covered by the planned
+// cloud-init configuration are reported for deletion.
+func TestVMRemovedIPConfigKeys(t *testing.T) {
+	t.Parallel()
+
+	existing := func(keys ...string) *vms.GetResponseData {
+		data := &vms.GetResponseData{IPConfigs: vms.CustomCloudInitIPConfigMap{}}
+		for _, key := range keys {
+			data.IPConfigs[key] = &vms.CustomCloudInitIPConfig{}
+		}
+
+		return data
+	}
+
+	planned := func(count int) *vms.CustomCloudInitConfig {
+		return &vms.CustomCloudInitConfig{IPConfig: make([]vms.CustomCloudInitIPConfig, count)}
+	}
+
+	tests := []struct {
+		name            string
+		vmConfig        *vms.GetResponseData
+		cloudInitConfig *vms.CustomCloudInitConfig
+		expected        []string
+	}{
+		{
+			name:            "removed block is deleted",
+			vmConfig:        existing("ipconfig0", "ipconfig1"),
+			cloudInitConfig: planned(1),
+			expected:        []string{"ipconfig1"},
+		},
+		{
+			name:            "unchanged configuration deletes nothing",
+			vmConfig:        existing("ipconfig0", "ipconfig1"),
+			cloudInitConfig: planned(2),
+			expected:        nil,
+		},
+		{
+			name:            "all blocks removed",
+			vmConfig:        existing("ipconfig0", "ipconfig1", "ipconfig2"),
+			cloudInitConfig: nil,
+			expected:        []string{"ipconfig0", "ipconfig1", "ipconfig2"},
+		},
+		{
+			name:            "no VM configuration",
+			vmConfig:        nil,
+			cloudInitConfig: planned(1),
+			expected:        nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, vmRemovedIPConfigKeys(tt.vmConfig, tt.cloudInitConfig))
 		})
 	}
 }


### PR DESCRIPTION
## Contributor's Note

- [x] I have read the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) and my PR follows the guidelines
- [x] My commits follow the Conventional Commits specification and are signed off (DCO)
- [x] I have added tests covering the change

## Description

Fixes #3040.

Removing an `ip_config` block from `initialization` is planned as a removal and reported as applied, but the corresponding `ipconfigN` key is never deleted on the Proxmox side, so the plan never converges.

Because cloud-init changes are applied by stopping and starting the guest, this is not just cosmetic drift: **every apply power-cycles the VM for a change that is never made**. On our six-node cluster each run rebooted all six guests and left `qm config` exactly as before.

## Root cause

`vmGetCloudInitConfig` builds `CustomCloudInitConfig` from what is *present* in the configuration, and `CustomCloudInitConfig.IPConfig` is serialised as a numbered list (`ipconfig0`, `ipconfig1`, …). Dropping a block simply makes the list shorter, so the removed key is never mentioned in the update payload — and Proxmox only removes keys named in `delete`.

The same class of problem is handled correctly a few blocks below for network devices, which compare planned keys against the ones present on the VM and add the leftovers to `del`.

## The fix

`vmRemovedIPConfigKeys` returns the `ipconfigN` keys present on the VM that the planned cloud-init configuration no longer covers, and the update path adds them to the delete list. It also covers the case where `initialization` is removed entirely (`cloudInitConfig == nil`), where every `ipconfigN` should go.

## Tests

New unit test `TestVMRemovedIPConfigKeys` covers four cases: one block removed, nothing removed, everything removed, and a nil VM configuration. `go test ./proxmoxtf/...` passes.

## Reproduction (before the fix)

```
# two ip_config blocks applied, then the second one removed from the configuration
$ tofu apply
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

$ qm config <vmid> | grep ipconfig
ipconfig0: gw=10.0.0.254,ip=10.0.0.10/24
ipconfig1: ip=10.1.0.10/24        # still present

$ tofu plan
Plan: 0 to add, 1 to change, 0 to destroy.   # same diff, forever
```

Verified against Proxmox VE 8.4.12 with provider v0.111.1.
