### PR TITLE
fix(vm): apply cloud-init password changes in place

### DIFF
--- a/fwprovider/test/resource_vm_test.go
+++ b/fwprovider/test/resource_vm_test.go
@@ -17,6 +17,7 @@ import (
 	"math/rand"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -856,6 +857,31 @@ func TestAccResourceVMInitialization(t *testing.T) {
 	imageFileID := te.DownloadCloudImage()
 	te.AddTemplateVars(map[string]any{"ImageFileID": imageFileID})
 
+	// PVE only ever returns a mask for cipassword, so the proof that a password reached PVE is the value in the VM
+	// config file: plaintext after a create, a crypt hash after a config update. Verify with perl on the node.
+	assertCloudInitPassword := func(resourceName, password string) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			rs, ok := s.RootModule().Resources[resourceName]
+			if !ok {
+				return fmt.Errorf("resource %s not found in state", resourceName)
+			}
+
+			vmID := rs.Primary.Attributes["vm_id"]
+			out := te.ExecuteNodeCommands([]string{fmt.Sprintf(
+				`/usr/bin/perl -e 'my ($h) = map { /^cipassword:\s*(\S+)/ ? $1 : () } `+
+					"`cat /etc/pve/qemu-server/%s.conf`"+
+					`; print((defined $h && ($h eq %[2]q || crypt(%[2]q, $h) eq $h)) ? "match" : "mismatch: $h"), "\n"'`,
+				vmID, password,
+			)})
+
+			if strings.TrimSpace(out) != "match" {
+				return fmt.Errorf("cipassword hash of VM %s does not verify against the configured password: %s", vmID, out)
+			}
+
+			return nil
+		}
+	}
+
 	tests := []struct {
 		name string
 		step []resource.TestStep
@@ -990,9 +1016,7 @@ func TestAccResourceVMInitialization(t *testing.T) {
 				}`),
 			Check: ResourceAttributes("proxmox_virtual_environment_vm.test_vm_cloudinit4", map[string]string{
 				"initialization.0.user_account.0.username": "ubuntu",
-				// override by PVE, set when reading back from the API
-				// have to escape the asterisks because of regex match
-				"initialization.0.user_account.0.password": `\*\*\*\*\*\*\*\*\*\*`,
+				"initialization.0.user_account.0.password": "^password$",
 			}),
 		}, {
 			Config: te.RenderConfig(`
@@ -1012,8 +1036,48 @@ func TestAccResourceVMInitialization(t *testing.T) {
 				}`),
 			Check: ResourceAttributes("proxmox_virtual_environment_vm.test_vm_cloudinit4", map[string]string{
 				"initialization.0.user_account.0.username": "ubuntu",
-				"initialization.0.user_account.0.password": `\*\*\*\*\*\*\*\*\*\*`,
+				"initialization.0.user_account.0.password": "^password$",
 			}),
+		}}},
+		{"native cloud-init: password update is applied in place", []resource.TestStep{{
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm_cloudinit_password" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					initialization {
+						user_account {
+							username = "ubuntu"
+							password = "password1"
+						}
+					}
+				}`),
+			Check: assertCloudInitPassword("proxmox_virtual_environment_vm.test_vm_cloudinit_password", "password1"),
+		}, {
+			Config: te.RenderConfig(`
+				resource "proxmox_virtual_environment_vm" "test_vm_cloudinit_password" {
+					node_name = "{{.NodeName}}"
+					started   = false
+					initialization {
+						user_account {
+							username = "ubuntu"
+							password = "password2"
+						}
+					}
+				}`),
+			ConfigPlanChecks: resource.ConfigPlanChecks{
+				PreApply: []plancheck.PlanCheck{
+					plancheck.ExpectResourceAction(
+						"proxmox_virtual_environment_vm.test_vm_cloudinit_password",
+						plancheck.ResourceActionUpdate,
+					),
+				},
+			},
+			Check: resource.ComposeTestCheckFunc(
+				ResourceAttributes("proxmox_virtual_environment_vm.test_vm_cloudinit_password", map[string]string{
+					"initialization.0.user_account.0.password": "^password2$",
+				}),
+				assertCloudInitPassword("proxmox_virtual_environment_vm.test_vm_cloudinit_password", "password2"),
+			),
 		}}},
 		{"native cloud-init: username update should not cause replacement", []resource.TestStep{{
 			Config: te.RenderConfig(`

--- a/proxmoxtf/resource/vm/vm.go
+++ b/proxmoxtf/resource/vm/vm.go
@@ -976,9 +976,12 @@ func VM() *schema.Resource {
 									Optional:    true,
 									Sensitive:   true,
 									Default:     dvInitializationUserAccountPassword,
-									DiffSuppressFunc: func(_, oldVal, _ string, _ *schema.ResourceData) bool {
-										return len(oldVal) > 0 &&
-											strings.ReplaceAll(oldVal, "*", "") == ""
+									DiffSuppressFunc: func(_, oldVal, newVal string, _ *schema.ResourceData) bool {
+										// PVE never returns the password, so a masked state value with no configured
+										// password stays unmanaged; a configured value against the mask is a real change.
+										masked := len(oldVal) > 0 && strings.ReplaceAll(oldVal, "*", "") == ""
+
+										return masked && newVal == ""
 									},
 								},
 								mkInitializationUserAccountUsername: {
@@ -5139,7 +5142,17 @@ func vmReadCustom(
 		}
 
 		if vmConfig.CloudInitPassword != nil {
-			initializationUserAccount[mkInitializationUserAccountPassword] = *vmConfig.CloudInitPassword
+			password := *vmConfig.CloudInitPassword
+
+			// PVE only returns a mask; keep the locally known value so a config change still produces a diff.
+			current, _ := d.Get(
+				fmt.Sprintf("%s.0.%s.0.%s", mkInitialization, mkInitializationUserAccount, mkInitializationUserAccountPassword),
+			).(string)
+			if password == MaskedPassword && current != "" && current != MaskedPassword {
+				password = current
+			}
+
+			initializationUserAccount[mkInitializationUserAccountPassword] = password
 		} else {
 			initializationUserAccount[mkInitializationUserAccountPassword] = ""
 		}

--- a/proxmoxtf/resource/vm/vm_test.go
+++ b/proxmoxtf/resource/vm/vm_test.go
@@ -616,3 +616,35 @@ func Test_parseImportIDWIthNodeName(t *testing.T) {
 		})
 	}
 }
+
+func TestVMCloudInitPasswordDiffSuppress(t *testing.T) {
+	t.Parallel()
+
+	initializationSchema := test.AssertNestedSchemaExistence(t, VM().Schema, mkInitialization)
+	userAccountSchema := test.AssertNestedSchemaExistence(t, initializationSchema, mkInitializationUserAccount)
+	suppress := userAccountSchema[mkInitializationUserAccountPassword].DiffSuppressFunc
+
+	require.NotNil(t, suppress)
+
+	tests := []struct {
+		name     string
+		state    string
+		config   string
+		expected bool
+	}{
+		{"masked state, no configured password", MaskedPassword, "", true},
+		{"masked state, configured password (legacy state migrates)", MaskedPassword, "secret", false},
+		{"kept state, changed password", "secret", "other", false},
+		{"kept state, same password", "secret", "secret", false},
+		{"empty state, configured password", "", "secret", false},
+		{"empty state, no password", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, suppress(mkInitializationUserAccountPassword, tt.state, tt.config, nil))
+		})
+	}
+}


### PR DESCRIPTION

### What does this PR do?
<!--- Clearly state the problem and how this PR solves it. -->

Changing `initialization.user_account.password` on an existing `proxmox_virtual_environment_vm` planned as "no changes" (#3003). PVE returns `**********` for `cipassword` on every config read, the provider stored that mask in state as-is, and the `DiffSuppressFunc` on `password` suppressed any diff whenever the state value was the mask, regardless of what the config said. The update path itself was fine: when a diff gets through, the provider does `PUT cipassword=...` and PVE regenerates the cloud-init drive, exactly what the GUI does. It was just never reached after the first refresh.

Two changes in `vmReadCustom` and the schema. On read, when PVE hands back the mask, the provider keeps the locally known value (the configured password from the last apply) instead of overwriting state with the mask; the mask only lands in state when there is no local value (import, or a password set outside Terraform). The suppressor now fires only when the state holds the mask and the config has no password, so an unmanaged password stays unmanaged while a configured value against the mask is a real diff. The update-side guard from #1864 that refuses to send the mask back to PVE stays as defence.

This mirrors the container resource, which never had the problem: LXC's password is create-only, PVE never returns it, and `containerRead` keeps the whole `user_account` block from state.

**Effect for existing users.** States written by earlier versions hold the mask. With a `password` configured, the next plan shows one `(sensitive value)` change on that attribute, and the apply re-sends the same password (regenerating the cloud-init drive); from then on the state holds the configured value. With no `password` configured, nothing changes. Removing `password` from config still does not clear it on PVE, same as before.

### Contributor's Note
<!---
Please mark the following items with an [x] if they apply to your PR.
Leave the [ ] if they are not applicable, or if you have not completed the item.
--->
- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [x] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

<!---
You can find more information about coding conventions and local testing in the [CONTRIBUTING.md](https://github.com/bpg/terraform-provider-proxmox/blob/main/CONTRIBUTING.md) file.

If you are unsure how to run `make example`, see [Deploying the example resources](https://github.com/bpg/terraform-provider-proxmox?tab=readme-ov-file#deploying-the-example-resources) section in README.

**PR Title:** Must follow [Conventional Commits](https://www.conventionalcommits.org/) format (e.g., `feat(vm): add clone support`). This becomes the squash commit message.
--->

<!--
*IF* your code contains breaking changes, add `!` before the colon in the PR title, e.g.:
```
feat(vm)!: add support for new feature
```
Also, uncomment the section just below and add a description of the breaking change.
--->

<!---
#### ⚠ BREAKING CHANGES

>>> Put your description here <<<
--->

### Proof of Work
<!---
REQUIRED for code changes. Include at minimum:
- Acceptance test output (`./testacc TestAccYourResource`)
- For bug fixes: test output showing the fix works
- For API changes: either mitmproxy logs showing correct API calls,
  or terraform/tofu output showing successful resource creation/update
  together with the test resource configuration used
Empty proof of work will delay review.
--->

New case in `TestAccResourceVMInitialization`, "native cloud-init: password update is applied in place": step 1 creates a stopped VM with `password = "password1"`, step 2 changes it to `password2` with `plancheck.ExpectResourceAction(Update)`. Both steps verify the password against `cipassword` in `/etc/pve/qemu-server/<vmid>.conf` on the node with perl, since the API only ever returns the mask. PVE stores the value in plaintext on create and as a crypt hash after a config update (`PVE/API2/Qemu.pm` has a single `encrypt_pw` call, in the update path), so the check accepts either form. The two existing assertions that expected the mask in state now expect the configured value, and a unit table test pins the suppressor semantics, including the legacy "mask in state, password in config" case.

RED, before the fix:

```text
resource_vm_test.go:1286: Step 2/2 error: Pre-apply plan check(s) failed:
    'proxmox_virtual_environment_vm.test_vm_cloudinit_password' - expected Update, got action(s): [no-op]
--- FAIL: TestAccResourceVMInitialization/native_cloud-init:_password_update_is_applied_in_place (4.06s)
```

GREEN, with the fix:

```text
./testacc TestAccResourceVMInitialization -- -v
--- PASS: TestAccResourceVMInitialization (102.50s)
    --- PASS: TestAccResourceVMInitialization/custom_cloud-init_drive_file_format (4.76s)
    --- PASS: TestAccResourceVMInitialization/custom_cloud-init:_use_SCSI_interface (38.56s)
    --- PASS: TestAccResourceVMInitialization/native_cloud-init:_username_should_not_change (3.23s)
    --- PASS: TestAccResourceVMInitialization/native_cloud-init:_username_should_not_change_after_update (4.28s)
    --- PASS: TestAccResourceVMInitialization/native_cloud-init:_password_update_is_applied_in_place (5.02s)
    --- PASS: TestAccResourceVMInitialization/native_cloud-init:_username_update_should_not_cause_replacement (4.14s)
    --- PASS: TestAccResourceVMInitialization/native_cloud-init:_config_update_on_running_VM_should_not_fail (17.45s)
    --- PASS: TestAccResourceVMInitialization/cloud-init_upgrade_disabled (3.14s)
    --- PASS: TestAccResourceVMInitialization/cloud-init_upgrade_default_is_true (3.14s)
    --- PASS: TestAccResourceVMInitialization/cloud-init_upgrade_update (5.16s)
    --- PASS: TestAccResourceVMInitialization/cloud-init_update_other_fields_without_upgrade_set (4.15s)
ok  	github.com/bpg/terraform-provider-proxmox/fwprovider/test	103.023s
```

mitmproxy (`--flow-detail 3`) for the new case:

```text
POST /api2/json/nodes/pve/qemu                 body: ... cipassword: password1 ...
GET  /api2/json/nodes/pve/qemu/{id}/config     "cipassword": "**********"   (every read)
PUT  /api2/json/nodes/pve/qemu/{id}/config     body: cipassword: password2   (step 2, one call)
```

Regression sweep of the whole `fwprovider/test` package: 132 passed, 3 failed. Every VM test passed. The failures are `TestAccResourceFile` (SFTP permission limitation of the test host) and `TestAccResourceClusterFirewall` / `TestAccResourceFirewallRulesIdentityFieldChange` ("Existing rules detected"), which fail identically on unmodified `main` with an empty cluster rule list, so they are unrelated to this change.

<!--- Please keep this note for the community --->
### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #3003

<!--- Release note for [CHANGELOG](https://github.com/bpg/terraform-provider-proxmox/blob/main/CHANGELOG.md) will be created automatically using the PR's title, update it accordingly. --->

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Fable 5.1). All changes have been reviewed and verified by a human.*

