### PR TITLE
fix(access): normalize absent default to false on openid realm read

### DIFF
--- a/fwprovider/access/model_realm_openid.go
+++ b/fwprovider/access/model_realm_openid.go
@@ -215,4 +215,9 @@ func (m *realmOpenIDModel) fromAPIResponse(data *access.RealmGetResponseData, di
 	m.GroupsOverwrite = types.BoolPointerValue(data.GroupsOverwrite.PointerBool())
 	m.QueryUserinfo = types.BoolPointerValue(data.QueryUserinfo.PointerBool())
 	m.Default = types.BoolPointerValue(data.Default.PointerBool())
+
+	// PVE drops `default` from every other realm when one becomes the default; absent means false.
+	if m.Default.IsNull() {
+		m.Default = types.BoolValue(false)
+	}
 }

--- a/fwprovider/access/resource_realm_openid_test.go
+++ b/fwprovider/access/resource_realm_openid_test.go
@@ -378,3 +378,94 @@ func TestAccRealmOpenID(t *testing.T) {
 		},
 	})
 }
+
+func TestAccRealmOpenIDDefaultExclusive(t *testing.T) {
+	te := test.InitEnvironment(t)
+	primary := test.SafeResourceName("oidc-pri")
+	secondary := test.SafeResourceName("oidc-sec")
+	te.AddTemplateVars(map[string]interface{}{
+		"Primary":   primary,
+		"Secondary": secondary,
+	})
+
+	// default=1 on any realm strips the key from every other realm, so this must not run
+	// concurrently with other realm tests.
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_realm_openid" "secondary" {
+						realm      = "{{.Secondary}}"
+						issuer_url = "https://accounts.google.com"
+						client_id  = "test-client-id"
+						default    = false
+					}
+
+					resource "proxmox_realm_openid" "primary" {
+						realm      = "{{.Primary}}"
+						issuer_url = "https://accounts.google.com"
+						client_id  = "test-client-id"
+						comment    = "before"
+						default    = false
+
+						depends_on = [proxmox_realm_openid.secondary]
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("proxmox_realm_openid.primary", "default", "false"),
+					resource.TestCheckResourceAttr("proxmox_realm_openid.secondary", "default", "false"),
+					testCheckOpenIDRealmDefaultKey(te, primary, true),
+				),
+			},
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_realm_openid" "secondary" {
+						realm      = "{{.Secondary}}"
+						issuer_url = "https://accounts.google.com"
+						client_id  = "test-client-id"
+						default    = true
+					}
+
+					resource "proxmox_realm_openid" "primary" {
+						realm      = "{{.Primary}}"
+						issuer_url = "https://accounts.google.com"
+						client_id  = "test-client-id"
+						comment    = "after"
+						default    = false
+
+						depends_on = [proxmox_realm_openid.secondary]
+					}`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("proxmox_realm_openid.primary", "default", "false"),
+					resource.TestCheckResourceAttr("proxmox_realm_openid.secondary", "default", "true"),
+					testCheckOpenIDRealmDefaultKey(te, primary, false),
+					testCheckOpenIDRealmDefaultKey(te, secondary, true),
+				),
+			},
+			{
+				ResourceName:            "proxmox_realm_openid.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"client_key"},
+			},
+		},
+	})
+}
+
+// testCheckOpenIDRealmDefaultKey verifies, via a direct API read, whether PVE returns the
+// `default` key for the realm at all. PVE drops it from every other realm once one realm
+// is made the default, so "absent" proves the strip happened rather than a false-green.
+func testCheckOpenIDRealmDefaultKey(te *test.Environment, realm string, want bool) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		data, err := te.AccessClient().GetRealm(context.Background(), realm)
+		if err != nil {
+			return fmt.Errorf("reading OpenID realm %q: %w", realm, err)
+		}
+
+		if has := data.Default != nil; has != want {
+			return fmt.Errorf("realm %q: default key present=%t, want %t", realm, has, want)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION

### What does this PR do?

<!--- Clearly state the problem and how this PR solves it. -->

`proxmox_realm_openid` fails with `Provider produced inconsistent result after apply: .default: was cty.False, but now null` when `default = false` is set and another realm becomes the default in the same run (#3053). PVE removes the `default` key from every other realm whenever one realm is written with `default=1` (`PVE/API2/Domains.pm`), so a realm that was created with `default 0` can read back with no `default` key at all. The OpenID model mapped that absent key to `null` instead of `false`, which Terraform rejects against the planned `false`. The error is timing-dependent inside a `for_each` apply, which is why it looks intermittent and converges on a second apply.

This PR normalizes an absent `default` to `false` in the OpenID realm's Read, mirroring what `proxmox_realm_ldap` already does. It adds an acceptance test that reproduces the strip deterministically: two realms, the second flipped to `default = true` while the first receives an unrelated update, so the first realm's post-update read happens after PVE has dropped its key.

### Usage Example

Two OpenID realms in one configuration, one of them the default. This now applies cleanly on the first run:

```hcl
resource "proxmox_realm_openid" "primary" {
  realm      = "corp-sso"
  issuer_url = "https://sso.example.com"
  client_id  = "proxmox"
  default    = true
}

resource "proxmox_realm_openid" "fallback" {
  realm      = "corp-sso-fallback"
  issuer_url = "https://fallback.example.com"
  client_id  = "proxmox"
  default    = false
}
```

### Contributor's Note

<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work

<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

**New test without the fix (RED)** reproduces the exact error from the issue:

```text
$ ./testacc TestAccRealmOpenIDDefaultExclusive
=== RUN   TestAccRealmOpenIDDefaultExclusive
    resource_realm_openid_test.go:393: Step 2/3 error: Error running apply: exit status 1
        Error: Provider produced inconsistent result after apply
        When applying changes to proxmox_realm_openid.primary, provider
        "provider[\"registry.terraform.io/hashicorp/proxmox\"]" produced an
        unexpected new value: .default: was cty.False, but now null.
--- FAIL: TestAccRealmOpenIDDefaultExclusive (1.53s)
FAIL
```

**With the fix (GREEN)** and the whole realm suite for regressions:

```text
$ ./testacc "TestAccRealm.*"
--- PASS: TestAccRealmOpenIDDefaultExclusive (2.04s)
--- PASS: TestAccRealmOpenIDUsernameClaim (1.19s)
--- PASS: TestAccRealmSync (1.91s)
--- PASS: TestAccRealmLDAP (2.36s)
--- PASS: TestAccRealmOpenIDWriteOnly (0.00s)
    --- PASS: TestAccRealmOpenIDWriteOnly/client_key_wo_keeps_the_secret_out_of_state
    --- PASS: TestAccRealmOpenIDWriteOnly/client_key_wo_version_triggers_rotation
    --- PASS: TestAccRealmOpenIDWriteOnly/removing_client_key_wo_deletes_the_key_from_PVE
    --- PASS: TestAccRealmOpenIDWriteOnly/migrating_from_client_key_to_client_key_wo_clears_it_from_state
    --- PASS: TestAccRealmOpenIDWriteOnly/client_key_wo_version_requires_client_key_wo
    --- PASS: TestAccRealmOpenIDWriteOnly/client_key_and_client_key_wo_are_mutually_exclusive
--- PASS: TestAccRealmOpenID (4.44s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/access	6.958s
```

`make lint`: 0 issues. `make test`: pass. `make build`: ok. No schema change, so `make docs` is not needed.

**mitmproxy capture** of the new test (PVE 9.2.11) shows the strip on the wire. The primary realm is created with `default=0` and echoes it back; after the secondary realm's `PUT` with `default=1`, the primary's own `PUT` carries only the comment and the `GET` immediately after has no `default` key. The provider now maps that to `false`, so the apply succeeds.

```text
POST /api2/json/access/domains
    realm: oidc-pri-deyiaakr  type: openid  default: '0'  comment: before  ...
 << 200 OK

GET /api2/json/access/domains/oidc-pri-deyiaakr
 << 200 OK
    { "data": { "default": 0, "comment": "before", "autocreate": 0, ... } }

PUT /api2/json/access/domains/oidc-sec-yocyrwvc
    default: '1'  autocreate: '0'  groups-autocreate: '0'  groups-overwrite: '0'  query-userinfo: '0'
 << 200 OK

PUT /api2/json/access/domains/oidc-pri-deyiaakr
    comment: after  autocreate: '0'  groups-autocreate: '0'  groups-overwrite: '0'  query-userinfo: '0'
 << 200 OK

GET /api2/json/access/domains/oidc-pri-deyiaakr
 << 200 OK
    { "data": { "comment": "after", "autocreate": 0, "groups-autocreate": 0,
                "groups-overwrite": 0, "query-userinfo": 0, ... } }   <-- no "default" key
```

The same behaviour was confirmed independently with `pvesh` on the host: create A with `--default 0` (A echoes `default: 0`), create B with `--default 1`, and A's `default` key is gone. `pvesh set A --default 0` brings it back, which is why the reporter's second apply converges.

<!--- Please keep this note for the community --->

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #3053

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->

---

🤖 _This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Fable 5.1). All changes have been reviewed and verified by a human._
