### PR TITLE
fix(core): plan tags as unknown instead of null when a tag is unknown

### DIFF
--- a/fwprovider/test/resource_vm_tags_test.go
+++ b/fwprovider/test/resource_vm_tags_test.go
@@ -1,0 +1,127 @@
+//go:build acceptance || all
+
+//testacc:tier=heavy
+//testacc:resource=vm
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccResourceVMTagsUnknownAtPlan(t *testing.T) {
+	t.Parallel()
+
+	te := InitEnvironment(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+				resource "terraform_data" "tag" {
+					input = "unknown-at-plan"
+				}
+
+				resource "proxmox_virtual_environment_vm" "test_tags" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-tags-unknown"
+					tags      = ["known-tag", terraform_data.tag.output]
+				}`),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectUnknownValue("proxmox_virtual_environment_vm.test_tags", tfjsonpath.New("tags")),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_tags", map[string]string{
+						"tags.#": "2",
+					}),
+					resource.TestCheckTypeSetElemAttr("proxmox_virtual_environment_vm.test_tags", "tags.*", "known-tag"),
+					resource.TestCheckTypeSetElemAttr("proxmox_virtual_environment_vm.test_tags", "tags.*", "unknown-at-plan"),
+					checkVMTagsOnPVE(te, "proxmox_virtual_environment_vm.test_tags", "known-tag;unknown-at-plan"),
+				),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "terraform_data" "tag" {
+					input = "unknown-on-update"
+				}
+
+				resource "proxmox_virtual_environment_vm" "test_tags" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-tags-unknown"
+					tags      = ["known-tag", terraform_data.tag.output]
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes("proxmox_virtual_environment_vm.test_tags", map[string]string{
+						"tags.#": "2",
+					}),
+					resource.TestCheckTypeSetElemAttr("proxmox_virtual_environment_vm.test_tags", "tags.*", "known-tag"),
+					resource.TestCheckTypeSetElemAttr("proxmox_virtual_environment_vm.test_tags", "tags.*", "unknown-on-update"),
+					checkVMTagsOnPVE(te, "proxmox_virtual_environment_vm.test_tags", "known-tag;unknown-on-update"),
+				),
+			},
+			{
+				Config: te.RenderConfig(`
+				resource "terraform_data" "tag" {
+					input = "unknown-on-update"
+				}
+
+				resource "proxmox_virtual_environment_vm" "test_tags" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					name      = "test-tags-unknown"
+					tags      = ["unknown-on-update", "known-tag"]
+				}`),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func checkVMTagsOnPVE(te *Environment, resourceName string, want string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %q not found in state", resourceName)
+		}
+
+		vmID, err := strconv.Atoi(rs.Primary.Attributes["vm_id"])
+		if err != nil {
+			return fmt.Errorf("failed to parse vm_id: %w", err)
+		}
+
+		vmConfig, err := te.NodeClient().VM(vmID).GetVM(context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to get VM config: %w", err)
+		}
+
+		got := ""
+		if vmConfig.Tags != nil {
+			got = *vmConfig.Tags
+		}
+
+		if got != want {
+			return fmt.Errorf("unexpected tags on PVE: got %q, want %q", got, want)
+		}
+
+		return nil
+	}
+}

--- a/proxmoxtf/structure/schema.go
+++ b/proxmoxtf/structure/schema.go
@@ -10,8 +10,10 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/bpg/terraform-provider-proxmox/utils"
@@ -98,6 +100,12 @@ func SuppressIfListsAreEqualIgnoringOrder(key, _, _ string, d *schema.ResourceDa
 		key = key[:lastDotIndex]
 	}
 
+	// An unknown element makes the SDK read the whole list as empty, which would compare equal to an empty
+	// prior state and plan null instead of "known after apply".
+	if isRawConfigUnknown(d, key) {
+		return false
+	}
+
 	oldData, newData := d.GetChange(key)
 	if oldData == nil || newData == nil {
 		return false
@@ -125,6 +133,27 @@ func SuppressIfListsAreEqualIgnoringOrder(key, _, _ string, d *schema.ResourceDa
 	sort.Strings(newEvents)
 
 	return reflect.DeepEqual(oldEvents, newEvents)
+}
+
+// isRawConfigUnknown reports whether the value at the flatmap key (e.g. "disk.0.mount_options") is not wholly
+// known in the raw config. Returns false when the raw config is unavailable (refresh) or the path does not resolve.
+func isRawConfigUnknown(d *schema.ResourceData, key string) bool {
+	var path cty.Path
+
+	for part := range strings.SplitSeq(key, ".") {
+		if idx, err := strconv.Atoi(part); err == nil {
+			path = path.IndexInt(idx)
+		} else {
+			path = path.GetAttr(part)
+		}
+	}
+
+	val, diags := d.GetRawConfigAt(path)
+	if diags.HasError() {
+		return false
+	}
+
+	return !val.IsWhollyKnown()
 }
 
 // SuppressIfListsOfMapsAreEqualIgnoringOrderByKey is a customdiff.SuppressionFunc that suppresses


### PR DESCRIPTION
### What does this PR do?
<!--- Clearly state the problem and how this PR solves it. -->

Fixes #2999. Creating a `proxmox_virtual_environment_vm` whose `tags` list contains a value that is unknown at plan time (for example an ID from a resource created in the same apply) failed with `Provider produced inconsistent final plan … invalid new value for .tags: was null, but now cty.ListVal(...)`. A second apply succeeded because the value was known by then.

Root cause: SDK v2 reports a `TypeList` with any unknown element as an empty computed list inside `DiffSuppressFunc`, so `structure.SuppressIfListsAreEqualIgnoringOrder` compared `[]` against the empty prior state on create, suppressed the only diff entry, and the plan recorded `tags = null`. The apply-time re-plan then produced the real list, which Terraform rejects.

The helper now resolves the list in the raw config via `GetRawConfigAt` and refuses to suppress when the value is not wholly known, so the plan shows `tags = (known after apply)`. When the raw config is unavailable (refresh) or the path does not resolve, it falls through to the existing comparison, so refresh-time and order-insensitive suppression are unchanged. The same helper backs `tags` and `disk.mount_options` on `proxmox_virtual_environment_container`, which are fixed by the same change.

### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

New acceptance test `TestAccResourceVMTagsUnknownAtPlan` (`fwprovider/test/resource_vm_tags_test.go`). Step 1 creates a stopped VM with `tags = ["known-tag", terraform_data.tag.output]` so one tag is unknown at plan time, asserts the plan carries `tags` as unknown (`plancheck.ExpectUnknownValue`), then checks state and the tags string on PVE via `GET /nodes/{node}/qemu/{vmid}/config`. Step 2 replaces the `terraform_data` so the tag is unknown again on update. Step 3 is a `PlanOnly` step with the same tags in reversed order, proving order-insensitive suppression still works.

**Before the fix** (same test, same command):

```text
    resource_vm_tags_test.go:29: Step 1/3 error: Error running apply: exit status 1
        Error: Provider produced inconsistent final plan
        When expanding the plan for proxmox_virtual_environment_vm.test_tags to
        include new values learned so far during apply, provider
        "registry.terraform.io/hashicorp/proxmox" produced an invalid new value for
        .tags: was null, but now cty.ListVal([]cty.Value{cty.StringVal("known-tag"),
        cty.StringVal("unknown-at-plan")}).
--- FAIL: TestAccResourceVMTagsUnknownAtPlan (0.70s)
```

**After the fix:**

```text
$ ./testacc TestAccResourceVMTagsUnknownAtPlan -- -v
=== RUN   TestAccResourceVMTagsUnknownAtPlan
--- PASS: TestAccResourceVMTagsUnknownAtPlan (4.73s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	5.838s
```

Regression runs on the other call sites of the patched helper (nested `disk.0.mount_options` path, and a removed disk block where the raw-config path does not resolve and the helper must fall through):

```text
$ ./testacc "TestAccResourceVMTagsUnknownAtPlan|TestAccResourceContainerMountOptions|TestAccResourceContainerRemoveDiskBlock"
--- PASS: TestAccResourceContainerRemoveDiskBlock (7.80s)
--- PASS: TestAccResourceVMTagsUnknownAtPlan (4.53s)
--- PASS: TestAccResourceContainerMountOptions (24.88s)
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	29.651s
```

API verification: the change is plan-time only and does not alter any request body; the test asserts the resulting `tags` value on PVE after each apply.

Known limitation: the plan shows the whole list as `(known after apply)` rather than a partially known list, because SDK flatmap diffing cannot express a partially unknown list.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2999

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Fable 5.1). All changes have been reviewed and verified by a human.*
