### PR TITLE
fix(lxc): do not reboot a container the update just started

### DIFF
--- a/fwprovider/test/resource_container_test.go
+++ b/fwprovider/test/resource_container_test.go
@@ -2179,60 +2179,6 @@ func TestAccResourceContainerIDMapFirstBoot(t *testing.T) {
 		"TimeoutDelete":   300,
 	})
 
-	// assertConfiguredMapActive reads the given map file inside the running container and requires
-	// the configured second range "1000 101000 64536" to be present. Under the default unprivileged
-	// mapping (a single "0 100000 65536" line) that row cannot appear, so this fails when the idmap
-	// is not active on first boot. The map stays within root's default subuid/subgid range
-	// (100000+65536) so the container can actually start on a stock host.
-	assertConfiguredMapActive := func(mapFile string) func(*terraform.State) error {
-		return func(*terraform.State) error {
-			out := te.ExecuteNodeCommands([]string{
-				fmt.Sprintf("/usr/sbin/pct exec %d -- cat %s", accTestContainerID, mapFile),
-			})
-
-			for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-				if f := strings.Fields(line); len(f) == 3 && f[0] == "1000" && f[1] == "101000" && f[2] == "64536" {
-					return nil
-				}
-			}
-
-			return fmt.Errorf("%s inside running container should contain the configured mapping (1000 101000 64536), got:\n%s", mapFile, out)
-		}
-	}
-
-	// The mapping must be active from the first start alone; a post-create reboot hangs on guests whose PID 1
-	// cannot handle the halt signal yet. The vzstart check is the positive control: PVE hides other users' tasks
-	// from a caller without Sys.Audit, so an empty listing must fail rather than pass.
-	assertNoRebootTask := func(*terraform.State) error {
-		var resBody struct {
-			Data []struct {
-				Type string `json:"type"`
-			} `json:"data,omitempty"`
-		}
-
-		nodeClient := te.NodeClient()
-		path := nodeClient.ExpandPath(fmt.Sprintf("tasks?vmid=%d", accTestContainerID))
-
-		if err := nodeClient.DoRequest(context.Background(), http.MethodGet, path, nil, &resBody); err != nil {
-			return fmt.Errorf("listing tasks for container %d: %w", accTestContainerID, err)
-		}
-
-		counts := map[string]int{}
-		for _, task := range resBody.Data {
-			counts[task.Type]++
-		}
-
-		if counts["vzstart"] == 0 {
-			return fmt.Errorf("expected a vzstart task for container %d in the task list, got %v", accTestContainerID, counts)
-		}
-
-		if counts["vzreboot"] > 0 {
-			return fmt.Errorf("expected no vzreboot task for container %d, found %d", accTestContainerID, counts["vzreboot"])
-		}
-
-		return nil
-	}
-
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: te.AccProviders,
 		Steps: []resource.TestStep{
@@ -2289,9 +2235,177 @@ func TestAccResourceContainerIDMapFirstBoot(t *testing.T) {
 					}
 				}`, WithRootUser()),
 				Check: resource.ComposeTestCheckFunc(
-					assertConfiguredMapActive("/proc/self/uid_map"),
-					assertConfiguredMapActive("/proc/self/gid_map"),
-					assertNoRebootTask,
+					assertContainerIDMapActive(te, accTestContainerID, "/proc/self/uid_map"),
+					assertContainerIDMapActive(te, accTestContainerID, "/proc/self/gid_map"),
+					assertContainerStartedWithoutReboot(te, accTestContainerID),
+				),
+			},
+		},
+	})
+}
+
+// assertContainerIDMapActive reads the given map file inside the running container and requires the configured
+// second range "1000 101000 64536" to be present. Under the default unprivileged mapping (a single
+// "0 100000 65536" line) that row cannot appear, so this fails when the idmap is not active. The map stays within
+// root's default subuid/subgid range (100000+65536) so the container can actually start on a stock host.
+func assertContainerIDMapActive(te *Environment, containerID int, mapFile string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		out := te.ExecuteNodeCommands([]string{
+			fmt.Sprintf("/usr/sbin/pct exec %d -- cat %s", containerID, mapFile),
+		})
+
+		for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+			if f := strings.Fields(line); len(f) == 3 && f[0] == "1000" && f[1] == "101000" && f[2] == "64536" {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("%s inside running container should contain the configured mapping (1000 101000 64536), got:\n%s", mapFile, out)
+	}
+}
+
+// assertContainerStartedWithoutReboot requires a vzstart task and no vzreboot task in the node task list for the
+// container. A reboot right after a cold start hangs on guests whose PID 1 cannot handle the halt signal yet. The
+// vzstart check is the positive control: PVE hides other users' tasks from a caller without Sys.Audit, so an empty
+// listing must fail rather than pass.
+func assertContainerStartedWithoutReboot(te *Environment, containerID int) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		var resBody struct {
+			Data []struct {
+				Type string `json:"type"`
+			} `json:"data,omitempty"`
+		}
+
+		nodeClient := te.NodeClient()
+		path := nodeClient.ExpandPath(fmt.Sprintf("tasks?vmid=%d", containerID))
+
+		if err := nodeClient.DoRequest(context.Background(), http.MethodGet, path, nil, &resBody); err != nil {
+			return fmt.Errorf("listing tasks for container %d: %w", containerID, err)
+		}
+
+		counts := map[string]int{}
+		for _, task := range resBody.Data {
+			counts[task.Type]++
+		}
+
+		if counts["vzstart"] == 0 {
+			return fmt.Errorf("expected a vzstart task for container %d in the task list, got %v", containerID, counts)
+		}
+
+		if counts["vzreboot"] > 0 {
+			return fmt.Errorf("expected no vzreboot task for container %d, found %d", containerID, counts["vzreboot"])
+		}
+
+		return nil
+	}
+}
+
+func TestAccResourceContainerIDMapChangeOnStart(t *testing.T) {
+	te := InitEnvironment(t)
+	imageFileName := fmt.Sprintf("%d-alpine-3.22-default_20250617_amd64.tar.xz", time.Now().UnixMicro())
+	testAccDownloadContainerTemplate(t, te, imageFileName)
+
+	accTestContainerID := 100000 + rand.Intn(99999)
+
+	te.AddTemplateVars(map[string]interface{}{
+		"ImageFileName":   imageFileName,
+		"TestContainerID": accTestContainerID,
+		"TimeoutDelete":   300,
+	})
+
+	containerConfig := func(started bool, idmap string) string {
+		return te.RenderConfig(fmt.Sprintf(`
+			resource "proxmox_virtual_environment_container" "test_container" {
+				node_name      = "{{.NodeName}}"
+				vm_id          = {{.TestContainerID}}
+				timeout_delete = {{ .TimeoutDelete }}
+				unprivileged   = true
+				started        = %t
+				disk {
+					datastore_id = "local-lvm"
+					size         = 4
+				}
+				%s
+				initialization {
+					hostname = "test-idmap-change"
+					ip_config {
+						ipv4 {
+							address = "dhcp"
+						}
+					}
+				}
+				network_interface {
+					name = "vmbr0"
+				}
+				operating_system {
+					template_file_id = "local:vztmpl/{{.ImageFileName}}"
+					type             = "alpine"
+				}
+			}`, started, idmap), WithRootUser())
+	}
+
+	singleRangeIDMap := `
+				idmap {
+					type         = "uid"
+					container_id = 0
+					host_id      = 100000
+					size         = 65536
+				}
+				idmap {
+					type         = "gid"
+					container_id = 0
+					host_id      = 100000
+					size         = 65536
+				}`
+
+	splitRangeIDMap := `
+				idmap {
+					type         = "uid"
+					container_id = 0
+					host_id      = 100000
+					size         = 1000
+				}
+				idmap {
+					type         = "uid"
+					container_id = 1000
+					host_id      = 101000
+					size         = 64536
+				}
+				idmap {
+					type         = "gid"
+					container_id = 0
+					host_id      = 100000
+					size         = 1000
+				}
+				idmap {
+					type         = "gid"
+					container_id = 1000
+					host_id      = 101000
+					size         = 64536
+				}`
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: te.AccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: containerConfig(false, singleRangeIDMap),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"started": "false",
+					}),
+				),
+			},
+			{
+				// Changing the idmap and starting the container in one apply must be a single cold start with the
+				// new mapping, not a start followed by a reboot.
+				Config: containerConfig(true, splitRangeIDMap),
+				Check: resource.ComposeTestCheckFunc(
+					ResourceAttributes(accTestContainerName, map[string]string{
+						"started": "true",
+					}),
+					assertContainerIDMapActive(te, accTestContainerID, "/proc/self/uid_map"),
+					assertContainerIDMapActive(te, accTestContainerID, "/proc/self/gid_map"),
+					assertContainerStartedWithoutReboot(te, accTestContainerID),
 				),
 			},
 		},

--- a/proxmoxtf/resource/container/container.go
+++ b/proxmoxtf/resource/container/container.go
@@ -4134,6 +4134,9 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 			if updateDiags.HasError() {
 				return updateDiags
 			}
+
+			// The config and idmap were written before this cold start, so it already applies every pending change.
+			rebootRequired = false
 		} else {
 			forceStop := types.CustomBool(true)
 			// Using delete timeout here as we're in the similar situation
@@ -4163,7 +4166,7 @@ func containerUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Di
 
 	// As a final step in the update procedure, we might need to reboot the container.
 	if !template && started && rebootRequired {
-		rebootTimeout := 300
+		rebootTimeout := updateTimeoutSec
 
 		rebootDiags := sdkresource.TaskResultDiags(containerAPI.RebootContainer(
 			ctx,


### PR DESCRIPTION

### What does this PR do?
<!--- Clearly state the problem and how this PR solves it. -->

Updating a stopped `proxmox_virtual_environment_container` with `started = true` and a reboot-requiring change (`idmap`, hostname, and so on) in the same apply started the container and then immediately rebooted it (#3077). `containerUpdate` writes the config and the `lxc.idmap` entries before the start, so that cold start already applies every pending change, but `rebootRequired` was only cleared in the shutdown branch. The redundant reboot is the update-path twin of #3021: on a guest whose PID 1 is still a shell script (NixOS stage-2 until it execs systemd) the halt signal is dropped and the reboot waits the full PVE timeout, which was hardcoded to 300 s here.

The start branch now clears `rebootRequired` after a successful start, mirroring the shutdown branch and the VM resource's "only reboot if the VM stayed running" rule in `vmFinalizePowerState`. The reboot still runs for a container that was already running when the update began, since that is the only case where pending changes need a restart. Its timeout now comes from `timeout_update` instead of the literal 300.

One thing worth knowing: `containerUpdate` does not strip the SDK's 20-minute context cap (the VM CRUD functions do), so on a guest that ignores the halt signal a 1800 s PVE reboot timeout can outlive the provider's deadline. Before this PR that case was the freshly started container itself; now it only applies to a guest that was already up for the whole update, which handles the signal.

### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [x] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

New `TestAccResourceContainerIDMapChangeOnStart`: step 1 creates the container with `started = false` and a single-range uid/gid idmap; step 2 splits the idmap into two ranges and sets `started = true` in one apply, then checks `/proc/self/uid_map` and `gid_map` inside the guest for the new mapping, that a `vzstart` task exists (positive control, since PVE hides other users' tasks from a caller without `Sys.Audit`), and that no `vzreboot` task exists. The idmap and task-list checks from `TestAccResourceContainerIDMapFirstBoot` were extracted into shared helpers used by both tests.

RED, before the fix (the mapping checks passed, so the cold start already applied it; only the extra reboot was there):

```text
resource_container_test.go:2387: Step 2/2 error: Check failed: Check 4/4 error: expected no vzreboot task for container 197172, found 1
--- FAIL: TestAccResourceContainerIDMapChangeOnStart (28.03s)
```

GREEN, with the fix:

```text
./testacc TestAccResourceContainerIDMapChangeOnStart -- -v
=== RUN   TestAccResourceContainerIDMapChangeOnStart
--- PASS: TestAccResourceContainerIDMapChangeOnStart (23.36s)
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	24.460s
```

The timeout change is only observable when a reboot does fire, so `TestAccResourceContainerHostname` (hostname change on a running container) was run through mitmproxy (`--flow-detail 3`). One reboot, with the `timeout_update` default:

```text
POST /api2/json/nodes/pve/lxc/{id}/status/reboot
    timeout: '1800'
 << 200 OK
```

Regression sweep of all container tests, `./testacc "TestAccResourceContainer.*"`: 31 passed, 0 failed (202 s).

Not covered: the NixOS hang itself is not reproduced, for the same reason as in #3076 (no template on the test host whose PID 1 stays a shell). The test proves the mechanism: one start, no reboot, mapping active.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3077

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Fable 5.1). All changes have been reviewed and verified by a human.*
