### PR TITLE
fix(vm): do not drop vm from state on cluster resource list miss

### DIFF
--- a/fwprovider/test/resource_vm_cluster_list_test.go
+++ b/fwprovider/test/resource_vm_cluster_list_test.go
@@ -1,0 +1,126 @@
+//go:build acceptance || all
+
+//testacc:tier=medium
+//testacc:resource=vm
+
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package test
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bpg/terraform-provider-proxmox/proxmox/api"
+	"github.com/bpg/terraform-provider-proxmox/utils"
+)
+
+// newEmptyClusterListProxy fronts the real PVE endpoint and answers every /cluster/resources request with
+// an empty list, which is what a multi-node cluster returns until the guest list has synced to the node
+// serving the request.
+func newEmptyClusterListProxy(t *testing.T) string {
+	t.Helper()
+
+	target, err := url.Parse(utils.GetAnyStringEnv("PROXMOX_VE_ENDPOINT"))
+	require.NoError(t, err)
+
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(target)
+			// keep the upstream response uncompressed so the body below can be swapped in
+			r.Out.Header.Del("Accept-Encoding")
+		},
+		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			if !strings.HasSuffix(resp.Request.URL.Path, "/cluster/resources") {
+				return nil
+			}
+
+			_ = resp.Body.Close()
+
+			body := `{"data":[]}`
+			resp.Body = io.NopCloser(strings.NewReader(body))
+			resp.ContentLength = int64(len(body))
+			resp.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+			return nil
+		},
+	}
+
+	server := httptest.NewTLSServer(proxy)
+	t.Cleanup(server.Close)
+
+	return server.URL
+}
+
+// TestAccResourceVMReadSurvivesClusterListLag verifies that a VM missing from the cluster-wide resource
+// list, as happens on a multi-node cluster right after creation, is still read through its node's config
+// endpoint instead of being dropped from state.
+func TestAccResourceVMReadSurvivesClusterListLag(t *testing.T) {
+	t.Parallel()
+
+	te := InitEnvironment(t)
+	vmID := 100000 + rand.Intn(99999)
+	te.AddTemplateVars(map[string]any{"TestVMID": vmID})
+
+	t.Cleanup(func() {
+		err := te.NodeClient().VM(vmID).DeleteVM(context.Background(), true, true).Err()
+		if err != nil && !errors.Is(err, api.ErrResourceDoesNotExist) {
+			t.Logf("cleanup: delete VM %d: %v", vmID, err)
+		}
+	})
+
+	endpoint := newEmptyClusterListProxy(t)
+	resourceName := "proxmox_virtual_environment_vm.test_cluster_list_lag"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_vm" "test_cluster_list_lag" {
+						node_name = "{{.NodeName}}"
+						vm_id     = {{.TestVMID}}
+						name      = "test-cluster-list-lag"
+						started   = false
+					}`, WithEndpoint(endpoint)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", strconv.Itoa(vmID)),
+					func(*terraform.State) error {
+						_, err := te.NodeClient().VM(vmID).GetVM(context.Background())
+
+						return err
+					},
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("%s/%d", te.NodeName, vmID),
+			},
+		},
+	})
+}

--- a/fwprovider/test/resource_vm_cluster_list_test.go
+++ b/fwprovider/test/resource_vm_cluster_list_test.go
@@ -1,6 +1,6 @@
 //go:build acceptance || all
 
-//testacc:tier=medium
+//testacc:tier=heavy
 //testacc:resource=vm
 
 /*
@@ -105,7 +105,7 @@ func TestAccResourceVMReadSurvivesClusterListLag(t *testing.T) {
 						vm_id     = {{.TestVMID}}
 						name      = "test-cluster-list-lag"
 						started   = false
-					}`, WithEndpoint(endpoint)),
+					}`, WithInsecureEndpoint(endpoint)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "id", strconv.Itoa(vmID)),
 					func(*terraform.State) error {
@@ -120,6 +120,72 @@ func TestAccResourceVMReadSurvivesClusterListLag(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateId:     fmt.Sprintf("%s/%d", te.NodeName, vmID),
+			},
+		},
+	})
+}
+
+// TestAccResourceVMReadSurvivesClusterListLagImportFrom mirrors the reported configuration: a disk imported from a
+// downloaded cloud image, which the provider resizes right after creation before the first read.
+func TestAccResourceVMReadSurvivesClusterListLagImportFrom(t *testing.T) {
+	t.Parallel()
+
+	te := InitEnvironment(t)
+	vmID := 100000 + rand.Intn(99999)
+	te.AddTemplateVars(map[string]any{"TestVMID": vmID})
+
+	t.Cleanup(func() {
+		err := te.NodeClient().VM(vmID).DeleteVM(context.Background(), true, true).Err()
+		if err != nil && !errors.Is(err, api.ErrResourceDoesNotExist) {
+			t.Logf("cleanup: delete VM %d: %v", vmID, err)
+		}
+	})
+
+	endpoint := newEmptyClusterListProxy(t)
+	resourceName := "proxmox_virtual_environment_vm.test_cluster_list_lag_import"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: te.RenderConfig(`
+					resource "proxmox_virtual_environment_download_file" "test_cluster_list_lag_image" {
+						content_type        = "import"
+						datastore_id        = "local"
+						node_name           = "{{.NodeName}}"
+						url                 = "{{.CloudImagesServer}}/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img"
+						file_name           = "{{.TestName}}-image.img.raw"
+						overwrite_unmanaged = true
+					}
+
+					resource "proxmox_virtual_environment_vm" "test_cluster_list_lag_import" {
+						node_name = "{{.NodeName}}"
+						vm_id     = {{.TestVMID}}
+						name      = "test-cluster-list-lag-import"
+						started   = false
+
+						disk {
+							datastore_id = "local-lvm"
+							import_from  = proxmox_virtual_environment_download_file.test_cluster_list_lag_image.id
+							interface    = "virtio0"
+							iothread     = true
+							discard      = "on"
+						}
+
+						initialization {
+							datastore_id = "local-lvm"
+							interface    = "ide2"
+						}
+					}`, WithInsecureEndpoint(endpoint)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", strconv.Itoa(vmID)),
+					resource.TestCheckResourceAttr(resourceName, "disk.0.size", "8"),
+					func(*terraform.State) error {
+						_, err := te.NodeClient().VM(vmID).GetVM(context.Background())
+
+						return err
+					},
+				),
 			},
 		},
 	})

--- a/fwprovider/test/test_environment.go
+++ b/fwprovider/test/test_environment.go
@@ -64,13 +64,14 @@ type RenderConfigOption interface {
 }
 
 type renderConfig struct {
+	endpoint   string
 	auth       string
 	apiHeaders string
 }
 
 // render assembles the provider configuration block from the applied options.
 func (r *renderConfig) render() string {
-	return fmt.Sprintf("provider \"proxmox\" {\n%s%s\n%s\n}", r.auth, r.apiHeaders, r.ssh())
+	return fmt.Sprintf("provider \"proxmox\" {\n%s%s%s\n%s\n}", r.endpoint, r.auth, r.apiHeaders, r.ssh())
 }
 
 // returns the ssh configuration section of the provider config.
@@ -167,6 +168,22 @@ func (o *apiHeadersConfigOption) apply(rc *renderConfig) error {
 	sb.WriteString("\t}")
 
 	rc.apiHeaders = sb.String()
+
+	return nil
+}
+
+// WithEndpoint returns a configuration option that points the provider at the given API endpoint instead of
+// PROXMOX_VE_ENDPOINT, with TLS verification disabled so an in-test proxy can front the real node.
+func WithEndpoint(endpoint string) RenderConfigOption {
+	return &endpointConfigOption{endpoint: endpoint}
+}
+
+type endpointConfigOption struct {
+	endpoint string
+}
+
+func (o *endpointConfigOption) apply(rc *renderConfig) error {
+	rc.endpoint = fmt.Sprintf("\tendpoint = %q\n\tinsecure = true\n", o.endpoint)
 
 	return nil
 }

--- a/fwprovider/test/test_environment.go
+++ b/fwprovider/test/test_environment.go
@@ -172,17 +172,18 @@ func (o *apiHeadersConfigOption) apply(rc *renderConfig) error {
 	return nil
 }
 
-// WithEndpoint returns a configuration option that points the provider at the given API endpoint instead of
-// PROXMOX_VE_ENDPOINT, with TLS verification disabled so an in-test proxy can front the real node.
-func WithEndpoint(endpoint string) RenderConfigOption {
-	return &endpointConfigOption{endpoint: endpoint}
+// WithInsecureEndpoint returns a configuration option that points the provider at the given API endpoint instead
+// of PROXMOX_VE_ENDPOINT and disables TLS verification, so an in-test TLS proxy with a self-signed certificate can
+// front the real node.
+func WithInsecureEndpoint(endpoint string) RenderConfigOption {
+	return &insecureEndpointConfigOption{endpoint: endpoint}
 }
 
-type endpointConfigOption struct {
+type insecureEndpointConfigOption struct {
 	endpoint string
 }
 
-func (o *endpointConfigOption) apply(rc *renderConfig) error {
+func (o *insecureEndpointConfigOption) apply(rc *renderConfig) error {
 	rc.endpoint = fmt.Sprintf("\tendpoint = %q\n\tinsecure = true\n", o.endpoint)
 
 	return nil

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -4303,19 +4303,15 @@ func vmRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics
 		return diag.FromErr(err)
 	}
 
+	// A miss in the cluster resource list is not proof the VM is gone: on a multi-node cluster the list can lag
+	// behind a VM created moments ago. Fall through to the node config endpoint, which is authoritative.
 	vmNodeName, err := client.Cluster().GetVMNodeName(ctx, vmID)
-	if err != nil {
-		if errors.Is(err, cluster.ErrVMDoesNotExist) {
-			d.SetId("")
-
-			return nil
-		}
-
+	if err != nil && !errors.Is(err, cluster.ErrVMDoesNotExist) {
 		return diag.FromErr(err)
 	}
 
-	if vmNodeName != d.Get(mkNodeName) {
-		err = d.Set(mkNodeName, vmNodeName)
+	if vmNodeName != nil && *vmNodeName != d.Get(mkNodeName).(string) {
+		err = d.Set(mkNodeName, *vmNodeName)
 		if err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
### What does this PR do?

<!--- Clearly state the problem and how this PR solves it. -->

On a multi-node cluster, creating a `proxmox_virtual_environment_vm` could fail on the very first apply with `Provider produced inconsistent result after apply … Root object was present, but now absent` (#3022), and `terraform import` could fail with `Cannot import non-existent remote object` (#1878). `vmRead` located the VM through `GET /cluster/resources?type=vm` and treated a miss as "the VM is gone". That list is built from the guest list of whichever node serves the request, which on a cluster can lag behind a config file written on another node moments earlier, and Create calls Read immediately when the VM is not started. A single-node host never shows this, since the create task and the list share one pmxcfs instance, which is why the existing suite never caught it.

A cluster-list miss no longer blanks the ID. Read keeps the node from state and falls through to the authoritative `GET /nodes/{node}/qemu/{vmid}/config`, whose not-found branch still removes the VM from state. A cluster-list hit still updates `node_name`, so out-of-band migration detection (#391) is preserved. The always-true pointer-vs-string comparison on the node name is corrected as a side effect.

Two new acceptance tests run the provider through an in-test TLS reverse proxy that answers every `/cluster/resources` request with an empty list: one creates and imports a bare VM, the other mirrors the reported configuration with a downloaded cloud image imported as the boot disk and resized after create. Both fail before the fix and pass after, on a single-node host. A `WithInsecureEndpoint` render option is added to the test environment for this.

The post-create resize of `import_from` disks mentioned in the issue is by design: `disk.size` defaults to `8` and the provider resizes the imported disk to match the configuration.

### Contributor's Note

<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work

<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

**Before the fix** — `TestAccResourceVMReadSurvivesClusterListLag` reproduces the reported error on a single-node host:

```text
./testacc TestAccResourceVMReadSurvivesClusterListLag
=== RUN   TestAccResourceVMReadSurvivesClusterListLag
    resource_vm_cluster_list_test.go:92: Step 1/2 error: Error running apply: exit status 1

        Error: Provider produced inconsistent result after apply

        When applying changes to
        proxmox_virtual_environment_vm.test_cluster_list_lag, provider
        "provider[\"registry.terraform.io/hashicorp/proxmox\"]" produced an
        unexpected new value: Root object was present, but now absent.
--- FAIL: TestAccResourceVMReadSurvivesClusterListLag (1.84s)
```

The `import_from` variant fails the same way against the pre-fix `vmRead`:

```text
./testacc TestAccResourceVMReadSurvivesClusterListLagImportFrom
        Error: Provider produced inconsistent result after apply
        unexpected new value: Root object was present, but now absent.
--- FAIL: TestAccResourceVMReadSurvivesClusterListLagImportFrom (14.31s)
```

**After the fix** — new test plus the existing VM create/import tests:

```text
./testacc 'TestAccResourceVM$|TestAccResourceVMImport$|TestAccResourceVMImportEffectiveDefaults$|TestAccResourceVMReadSurvivesClusterListLag$' -- -v
--- PASS: TestAccResourceVMImport (4.91s)
--- PASS: TestAccResourceVMImportEffectiveDefaults (1.60s)
--- PASS: TestAccResourceVMReadSurvivesClusterListLag (3.46s)
--- PASS: TestAccResourceVMReadSurvivesClusterListLagImportFrom (20.32s)
--- PASS: TestAccResourceVM (0.00s)
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	25.832s
subtests: 25 pass, 0 fail
```

**mitmproxy** — request sequence for the new test (upstream leg of the in-test proxy). After the cluster list call the provider continues to the per-node read instead of dropping the VM; that GET was unreachable before the fix:

```text
POST /api2/json/nodes/pve/qemu                                200
GET  /api2/json/nodes/pve/tasks/UPID:...:qmcreate:.../status  200
GET  /api2/json/cluster/resources?type=vm                     200  (provider received {"data":[]} from the test proxy)
GET  /api2/json/nodes/pve/qemu/150275/config                  200  <- fall-through
GET  /api2/json/nodes/pve/qemu/150275/status/current          200
GET  /api2/json/pools                                         200
GET  cluster/resources -> config -> status/current            200  (post-apply refresh)
GET  cluster/resources -> config -> status/current            200  (import step)
DELETE /api2/json/nodes/pve/qemu/150275/?destroy-unreferenced-disks=1&purge=1  200
```

Also: `make build`, `make lint` (0 issues), `make test` pass; `make docs` produces no diff.

<!--- Please keep this note for the community --->

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #3022

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->

---

🤖 _This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Fable 5.1). All changes have been reviewed and verified by a human._
