### PR TITLE
fix(ci): pin release signing to the ci subkey

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           gpg_private_key: "${{ secrets.GPG_PRIVATE_KEY }}"
           passphrase: "${{ secrets.PASSPHRASE }}"
+          # Signing subkey of the master key; the primary secret lives on a smartcard,
+          # so the action must preset the passphrase for this subkey only.
+          fingerprint: "DFE55260A45246244FACE9623FF640C0C9ABD10F"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,7 +38,7 @@ signs:
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"
-      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "{{ .Env.GPG_FINGERPRINT }}!" # trailing "!" pins gpg to this exact subkey
       - "--output"
       - "${signature}"
       - "--detach-sign"


### PR DESCRIPTION
### What does this PR do?

The 2024 release signing key expired on 2026-09-09 and its replacement is a signing subkey of the master key, whose primary secret lives on a smartcard. The exported CI secret therefore carries a card-stub primary, and `ghaction-import-gpg` fails while presetting the passphrase for that stub (`ERR 67108891 Not found <GPG Agent>`) unless told which subkey to use.

- `publish.yml`: pass `fingerprint` to the import action so it presets the passphrase for the CI signing subkey only (the action's documented subkey flow).
- `.goreleaser.yaml`: append `!` to `--local-user` so gpg signs with exactly that subkey instead of picking "the newest signing subkey".

The v0.113.0 tag will be moved onto the merge commit to re-trigger the publish workflow with this change.

### Contributor's Note

- [x] I have run `make lint` and fixed any issues.
- [ ] I have updated documentation (FWK: schema descriptions + `make docs`; SDK: manual `/docs/` edits).
- [ ] I have added / updated acceptance tests (**required** for new resources and bug fixes — see [ADR-006](docs/adr/006-testing-requirements.md)).
- [x] I have considered backward compatibility (no breaking schema changes without `!` in PR title).
- [ ] For new resources: I followed the [reference examples](docs/adr/reference-examples.md).
- [ ] I have run `make example` to verify the change works (mainly for SDK / provider config changes).

### Proof of Work

CI-only change, no provider code touched. Verified locally by replaying the workflow's steps in a throwaway `GNUPGHOME`: import the subkey-only export, preset the passphrase for the subkey keygrip only, then `gpg --batch --local-user <fpr>! --detach-sign` and `--verify`. Final proof is the re-triggered `Publish Release` run for v0.113.0 after merge.

### Community Note

- Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
- Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Closes #3086
