### PR TITLE
fix(docs): clarify QEMU agent inheritance on cloned VMs

### DIFF
--- a/docs/guides/clone-vm.md
+++ b/docs/guides/clone-vm.md
@@ -89,6 +89,8 @@ resource "proxmox_virtual_environment_vm" "ubuntu_clone" {
     # The working agent is *required* to retrieve the VM IP addresses.
     # If you are using a different cloud-init configuration, or a different clone source
     # that does not have the qemu-guest-agent installed, you may need to disable the `agent` below and remove the `vm_ipv4_address` output.
+    # Clones inherit the agent setting from the template's Proxmox config: omitting this block does NOT
+    # disable the wait for the agent — set `enabled = false` explicitly to override the template.
     # See https://bpg.sh/docs/resources/virtual_environment_vm#qemu-guest-agent for more details.
     enabled = true
   }

--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -690,7 +690,12 @@ install and *start* it using cloud-init, e.g. using custom `user_data_file_id`
 file.
 
 This provider requires `agent.enabled = true` to populate `ipv4_addresses`,
-`ipv6_addresses` and `network_interface_names` output attributes.
+`ipv6_addresses` and `network_interface_names` output attributes. Note that the
+provider honors the agent flag from the VM's *actual* Proxmox configuration,
+not only from the Terraform configuration: a cloned VM inherits the `agent`
+setting from the template, so omitting the `agent` block on the clone does not
+disable the agent wait (up to 15 minutes by default). Set
+`agent { enabled = false }` explicitly on the clone to override the template.
 
 Setting `agent.enabled = true` without running `qemu-guest-agent` in the VM will
 also result in long timeouts when using the provider, both when creating VMs,

--- a/examples/guides/clone-vm/clone.tf
+++ b/examples/guides/clone-vm/clone.tf
@@ -11,6 +11,8 @@ resource "proxmox_virtual_environment_vm" "ubuntu_clone" {
     # The working agent is *required* to retrieve the VM IP addresses.
     # If you are using a different cloud-init configuration, or a different clone source
     # that does not have the qemu-guest-agent installed, you may need to disable the `agent` below and remove the `vm_ipv4_address` output.
+    # Clones inherit the agent setting from the template's Proxmox config: omitting this block does NOT
+    # disable the wait for the agent — set `enabled = false` explicitly to override the template.
     # See https://bpg.sh/docs/resources/virtual_environment_vm#qemu-guest-agent for more details.
     enabled = true
   }


### PR DESCRIPTION
## Summary

Fixes #3047.

A cloned VM inherits the QEMU agent setting from the template's Proxmox config, and the provider's wait-for-network-interfaces logic keys off the VM's **actual** config read from the API (`vmConfig.Agent.Enabled` in `proxmoxtf/resource/vm/network/network.go`), not the Terraform configuration. So omitting the `agent` block on a clone resource does **not** opt out of the agent wait — it still applies in full (15m by default, `dvAgentTimeout` in `vm.go`) and times out on images without `qemu-guest-agent` running (most recently seen in discussion #3045).

## Changes

- `examples/guides/clone-vm/clone.tf` — extend the NOTE on the clone's `agent` block: inheritance means omitting the block does not disable the wait; `enabled = false` explicitly overrides the template.
- `docs/resources/virtual_environment_vm.md` — "Qemu guest agent" section: document that the provider honors the agent flag from the VM's actual Proxmox config, that clones inherit it, and the explicit opt-out.
- `docs/guides/clone-vm.md` — regenerated via `make docs` (unrelated generator whitespace churn in 6 other files reverted to keep the diff scoped).

## Validation

- [x] Mechanism verified against source: `network.go:203` gates the wait on `vmConfig.Agent.Enabled` from the API; `vm.go:52` `dvAgentTimeout = "15m"`.
- [x] `make docs` runs clean; guide diff matches the example change exactly.
- [x] No functional code changes — documentation only.