### PR TITLE
fix(lxc): start container after idmap is written instead of rebooting

### DIFF
--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -2199,6 +2200,29 @@ func TestAccResourceContainerIDMapFirstBoot(t *testing.T) {
 		}
 	}
 
+	// The mapping must be active from the first start alone; a post-create reboot hangs on guests whose PID 1
+	// cannot handle the halt signal yet.
+	assertNoRebootTask := func(*terraform.State) error {
+		var resBody struct {
+			Data []struct {
+				UPID string `json:"upid"`
+			} `json:"data,omitempty"`
+		}
+
+		nodeClient := te.NodeClient()
+		path := nodeClient.ExpandPath(fmt.Sprintf("tasks?vmid=%d&typefilter=vzreboot", accTestContainerID))
+
+		if err := nodeClient.DoRequest(context.Background(), http.MethodGet, path, nil, &resBody); err != nil {
+			return fmt.Errorf("listing tasks for container %d: %w", accTestContainerID, err)
+		}
+
+		if len(resBody.Data) > 0 {
+			return fmt.Errorf("expected no vzreboot task for container %d, found %d", accTestContainerID, len(resBody.Data))
+		}
+
+		return nil
+	}
+
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: te.AccProviders,
 		Steps: []resource.TestStep{
@@ -2257,6 +2281,7 @@ func TestAccResourceContainerIDMapFirstBoot(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					assertConfiguredMapActive("/proc/self/uid_map"),
 					assertConfiguredMapActive("/proc/self/gid_map"),
+					assertNoRebootTask,
 				),
 			},
 		},

--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -2201,23 +2201,33 @@ func TestAccResourceContainerIDMapFirstBoot(t *testing.T) {
 	}
 
 	// The mapping must be active from the first start alone; a post-create reboot hangs on guests whose PID 1
-	// cannot handle the halt signal yet.
+	// cannot handle the halt signal yet. The vzstart check is the positive control: PVE hides other users' tasks
+	// from a caller without Sys.Audit, so an empty listing must fail rather than pass.
 	assertNoRebootTask := func(*terraform.State) error {
 		var resBody struct {
 			Data []struct {
-				UPID string `json:"upid"`
+				Type string `json:"type"`
 			} `json:"data,omitempty"`
 		}
 
 		nodeClient := te.NodeClient()
-		path := nodeClient.ExpandPath(fmt.Sprintf("tasks?vmid=%d&typefilter=vzreboot", accTestContainerID))
+		path := nodeClient.ExpandPath(fmt.Sprintf("tasks?vmid=%d", accTestContainerID))
 
 		if err := nodeClient.DoRequest(context.Background(), http.MethodGet, path, nil, &resBody); err != nil {
 			return fmt.Errorf("listing tasks for container %d: %w", accTestContainerID, err)
 		}
 
-		if len(resBody.Data) > 0 {
-			return fmt.Errorf("expected no vzreboot task for container %d, found %d", accTestContainerID, len(resBody.Data))
+		counts := map[string]int{}
+		for _, task := range resBody.Data {
+			counts[task.Type]++
+		}
+
+		if counts["vzstart"] == 0 {
+			return fmt.Errorf("expected a vzstart task for container %d in the task list, got %v", accTestContainerID, counts)
+		}
+
+		if counts["vzreboot"] > 0 {
+			return fmt.Errorf("expected no vzreboot task for container %d, found %d", accTestContainerID, counts["vzreboot"])
 		}
 
 		return nil

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -2197,7 +2197,6 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m any) d
 
 	poolID := d.Get(mkPoolID).(string)
 	protection := types.CustomBool(d.Get(mkProtection).(bool))
-	started := types.CustomBool(d.Get(mkStarted).(bool))
 	startOnBoot := types.CustomBool(d.Get(mkStartOnBoot).(bool))
 	startupBehavior := containerGetStartupBehavior(d)
 	tags := d.Get(mkTags).([]any)
@@ -2221,7 +2220,6 @@ func containerCreateCustom(ctx context.Context, d *schema.ResourceData, m any) d
 		OSType:               &operatingSystemType,
 		Protection:           &protection,
 		RootFS:               rootFS,
-		Start:                &started,
 		StartOnBoot:          &startOnBoot,
 		StartupBehavior:      startupBehavior,
 		Swap:                 &memorySwap,
@@ -2332,28 +2330,10 @@ func containerCreateStart(ctx context.Context, d *schema.ResourceData, m any) di
 
 	containerAPI := client.Node(nodeName).Container(vmID)
 
-	// Start the container and wait for it to reach a running state before continuing.
+	// The first start happens here, after the idmap is written, so PVE picks up the mapping on a cold boot.
 	diags := sdkresource.TaskResultDiags(containerAPI.StartContainer(ctx), "Container start")
 	if diags.HasError() {
 		return diags
-	}
-
-	// idmap is written to the config via SSH after create, but PVE's first start does not apply
-	// it; a reboot regenerates the runtime mapping. Mirrors the rebootRequired path in update.
-	if len(containerGetIDMaps(d.Get(mkIDMap).([]any))) > 0 {
-		rebootTimeoutSec := d.Get(mkTimeoutCreate).(int)
-
-		rebootDiags := sdkresource.TaskResultDiags(containerAPI.RebootContainer(
-			ctx,
-			&containers.RebootRequestBody{
-				Timeout: &rebootTimeoutSec,
-			},
-		), "Container reboot")
-		if rebootDiags.HasError() {
-			return append(diags, rebootDiags...)
-		}
-
-		diags = append(diags, rebootDiags...)
 	}
 
 	return append(diags, containerRead(ctx, d, m)...)


### PR DESCRIPTION

### What does this PR do?
<!--- Clearly state the problem and how this PR solves it. -->

Creating a `proxmox_virtual_environment_container` with `idmap` and `started = true` could hang in the post-create reboot (#3021). The create request carried `start=1`, so PVE booted the container inside the `vzcreate` task before the provider wrote `lxc.idmap` to the config over SSH. The reboot added for #2895 was the only thing applying the mapping, and PVE's `vm_reboot` waits the full `timeout` (the provider passed `timeout_create`, 1800 s by default) for the guest to honour the halt signal before killing it. A guest whose PID 1 has no signal handler yet, such as NixOS where stage-2 is a shell script until it execs systemd, never answers, so the reboot task sat there until the user cancelled it.

The create request no longer sends `start`. `containerCreateStart` performs the first, cold start after the idmap is in the config, which PVE honours on any start, and the post-create reboot is removed. The clone path already worked this way. A configurable delay, as suggested in the issue, is not needed since there is no reboot left to race.

### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

`TestAccResourceContainerIDMapFirstBoot` now also asserts that no `vzreboot` task exists for the container, next to the existing `/proc/self/uid_map` and `gid_map` checks that prove the mapping is active from the first boot.

RED, before the fix:

```text
resource_container_test.go:2226: Step 1/1 error: Check failed: Check 3/3 error: expected no vzreboot task for container 100890, found 1
--- FAIL: TestAccResourceContainerIDMapFirstBoot (23.88s)
```

GREEN, with the fix:

```text
./testacc TestAccResourceContainerIDMapFirstBoot -- -v
=== RUN   TestAccResourceContainerIDMapFirstBoot
--- PASS: TestAccResourceContainerIDMapFirstBoot (21.63s)
PASS
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	22.170s
```

mitmproxy (`--flow-detail 3`) for the same test:

```text
POST /api2/json/nodes/pve/lxc                        body: arch, cmode, console, cores, cpulimit, hostname, memory, net0,
                                                     onboot, ostemplate, ostype, protection, storage, swap, template, tty,
                                                     unprivileged, vmid   (no `start`)
POST /api2/json/nodes/pve/lxc/{id}/status/start      1 call, after the idmap was written over SSH
POST /api2/json/nodes/pve/lxc/{id}/status/reboot     0 calls
POST /api2/json/nodes/pve/lxc/{id}/status/shutdown   1 call (destroy)
```

Before the fix the same test sent the create with `start=1` and then `status/reboot` with `timeout=1800`.

Regression sweep of the whole `fwprovider/test` package: 120 passed, 1 failed. The failure is `TestAccResourceFile` (`permission denied` on `/var/lib/vz/snippets`), a known limitation of the test host unrelated to this change. All 29 container tests passed.

Not covered: the NixOS hang itself is not reproduced, since the test host has no template whose PID 1 stays a shell long enough. The test proves the mechanism instead: the mapping is active from the first boot and no reboot is issued.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3021

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Fable 5.1). All changes have been reviewed and verified by a human.*
