### PR TITLE
fix(docs): note that mailnotification is ignored without mailto

### DIFF
--- a/docs/data-sources/backup_jobs.md
+++ b/docs/data-sources/backup_jobs.md
@@ -35,7 +35,7 @@ Read-Only:
 - `enabled` (Boolean) Indicates whether the backup job is enabled.
 - `exclude` (List of String) List of guest VM/CT IDs excluded from the backup.
 - `id` (String) Unique identifier of the backup job.
-- `mailnotification` (String) When to send email notifications (always or failure).
+- `mailnotification` (String) When to send email notifications (`always` or `failure`). Ignored by Proxmox VE unless `mailto` is set or the job uses the `legacy-sendmail` notification mode.
 - `mailto` (List of String) List of email addresses for notifications.
 - `mode` (String) Backup mode (e.g. snapshot, suspend, stop).
 - `node` (String) Node on which the backup job runs.

--- a/docs/resources/backup_job.md
+++ b/docs/resources/backup_job.md
@@ -44,7 +44,7 @@ resource "proxmox_backup_job" "daily_backup" {
 - `fleecing` (Attributes) Fleecing configuration for the backup job. (see [below for nested schema](#nestedatt--fleecing))
 - `ionice` (Number) I/O priority (0-8).
 - `lockwait` (Number) Maximum wait time in minutes for the global lock.
-- `mailnotification` (String) Email notification setting (always or failure).
+- `mailnotification` (String) Email notification setting (`always` or `failure`). Deprecated by Proxmox VE in favour of the notification system: it is only honoured when `mailto` is set (notification mode `auto`) or the job uses the `legacy-sendmail` notification mode. Otherwise notifications are routed through the PVE notification system and this setting is ignored.
 - `mailto` (List of String) A list of email addresses to send notifications to.
 - `maxfiles` (Number) Deprecated: use prune_backups instead. Maximum number of backup files per guest.
 - `mode` (String) The backup mode (snapshot, suspend, or stop).

--- a/fwprovider/cluster/backup/datasource.go
+++ b/fwprovider/cluster/backup/datasource.go
@@ -134,8 +134,9 @@ func (d *backupJobsDataSource) Schema(
 							ElementType: types.StringType,
 						},
 						"mailnotification": schema.StringAttribute{
-							Description: "When to send email notifications (always or failure).",
-							Computed:    true,
+							Description: "When to send email notifications (`always` or `failure`). " +
+								"Ignored by Proxmox VE unless `mailto` is set or the job uses the `legacy-sendmail` notification mode.",
+							Computed: true,
 						},
 						"notes_template": schema.StringAttribute{
 							Description: "Template for backup notes.",

--- a/fwprovider/cluster/backup/resource.go
+++ b/fwprovider/cluster/backup/resource.go
@@ -186,9 +186,11 @@ func (r *backupJobResource) Schema(
 				ElementType: types.StringType,
 			},
 			"mailnotification": schema.StringAttribute{
-				Description: "Email notification setting (always or failure).",
-				Optional:    true,
-				Computed:    true,
+				Description: "Email notification setting (`always` or `failure`). Deprecated by Proxmox VE in favour of the notification system: " +
+					"it is only honoured when `mailto` is set (notification mode `auto`) or the job uses the `legacy-sendmail` notification mode. " +
+					"Otherwise notifications are routed through the PVE notification system and this setting is ignored.",
+				Optional: true,
+				Computed: true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("always", "failure"),
 				},


### PR DESCRIPTION
### What does this PR do?

Adds the missing caveat to the `mailnotification` description on `proxmox_backup_job` (and the read-only field on `proxmox_backup_jobs`). PVE 8.1+ deprecated `mailnotification` in favour of the notification system: with the default `notification-mode` (`auto`) it is only honoured when `mailto` is set, otherwise vzdump routes through the notification system and the built-in matcher emails root on every job result. The provider sent the value correctly; users just had no way to know PVE would ignore it.

Exposing `notification_mode` itself is tracked in #3074.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

Description-only change. The behaviour is from the vzdump schema in `PVE/VZDump/Common.pm` on a PVE 9.2 host: `mailnotification` is marked "Deprecated: use notification targets/matchers instead", and `notification-mode` `auto` means "an email will be sent if mailto is set, and the notification system will be used if not". `make lint` reports 0 issues; regenerated docs are in the diff.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates #3000
