### PR TITLE
fix(docs): document privileges required to list bridges

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -184,6 +184,8 @@ You can create an API Token via the Proxmox UI or the command line on the Proxmo
   ~> The list of available privileges has changed in PVE 9.0. The above list is only an example (and likely too permissive for most use cases). Please review and adjust to your needs.
   Refer to the [privileges documentation](https://pve.proxmox.com/pve-docs/pveum.1.html#_privileges) for more details.
 
+  ~> Keep `SDN.Audit` or `SDN.Use` in the role: PVE hides bridges from `GET /nodes/{node}/network` when the caller lacks either of them on `/sdn/zones/localnetwork/<iface>`. The provider uses that list to read `proxmox_network_linux_bridge` resources and to resolve node IP addresses for SSH, so a token without them fails with "interface not found" and falls back to DNS for the SSH node address. Privilege-separated tokens (`privsep=1`, the `pveum` default) need the privileges granted to the token itself.
+
 - Assign the role to the previously created user:
 
   ```sh
@@ -446,6 +448,8 @@ The following methods are used to resolve the node name, in the specified order:
    2. Has an IPv6 address with IPv6 gateway configured, or
    3. Has an IPv4 address
 2. Resolve the Proxmox node name (usually a shortname) via DNS using the system DNS resolver of the machine running Terraform.
+
+~> The interface enumeration in step 1 is subject to PVE permission filtering: bridges are omitted from the list when the API user lacks `SDN.Audit` or `SDN.Use` on `/sdn/zones/localnetwork/<iface>`. If the node address lives on such a bridge, resolution falls through to DNS. See [Creating an API Token](#creating-an-api-token-on-the-proxmox-server).
 
 In some cases, this may not be the desired behavior — for example, when the node has multiple network interfaces and the one that should be used for SSH is not the first one.
 

--- a/docs/resources/network_linux_bridge.md
+++ b/docs/resources/network_linux_bridge.md
@@ -5,11 +5,14 @@ parent: Resources
 subcategory: Virtual Environment
 description: |-
   Manages a Linux Bridge network interface in a Proxmox VE node.
+  ~> Proxmox VE hides bridges from the interface list (GET /nodes/{node}/network) when the API user lacks SDN.Audit or SDN.Use on /sdn/zones/localnetwork/<iface> (a grant on / propagates). The provider reads this resource from that list, so a token without these privileges fails with "interface not found" after create or on import. Privilege-separated tokens (privsep=1, the pveum default) need the grant on the token itself, not only on the user.
 ---
 
 # Resource: proxmox_network_linux_bridge
 
 Manages a Linux Bridge network interface in a Proxmox VE node.
+
+~> Proxmox VE hides bridges from the interface list (`GET /nodes/{node}/network`) when the API user lacks `SDN.Audit` or `SDN.Use` on `/sdn/zones/localnetwork/<iface>` (a grant on `/` propagates). The provider reads this resource from that list, so a token without these privileges fails with "interface not found" after create or on import. Privilege-separated tokens (`privsep=1`, the `pveum` default) need the grant on the token itself, not only on the user.
 
 ## Example Usage
 

--- a/docs/resources/virtual_environment_network_linux_bridge.md
+++ b/docs/resources/virtual_environment_network_linux_bridge.md
@@ -5,6 +5,7 @@ parent: Resources
 subcategory: Virtual Environment
 description: |-
   Manages a Linux Bridge network interface in a Proxmox VE node.
+  ~> Proxmox VE hides bridges from the interface list (GET /nodes/{node}/network) when the API user lacks SDN.Audit or SDN.Use on /sdn/zones/localnetwork/<iface> (a grant on / propagates). The provider reads this resource from that list, so a token without these privileges fails with "interface not found" after create or on import. Privilege-separated tokens (privsep=1, the pveum default) need the grant on the token itself, not only on the user.
 ---
 
 # Resource: proxmox_virtual_environment_network_linux_bridge
@@ -12,6 +13,8 @@ description: |-
 ~> **Deprecated:** Use [`proxmox_network_linux_bridge`](network_linux_bridge.md) instead. This resource will be removed in v1.0.
 
 Manages a Linux Bridge network interface in a Proxmox VE node.
+
+~> Proxmox VE hides bridges from the interface list (`GET /nodes/{node}/network`) when the API user lacks `SDN.Audit` or `SDN.Use` on `/sdn/zones/localnetwork/<iface>` (a grant on `/` propagates). The provider reads this resource from that list, so a token without these privileges fails with "interface not found" after create or on import. Privilege-separated tokens (`privsep=1`, the `pveum` default) need the grant on the token itself, not only on the user.
 
 ## Example Usage
 

--- a/fwprovider/nodes/network/resource_linux_bridge.go
+++ b/fwprovider/nodes/network/resource_linux_bridge.go
@@ -200,6 +200,12 @@ func (r *linuxBridgeResource) Schema(
 	resp.Schema = schema.Schema{
 		DeprecationMessage: migration.DeprecationMessage("proxmox_network_linux_bridge"),
 		Description:        "Manages a Linux Bridge network interface in a Proxmox VE node.",
+		MarkdownDescription: "Manages a Linux Bridge network interface in a Proxmox VE node.\n\n" +
+			"~> Proxmox VE hides bridges from the interface list (`GET /nodes/{node}/network`) when the API user lacks " +
+			"`SDN.Audit` or `SDN.Use` on `/sdn/zones/localnetwork/<iface>` (a grant on `/` propagates). " +
+			"The provider reads this resource from that list, so a token without these privileges fails with " +
+			"\"interface not found\" after create or on import. Privilege-separated tokens (`privsep=1`, the `pveum` default) " +
+			"need the grant on the token itself, not only on the user.",
 		Attributes: map[string]schema.Attribute{
 			// Base attributes
 			"id": attribute.ResourceID("A unique identifier with format `<node name>:<iface>`"),


### PR DESCRIPTION
### What does this PR do?

Documents a PVE permission filter that surfaces as "interface not found" in the provider. `GET /nodes/{node}/network` silently drops bridges when the caller lacks `SDN.Audit` or `SDN.Use` on `/sdn/zones/localnetwork/<iface>`; the single-interface GET needs only `Sys.Audit`, so a curl "proving" the bridge exists does not prove the list includes it. The provider reads `proxmox_network_linux_bridge` from that list and uses the same list to resolve node IP addresses for SSH.

Adds:

- a `~>` note to the `proxmox_network_linux_bridge` resource description (Framework schema, regenerated docs)
- a note in `docs/index.md` next to the example role, and one in "Node IP address used for SSH connection" saying the enumeration is filtered the same way

Privilege-separated tokens (`privsep=1`, the `pveum` default) need the grant on the token itself, which is the usual way to hit this.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

Docs-only change, no code behaviour touched. The filter was verified against `PVE::API2::Network::index` on a PVE 9.2 host (`check_sdn_bridge(..., ['SDN.Audit','SDN.Use'], noerr)` per bridge, present since pve-manager 8.0). `make lint` reports 0 issues and `make docs` output is included in the diff.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #3029
