### PR TITLE
feat(lxc): add purge and unreferenced-disk cleanup options on destroy

### DIFF
--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -335,6 +335,12 @@ The `mount_point.volume` attribute accepts three forms:
         seconds before the next container is shut down.
 - `start_on_boot` - (Optional) Automatically start container when the host
   system boots (defaults to `true`).
+- `purge_on_destroy` - (Optional) Whether to purge the container from backup,
+  replication and HA configurations on destroy (defaults to `true`). Proxmox
+  refuses to delete a container that is still referenced by an HA resource
+  unless this is set.
+- `delete_unreferenced_disks_on_destroy` - (Optional) Whether to delete
+  unreferenced disks on destroy (defaults to `true`)
 - `tags` - (Optional) A list of tags the container tags. This is only meta
   information (defaults to `[]`). Note: Proxmox always sorts the container tags and set them to lowercase.
   If tag contains capital letters, then Proxmox will always report a

--- a/docs/resources/virtual_environment_container.md
+++ b/docs/resources/virtual_environment_container.md
@@ -337,10 +337,13 @@ The `mount_point.volume` attribute accepts three forms:
   system boots (defaults to `true`).
 - `purge_on_destroy` - (Optional) Whether to purge the container from backup,
   replication and HA configurations on destroy (defaults to `true`). Proxmox
-  refuses to delete a container that is still referenced by an HA resource
-  unless this is set.
-- `delete_unreferenced_disks_on_destroy` - (Optional) Whether to delete
-  unreferenced disks on destroy (defaults to `true`)
+  refuses to delete a container that is still referenced by an HA resource or
+  a replication job unless this is set.
+- `delete_unreferenced_disks_on_destroy` - (Optional) Whether to also delete
+  disks on any enabled storage that carry the container ID but are not
+  referenced in its configuration (defaults to `false`). Unlike the VM
+  resource, this is opt-in for containers so that deliberately detached
+  volumes are not removed on destroy.
 - `tags` - (Optional) A list of tags the container tags. This is only meta
   information (defaults to `[]`). Note: Proxmox always sorts the container tags and set them to lowercase.
   If tag contains capital letters, then Proxmox will always report a

--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"math/rand"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/require"
 
+	haresources "github.com/bpg/terraform-provider-proxmox/proxmox/cluster/ha/resources"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/containers"
 	"github.com/bpg/terraform-provider-proxmox/proxmox/nodes/storage"
 	proxmoxtypes "github.com/bpg/terraform-provider-proxmox/proxmox/types"
@@ -3259,5 +3261,184 @@ func testAccDownloadContainerTemplate(t *testing.T, te *Environment, imageFileNa
 	t.Cleanup(func() {
 		e := te.NodeStorageClient().DeleteDatastoreFile(context.Background(), fmt.Sprintf("vztmpl/%s", imageFileName))
 		require.NoError(t, e)
+	})
+}
+
+func TestAccResourceContainerDestroyOptions(t *testing.T) {
+	te := InitEnvironment(t)
+	imageFileName := fmt.Sprintf("%d-alpine-3.22-default_20250617_amd64.tar.xz", time.Now().UnixMicro())
+	testAccDownloadContainerTemplate(t, te, imageFileName)
+
+	accTestContainerID := 100000 + rand.Intn(99999)
+
+	te.AddTemplateVars(map[string]interface{}{
+		"ImageFileName":   imageFileName,
+		"TestContainerID": accTestContainerID,
+	})
+
+	containerConfig := func(destroyOptions string) string {
+		return te.RenderConfig(fmt.Sprintf(`
+			resource "proxmox_virtual_environment_container" "test_container" {
+				node_name    = "{{.NodeName}}"
+				vm_id        = {{.TestContainerID}}
+				started      = false
+				unprivileged = true
+				%s
+				disk {
+					datastore_id = "local-lvm"
+					size         = 4
+				}
+				initialization {
+					hostname = "test-destroy-options"
+				}
+				operating_system {
+					template_file_id = "local:vztmpl/{{.ImageFileName}}"
+					type             = "alpine"
+				}
+			}`, destroyOptions))
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: containerConfig(""),
+				Check: ResourceAttributes(accTestContainerName, map[string]string{
+					"purge_on_destroy":                     "true",
+					"delete_unreferenced_disks_on_destroy": "false",
+				}),
+			},
+			{
+				ResourceName:  accTestContainerName,
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s/%d", te.NodeName, accTestContainerID),
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 imported state, got %d", len(states))
+					}
+
+					attrs := states[0].Attributes
+					if attrs["purge_on_destroy"] != "true" {
+						return fmt.Errorf("expected purge_on_destroy=true after import, got %q", attrs["purge_on_destroy"])
+					}
+
+					if attrs["delete_unreferenced_disks_on_destroy"] != "false" {
+						return fmt.Errorf(
+							"expected delete_unreferenced_disks_on_destroy=false after import, got %q",
+							attrs["delete_unreferenced_disks_on_destroy"],
+						)
+					}
+
+					return nil
+				},
+			},
+			{
+				Config: containerConfig(`
+				purge_on_destroy                     = false
+				delete_unreferenced_disks_on_destroy = true`),
+				Check: ResourceAttributes(accTestContainerName, map[string]string{
+					"purge_on_destroy":                     "false",
+					"delete_unreferenced_disks_on_destroy": "true",
+				}),
+			},
+			{
+				Config: containerConfig(`
+				purge_on_destroy                     = true
+				delete_unreferenced_disks_on_destroy = false`),
+				Check: ResourceAttributes(accTestContainerName, map[string]string{
+					"purge_on_destroy":                     "true",
+					"delete_unreferenced_disks_on_destroy": "false",
+				}),
+			},
+		},
+	})
+}
+
+func TestAccResourceContainerDestroyPurgesHAResource(t *testing.T) {
+	te := InitEnvironment(t)
+	imageFileName := fmt.Sprintf("%d-alpine-3.22-default_20250617_amd64.tar.xz", time.Now().UnixMicro())
+	testAccDownloadContainerTemplate(t, te, imageFileName)
+
+	accTestContainerID := 100000 + rand.Intn(99999)
+
+	haClient := te.ClusterClient().HA().Resources()
+	haResourceID := proxmoxtypes.HAResourceID{
+		Type: proxmoxtypes.HAResourceTypeContainer,
+		Name: strconv.Itoa(accTestContainerID),
+	}
+
+	t.Cleanup(func() {
+		// Only needed when destroy failed before PVE purged the HA entry.
+		_ = haClient.Delete(context.Background(), haResourceID)
+	})
+
+	te.AddTemplateVars(map[string]interface{}{
+		"ImageFileName":   imageFileName,
+		"TestContainerID": accTestContainerID,
+	})
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		CheckDestroy: func(*terraform.State) error {
+			exists, err := haClient.Exists(context.Background(), haResourceID)
+			if err != nil {
+				return fmt.Errorf("checking HA resource %s: %w", haResourceID.String(), err)
+			}
+
+			if exists {
+				return fmt.Errorf("HA resource %s still exists after destroy, purge was not applied", haResourceID.String())
+			}
+
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_container" "test_container" {
+					node_name    = "{{.NodeName}}"
+					vm_id        = {{.TestContainerID}}
+					started      = false
+					unprivileged = true
+					disk {
+						datastore_id = "local-lvm"
+						size         = 4
+					}
+					initialization {
+						hostname = "test-destroy-ha"
+					}
+					operating_system {
+						template_file_id = "local:vztmpl/{{.ImageFileName}}"
+						type             = "alpine"
+					}
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"purge_on_destroy": "true",
+					}),
+					func(*terraform.State) error {
+						err := haClient.Create(t.Context(), &haresources.HAResourceCreateRequestBody{
+							HAResourceDataBase: haresources.HAResourceDataBase{
+								State: proxmoxtypes.HAResourceStateDisabled,
+							},
+							ID: haResourceID,
+						})
+						if err != nil {
+							return fmt.Errorf("adding container to HA: %w", err)
+						}
+
+						exists, err := haClient.Exists(t.Context(), haResourceID)
+						if err != nil {
+							return fmt.Errorf("checking HA resource %s: %w", haResourceID.String(), err)
+						}
+
+						if !exists {
+							return fmt.Errorf("HA resource %s was not created", haResourceID.String())
+						}
+
+						return nil
+					},
+				),
+			},
+		},
 	})
 }

--- a/proxmox/nodes/containers/containers.go
+++ b/proxmox/nodes/containers/containers.go
@@ -82,7 +82,11 @@ func (c *Client) CreateContainerAsync(ctx context.Context, d *CreateRequestBody)
 }
 
 // DeleteContainer deletes a container.
-func (c *Client) DeleteContainer(ctx context.Context) tasks.TaskResult {
+func (c *Client) DeleteContainer(
+	ctx context.Context,
+	purge bool,
+	destroyUnreferencedDisks bool,
+) tasks.TaskResult {
 	op := retry.NewTaskOperation("container delete",
 		retry.WithRetryIf(func(err error) bool {
 			return retry.IsTransientAPIError(err) && !errors.Is(err, api.ErrResourceDoesNotExist)
@@ -90,15 +94,36 @@ func (c *Client) DeleteContainer(ctx context.Context) tasks.TaskResult {
 	)
 
 	return c.Tasks().DoTask(ctx, op,
-		func() (*string, error) { return c.DeleteContainerAsync(ctx) },
+		func() (*string, error) { return c.DeleteContainerAsync(ctx, purge, destroyUnreferencedDisks) },
 	)
 }
 
 // DeleteContainerAsync deletes a container asynchronously.
-func (c *Client) DeleteContainerAsync(ctx context.Context) (*string, error) {
+func (c *Client) DeleteContainerAsync(
+	ctx context.Context,
+	purge bool,
+	destroyUnreferencedDisks bool,
+) (*string, error) {
+	purgeValue := 0
+	if purge {
+		purgeValue = 1
+	}
+
+	destroyUnreferencedDisksValue := 0
+	if destroyUnreferencedDisks {
+		destroyUnreferencedDisksValue = 1
+	}
+
 	resBody := &DeleteResponseBody{}
 
-	err := c.DoRequest(ctx, http.MethodDelete, c.ExpandPath(""), nil, resBody)
+	// Appended to the expanded path rather than passed through ExpandPath:
+	// that helper joins with a "/", which would yield ".../100/?purge=1".
+	path := fmt.Sprintf(
+		"%s?destroy-unreferenced-disks=%d&purge=%d",
+		c.ExpandPath(""), destroyUnreferencedDisksValue, purgeValue,
+	)
+
+	err := c.DoRequest(ctx, http.MethodDelete, path, nil, resBody)
 	if err != nil {
 		return nil, fmt.Errorf("error deleting container: %w", err)
 	}

--- a/proxmox/nodes/containers/containers_test.go
+++ b/proxmox/nodes/containers/containers_test.go
@@ -206,7 +206,7 @@ func TestDeleteContainerWaitsForTask(t *testing.T) {
 
 	client := newTestClient(t, server.URL)
 
-	result := client.DeleteContainer(t.Context())
+	result := client.DeleteContainer(t.Context(), true, true)
 	require.NoError(t, result.Err())
 }
 

--- a/proxmox/nodes/containers/containers_test.go
+++ b/proxmox/nodes/containers/containers_test.go
@@ -210,6 +210,56 @@ func TestDeleteContainerWaitsForTask(t *testing.T) {
 	require.NoError(t, result.Err())
 }
 
+func TestDeleteContainerSendsDestroyParams(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                     string
+		purge                    bool
+		destroyUnreferencedDisks bool
+		wantQuery                string
+	}{
+		{"both enabled", true, true, "destroy-unreferenced-disks=1&purge=1"},
+		{"both disabled", false, false, "destroy-unreferenced-disks=0&purge=0"},
+		{"purge only", true, false, "destroy-unreferenced-disks=0&purge=1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				mu       sync.Mutex
+				gotQuery string
+			)
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("DELETE /api2/json/lxc/100", func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				gotQuery = r.URL.RawQuery
+				mu.Unlock()
+
+				w.Header().Set("Content-Type", "application/json")
+				writeJSON(w, map[string]any{"data": testUPID})
+			})
+			mux.HandleFunc("GET /api2/json/nodes/", taskCompletedHandler(&requestCaptures{}))
+
+			server := newTestServer(t, mux)
+			defer server.Close()
+
+			client := newTestClient(t, server.URL)
+
+			result := client.DeleteContainer(t.Context(), tt.purge, tt.destroyUnreferencedDisks)
+			require.NoError(t, result.Err())
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			assert.Equal(t, tt.wantQuery, gotQuery)
+		})
+	}
+}
+
 func TestResizeContainerDiskWaitsForTask(t *testing.T) {
 	t.Parallel()
 

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -96,6 +96,8 @@ const (
 	dvStartupUpDelay                    = -1
 	dvStartupDownDelay                  = -1
 	dvStartOnBoot                       = true
+	dvPurgeOnDestroy                    = true
+	dvDeleteUnreferencedDisksOnDestroy  = true
 	dvTemplate                          = false
 	dvTimeoutCreate                     = 1800
 	dvTimeoutClone                      = 1800
@@ -203,6 +205,8 @@ const (
 	mkStartupUpDelay                    = "up_delay"
 	mkStartupDownDelay                  = "down_delay"
 	mkStartOnBoot                       = "start_on_boot"
+	mkPurgeOnDestroy                    = "purge_on_destroy"
+	mkDeleteUnreferencedDisksOnDestroy  = "delete_unreferenced_disks_on_destroy"
 	mkTags                              = "tags"
 	mkTemplate                          = "template"
 	mkTimeoutCreate                     = "timeout_create"
@@ -1075,6 +1079,20 @@ func Container() *schema.Resource {
 				Optional:    true,
 				ForceNew:    false,
 				Default:     dvStartOnBoot,
+			},
+			mkPurgeOnDestroy: {
+				Type:        schema.TypeBool,
+				Description: "Whether to purge the container from backup/replication/HA configurations on destroy",
+				Optional:    true,
+				ForceNew:    false,
+				Default:     dvPurgeOnDestroy,
+			},
+			mkDeleteUnreferencedDisksOnDestroy: {
+				Type:        schema.TypeBool,
+				Description: "Whether to delete unreferenced disks on destroy",
+				Optional:    true,
+				ForceNew:    false,
+				Default:     dvDeleteUnreferencedDisksOnDestroy,
 			},
 			mkTags: {
 				Type:        schema.TypeList,
@@ -4233,7 +4251,10 @@ func containerDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 		}
 	}
 
-	deleteResult := containerAPI.DeleteContainer(ctx)
+	purge := d.Get(mkPurgeOnDestroy).(bool)
+	deleteUnreferencedDisks := d.Get(mkDeleteUnreferencedDisksOnDestroy).(bool)
+
+	deleteResult := containerAPI.DeleteContainer(ctx, purge, deleteUnreferencedDisks)
 	if errors.Is(deleteResult.Err(), api.ErrResourceDoesNotExist) {
 		d.SetId("")
 

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -97,7 +97,7 @@ const (
 	dvStartupDownDelay                  = -1
 	dvStartOnBoot                       = true
 	dvPurgeOnDestroy                    = true
-	dvDeleteUnreferencedDisksOnDestroy  = true
+	dvDeleteUnreferencedDisksOnDestroy  = false
 	dvTemplate                          = false
 	dvTimeoutCreate                     = 1800
 	dvTimeoutClone                      = 1800
@@ -1082,14 +1082,14 @@ func Container() *schema.Resource {
 			},
 			mkPurgeOnDestroy: {
 				Type:        schema.TypeBool,
-				Description: "Whether to purge the container from backup/replication/HA configurations on destroy",
+				Description: "Whether to purge the container from backup, replication and HA configurations on destroy",
 				Optional:    true,
 				ForceNew:    false,
 				Default:     dvPurgeOnDestroy,
 			},
 			mkDeleteUnreferencedDisksOnDestroy: {
 				Type:        schema.TypeBool,
-				Description: "Whether to delete unreferenced disks on destroy",
+				Description: "Whether to also delete disks that carry the container ID but are not referenced in its configuration on destroy",
 				Optional:    true,
 				ForceNew:    false,
 				Default:     dvDeleteUnreferencedDisksOnDestroy,
@@ -3533,6 +3533,10 @@ func containerRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diag
 	e = d.Set(mkStarted, started)
 	diags = append(diags, diag.FromErr(e)...)
 
+	// Backfill provider-only flags so pre-existing or imported state reads the default on destroy, not the zero value
+	diags = setDefaultIfNotExists(d, diags, mkPurgeOnDestroy, dvPurgeOnDestroy)
+	diags = setDefaultIfNotExists(d, diags, mkDeleteUnreferencedDisksOnDestroy, dvDeleteUnreferencedDisksOnDestroy)
+
 	return diags
 }
 
@@ -4311,6 +4315,17 @@ func parseImportIDWithNodeName(id string) (string, string, error) {
 	}
 
 	return nodeName, id, nil
+}
+
+func setDefaultIfNotExists(d *schema.ResourceData, diags diag.Diagnostics, key string, value any) diag.Diagnostics {
+	//nolint:staticcheck
+	if _, ok := d.GetOkExists(key); !ok {
+		if err := d.Set(key, value); err != nil {
+			return append(diags, diag.FromErr(err)...)
+		}
+	}
+
+	return diags
 }
 
 func skipDnsDiffIfEmpty(k, oldValue, newValue string, d *schema.ResourceData) bool {


### PR DESCRIPTION
### What does this PR do?

Adds `purge_on_destroy` and `delete_unreferenced_disks_on_destroy` to `proxmox_virtual_environment_container`, mirroring the VM resource, and sends them as `purge` / `destroy-unreferenced-disks` on the container DELETE.

Without `purge`, Proxmox refuses to destroy a container that is still referenced by an HA resource or a replication job:

```
unable to remove CT 116 - used in HA resources and purge parameter not set
```

Because the provider stops the container before issuing the DELETE, the failed destroy leaves it stopped. This also deadlocks when the container and its HA policy are managed by different modules.

**Defaults:** `purge_on_destroy = true` (config-only cleanup, fixes the refusal) and `delete_unreferenced_disks_on_destroy = false`. The VM client has always sent both flags, so the VM defaults changed nothing on the wire; containers never sent either, so unreferenced-disk deletion is opt-in here to avoid removing deliberately detached volumes. The docs explain the difference.

The two flags are backfilled into state on read (as the VM resource does), so containers created before this change, or imported, destroy with the defaults instead of the zero value `false`, and do not show a spurious plan diff after upgrading.

The query string is appended to the expanded path rather than passed through `ExpandPath`, which joins with a `/` and would produce `.../100/?purge=1`. The VM code has that quirk and PVE tolerates it; it is left alone here.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests.
- [x] I have considered backward compatibility. `purge_on_destroy` defaults to `true`, so destroying a container now also removes it from backup jobs, replication jobs and HA configuration. Unreferenced-disk deletion stays off by default.
- [ ] For new resources: N/A.
- [ ] `make example`: not run.

### Proof of Work

Unit tests for the query-string mapping:

```
=== RUN   TestDeleteContainerSendsDestroyParams
    --- PASS: TestDeleteContainerSendsDestroyParams/both_disabled (0.01s)
    --- PASS: TestDeleteContainerSendsDestroyParams/both_enabled (0.01s)
    --- PASS: TestDeleteContainerSendsDestroyParams/purge_only (0.01s)
--- PASS: TestDeleteContainerSendsDestroyParams (0.00s)
```

Acceptance tests (defaults, explicit values, update round-trip, import backfill, and destroy of an HA-managed container):

```
--- PASS: TestAccResourceContainerDestroyPurgesHAResource (6.02s)
--- PASS: TestAccResourceContainerDestroyOptions (8.70s)
ok      github.com/bpg/terraform-provider-proxmox/fwprovider/test       10.344s
```

Without the read-side backfill, the import step fails, so the test is a real behavioural check:

```
testing_new_import_state.go:295: expected purge_on_destroy=true after import, got ""
--- FAIL: TestAccResourceContainerDestroyOptions (4.94s)
```

mitmproxy capture of the HA test (PVE 9.2): the container is added to HA out of band, the DELETE carries the defaults, and the HA entry is gone afterwards.

```
POST   /api2/json/cluster/ha/resources/                                          << 200 OK
GET    /api2/json/cluster/ha/resources/ct:139087                                 << 200 OK
DELETE /api2/json/nodes/pve/lxc/139087?destroy-unreferenced-disks=0&purge=1      << 200 OK
GET    /api2/json/cluster/ha/resources/ct:139087                                 << 500 no such resource 'ct:139087'
```

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #2842
