### PR TITLE
chore(docs): add uefi boot example to vm resource

### DIFF
--- a/docs/resources/virtual_environment_vm.md
+++ b/docs/resources/virtual_environment_vm.md
@@ -340,7 +340,7 @@ output "ubuntu_vm_public_key" {
         defaults to `false`). Note that SSD emulation is not supported on VirtIO
         Block drives.
 - `efi_disk` - (Optional) The efi disk device (required if `bios` is set
-    to `ovmf`)
+    to `ovmf`). See [Example: UEFI boot](#example-uefi-boot).
     - `datastore_id` (Optional) The identifier for the datastore to create
         the disk in (defaults to `local-lvm`).
     - `file_format` (Optional) The file format (defaults to `raw`).
@@ -348,10 +348,11 @@ output "ubuntu_vm_public_key" {
         recommended, and required for Secure Boot. For backwards compatibility
         use `2m`. Ignored for VMs with cpu.architecture=`aarch64` (defaults
         to `2m`).
-    - `pre_enrolled_keys` (Optional) Use am EFI vars template with
+    - `pre_enrolled_keys` (Optional) Use an EFI vars template with
         distribution-specific and Microsoft Standard keys enrolled, if used with
-        EFI type=`4m`. Ignored for VMs with cpu.architecture=`aarch64` (defaults
-        to `false`).
+        EFI type=`4m`. For VMs with cpu.architecture=`aarch64` this requires
+        `pve-edk2-firmware-aarch64` newer than `4.2025.05-2` on the host and is
+        ignored otherwise (defaults to `false`).
 - `tpm_state` - (Optional) The TPM state device. The VM must be stopped before
     adding, removing, or moving a TPM state device; the provider automatically
     handles the shutdown/start cycle. Changing `version` requires recreating the
@@ -879,6 +880,41 @@ resource "proxmox_virtual_environment_vm" "test_vm" {
   ...
 }
 ```
+
+## Example: UEFI boot
+
+Set `bios = "ovmf"` and add an `efi_disk` block. The EFI disk stores the UEFI
+variables (boot entries, Secure Boot state). Without it, Proxmox VE starts the
+VM with a temporary variables file and those settings are lost on every stop
+and start.
+
+```hcl
+resource "proxmox_virtual_environment_vm" "uefi_vm" {
+  name      = "terraform-provider-proxmox-uefi-vm"
+  node_name = "first-node"
+
+  bios = "ovmf"
+
+  efi_disk {
+    datastore_id      = "local-lvm"
+    type              = "4m"
+    pre_enrolled_keys = true # Secure Boot keys; set to false for unsigned kernels
+  }
+
+  disk {
+    datastore_id = "local-lvm"
+    interface    = "scsi0"
+    size         = 20
+  }
+
+  # ...
+}
+```
+
+~> **arm64 hosts** always boot VMs through UEFI (AAVMF); SeaBIOS is not
+available there. The provider still defaults `bios` to `seabios`, so set
+`bios = "ovmf"` explicitly together with `cpu.architecture = "aarch64"`.
+`efi_disk.type` is ignored on `aarch64`.
 
 ## Pool Management
 


### PR DESCRIPTION
### What does this PR do?

The `proxmox_virtual_environment_vm` docs describe `bios` and `efi_disk` as reference entries only; there was no example showing them together, and nothing about the new official arm64 build where guests always boot through UEFI (#3031).

This adds an `Example: UEFI boot` section with a minimal `bios = "ovmf"` + `efi_disk` config, a note on why the EFI disk matters (without it PVE uses a temporary efivars file, so boot entries and Secure Boot state are lost on every stop/start), an admonition for arm64 hosts (`bios = "ovmf"` must still be set explicitly because the provider defaults to `seabios`; `efi_disk.type` is ignored there), and a cross-link from the `efi_disk` reference entry.

It also corrects the stale claim that `pre_enrolled_keys` is ignored on `aarch64`: PVE 9.2 (`PVE/QemuServer/OVMF.pm`) honours it when `pve-edk2-firmware-aarch64` newer than `4.2025.05-2` is installed, and logs a warning and ignores it otherwise.

### Usage Example

```hcl
resource "proxmox_virtual_environment_vm" "uefi_vm" {
  name      = "terraform-provider-proxmox-uefi-vm"
  node_name = "first-node"

  bios = "ovmf"

  efi_disk {
    datastore_id      = "local-lvm"
    type              = "4m"
    pre_enrolled_keys = true # Secure Boot keys; set to false for unsigned kernels
  }

  disk {
    datastore_id = "local-lvm"
    interface    = "scsi0"
    size         = 20
  }

  # ...
}
```

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [x] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

Docs-only change. The `efi_disk` behaviour itself is already covered by the `efi disk` cases in `TestAccResourceVMDisks`.

The snippet from the new section was applied verbatim (only `node_name`, `vm_id`, and `started = false` added) against PVE 9.2.18 with a dev override of the current build, then re-planned and destroyed:

```text
proxmox_virtual_environment_vm.uefi_vm: Creating...
proxmox_virtual_environment_vm.uefi_vm: Creation complete after 1s [id=199998]
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

$ grep -E '^(bios|efidisk0):' /etc/pve/qemu-server/199998.conf
bios: ovmf
efidisk0: local-lvm:vm-199998-disk-0,efitype=4m,ms-cert=2023k,pre-enrolled-keys=1,size=4M

$ terraform plan
No changes. Your infrastructure matches the configuration.

$ terraform destroy -auto-approve
Destroy complete! Resources: 1 destroyed.
```

The arm64 statements are taken from the PVE 9.2.18 source (`QemuServer.pm` attaches OVMF only when `bios` is `ovmf`; `OVMF.pm` selects `AAVMF_*` images for `aarch64`, consults `efitype` only for `x86_64`, and honours `pre-enrolled-keys` when `AAVMF_CODE.secboot.fd` exists). No arm64 host was available to exercise them.

Markdown: `prettier` and `markdownlint-cli2` clean. `make lint`: 0 issues.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #3031

---

🤖 *This PR was authored with the help of [Claude Code](https://www.anthropic.com/claude-code) (Claude Fable 5.1). All changes have been reviewed and verified by a human.*
